### PR TITLE
Switch "Declination" to "Azimuth"

### DIFF
--- a/src/main/java/org/hwyl/sexytopo/comms/DistoXProtocol.java
+++ b/src/main/java/org/hwyl/sexytopo/comms/DistoXProtocol.java
@@ -10,8 +10,8 @@ public class DistoXProtocol {
     private static final int ADMIN = 0;
     private static final int DISTANCE_LOW_BYTE = 1;
     private static final int DISTANCE_HIGH_BYTE = 2;
-    private static final int DECLINATION_LOW_BYTE = 3;
-    private static final int DECLINATION_HIGH_BYTE = 4;
+    private static final int AZIMUTH_LOW_BYTE = 3;
+    private static final int AZIMUTH_HIGH_BYTE = 4;
     private static final int INCLINATION_LOW_BYTE = 5;
     private static final int INCLINATION_HIGH_BYTE = 6;
     private static final int ROLL_ANGLE_HIGH_BYTE = 7;
@@ -35,9 +35,6 @@ public class DistoXProtocol {
 
 
     public static Leg parseDataPacket(byte[] dataPacket) {
-
-
-
         int d0 = (int)(dataPacket[ADMIN] & 0x40 );
         int d1  = (int)(dataPacket[DISTANCE_LOW_BYTE] & 0xff);
         if (d1 < 0) d1 += 256;
@@ -46,9 +43,8 @@ public class DistoXProtocol {
         // double d =  (((int)mBuffer[0]) & 0x40) * 1024.0 + (mBuffer[1] & 0xff) * 1.0 + (mBuffer[2] & 0xff) * 256.0;
         double distance =  (d0 * 1024 + d2 * 256 + d1 * 1) / 1000.0; // in mm
 
-
-        int b3 = (int)(dataPacket[DECLINATION_LOW_BYTE] & 0xff); if ( b3 < 0 ) b3 += 256;
-        int b4 = (int)(dataPacket[DECLINATION_HIGH_BYTE] & 0xff); if ( b4 < 0 ) b4 += 256;
+        int b3 = (int)(dataPacket[AZIMUTH_LOW_BYTE] & 0xff); if ( b3 < 0 ) b3 += 256;
+        int b4 = (int)(dataPacket[AZIMUTH_HIGH_BYTE] & 0xff); if ( b4 < 0 ) b4 += 256;
         // double b = (mBuffer[3] & 0xff) + (mBuffer[4] & 0xff) * 256.0;
         double b = b3 + b4 * 256.0;
         double bearing  = b * 180.0 / 32768.0;

--- a/src/main/java/org/hwyl/sexytopo/control/table/ManualEntry.java
+++ b/src/main/java/org/hwyl/sexytopo/control/table/ManualEntry.java
@@ -12,9 +12,7 @@ import android.widget.EditText;
 import android.widget.TextView;
 
 import org.hwyl.sexytopo.R;
-import org.hwyl.sexytopo.SexyTopo;
 import org.hwyl.sexytopo.control.SurveyManager;
-import org.hwyl.sexytopo.control.activity.SexyTopoActivity;
 import org.hwyl.sexytopo.control.activity.TableActivity;
 import org.hwyl.sexytopo.control.util.SurveyUpdater;
 import org.hwyl.sexytopo.model.survey.Leg;
@@ -88,7 +86,7 @@ public class ManualEntry {
 
         ((TextView) (dialog.findViewById(R.id.editDistance)))
                 .setText("" + toEdit.getDistance());
-        ((TextView) (dialog.findViewById(R.id.editDeclination)))
+        ((TextView) (dialog.findViewById(R.id.editAzimuth)))
                 .setText("" + toEdit.getBearing());
         ((TextView) (dialog.findViewById(R.id.editInclination)))
                 .setText("" + toEdit.getInclination());
@@ -178,24 +176,24 @@ public class ManualEntry {
             public void onClick(DialogInterface dialogInterface, int buttonId) {
 
                 Double distance = getFieldValue(dialog, R.id.editDistance);
-                Double declination = getFieldValue(dialog, R.id.editDeclination);
+                Double azimuth = getFieldValue(dialog, R.id.editAzimuth);
                 Double inclination = getFieldValue(dialog, R.id.editInclination);
 
                 if (distance == null || !Leg.isDistanceLegal(distance)) {
                     TextView editDistance = ((TextView) dialogView.findViewById(R.id.editDistance));
                     editDistance.setError("Bad distance");
                     tableActivity.showSimpleToast("Bad distance");
-                } else if (declination == null || !Leg.isDeclinationLegal(declination)) {
-                    TextView editDeclination = ((TextView)(dialogView.findViewById(R.id.editDeclination)));
-                    tableActivity.showSimpleToast("Bad declination");
-                    editDeclination.setError("Bad declination");
+                } else if (azimuth == null || !Leg.isAzimuthLegal(azimuth)) {
+                    TextView editAzimuth = ((TextView)(dialogView.findViewById(R.id.editAzimuth)));
+                    tableActivity.showSimpleToast("Bad azimuth");
+                    editAzimuth.setError("Bad azimuth");
                 } else if (inclination == null || !Leg.isInclinationLegal(inclination)) {
                     TextView editInclination = ((TextView)(dialogView.findViewById(R.id.editInclination)));
                     editInclination.setError("Bad inclination");
                     tableActivity.showSimpleToast("Bad inclination " + inclination);
                 } else {
                     dialogInterface.dismiss();
-                    Leg leg = new Leg(distance, declination, inclination);
+                    Leg leg = new Leg(distance, azimuth, inclination);
                     editCallback.submit(leg, dialog);
                 }
             }

--- a/src/main/java/org/hwyl/sexytopo/model/survey/Leg.java
+++ b/src/main/java/org/hwyl/sexytopo/model/survey/Leg.java
@@ -38,7 +38,7 @@ public class Leg extends SurveyComponent{
             throw new IllegalArgumentException("Distance should be positive; actual" + distance);
         }
 
-        if (!isDeclinationLegal(bearing)) {
+        if (!isAzimuthLegal(bearing)) {
             throw new IllegalArgumentException(
                     "Bearing should be at least 0 and less than 360; actual=" + bearing);
         }
@@ -99,8 +99,8 @@ public class Leg extends SurveyComponent{
         return distance >= MIN_DISTANCE;
     }
 
-    public static boolean isDeclinationLegal(double declination) {
-        return MIN_BEARING <= declination && declination < MAX_BEARING;
+    public static boolean isAzimuthLegal(double azimuth) {
+        return MIN_BEARING <= azimuth && azimuth < MAX_BEARING;
     }
 
     public static boolean isInclinationLegal(double inclination) {

--- a/src/main/res/layout/leg_edit_dialog.xml
+++ b/src/main/res/layout/leg_edit_dialog.xml
@@ -27,10 +27,10 @@
         <TextView
             android:layout_width="100dp"
             android:layout_height="wrap_content"
-            android:text="@string/manual_edit_declination"
+            android:text="@string/manual_edit_azimuth"
             />
         <EditText
-            android:id="@+id/editDeclination"
+            android:id="@+id/editAzimuth"
             android:layout_width="100dp"
             android:layout_height="50dp"
             android:inputType="number|numberDecimal"/>

--- a/src/main/res/layout/leg_edit_dialog_with_lruds.xml
+++ b/src/main/res/layout/leg_edit_dialog_with_lruds.xml
@@ -27,10 +27,10 @@
         <TextView
             android:layout_width="100dp"
             android:layout_height="wrap_content"
-            android:text="@string/manual_edit_declination"
+            android:text="@string/manual_edit_azimuth"
             />
         <EditText
-            android:id="@+id/editDeclination"
+            android:id="@+id/editAzimuth"
             android:layout_width="100dp"
             android:layout_height="50dp"
             android:inputType="number|numberDecimal"/>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -27,7 +27,7 @@
     <string name="table_head_from">From</string>
     <string name="table_head_to">To</string>
     <string name="table_head_distance">Dist</string>
-    <string name="table_head_bearing">Decl</string>
+    <string name="table_head_bearing">Azm</string>
     <string name="table_head_elevation">Incl</string>
     <string name="title_activity_table">Table</string>
     <string name="title_activity_plan">Plan</string>
@@ -88,7 +88,7 @@
     <string name="manual_add_splay_title">Add Splay</string>
     <string name="manual_edit_leg_title">Edit Leg</string>
     <string name="manual_edit_distance">Distance (m)</string>
-    <string name="manual_edit_declination">Declination (&#176;)</string>
+    <string name="manual_edit_azimuth">Azimuth (&#176;)</string>
     <string name="manual_edit_inclination">Inclination (&#176;)</string>
     <string name="manual_edit_left">Left (m)</string>
     <string name="manual_edit_right">Right (m)</string>


### PR DESCRIPTION
SexyTopo's UI currently uses the term "declination" to refer to refer to the magnetic compass measurement. The term "declination", however, is more correctly used to refer to a location's Magnetic North offset from True North. This ambiguous usage makes it difficult to add support for magnetic declination correction to the application.

This PR replaces all incorrect usages of "declination" with "azimuth", so that there will be no confusion when magnetic declination correction is added in the future.

Note that the internal API most frequently uses the term "bearing" to refer to compass measurement. PocketTopo now uses the term "azimuth" in its UI. And "azimuth" is the correct term for a 0 - 360-deg measurement, while "bearing" more correctly refers to quadrant + 0 - 90-deg measurement (eg. W70-deg) [see: https://engineering.purdue.edu/~asm215/topics/bearings.html]. If you like, I can replace all internal use of the term "bearing" with "azimuth" as well, but this PR currently maintains that usage.