### PR TITLE
Compass export

### DIFF
--- a/src/main/java/org/hwyl/sexytopo/control/activity/SexyTopoActivity.java
+++ b/src/main/java/org/hwyl/sexytopo/control/activity/SexyTopoActivity.java
@@ -21,6 +21,7 @@ import android.widget.Toast;
 import org.hwyl.sexytopo.R;
 import org.hwyl.sexytopo.SexyTopo;
 import org.hwyl.sexytopo.control.SurveyManager;
+import org.hwyl.sexytopo.control.io.CompassExporter;
 import org.hwyl.sexytopo.control.io.Loader;
 import org.hwyl.sexytopo.control.io.Saver;
 import org.hwyl.sexytopo.control.io.TherionExporter;
@@ -172,9 +173,18 @@ public abstract class SexyTopoActivity extends ActionBarActivity {
     private void exportSurvey() {
         try {
             Survey survey = getSurvey();
+
+            // Therion text file
             String content = TherionExporter.export(survey);
             String filename = Util.getPathForSurveyFile(survey.getName(), "txt");
             Saver.saveFile(filename, content);
+
+            // Compass dat file
+            CompassExporter exporter = new CompassExporter();
+            String datFilename = Util.getPathForSurveyFile(survey.getName(), "dat");
+            String datContents = exporter.export(survey);
+            Saver.saveFile(datFilename, datContents);
+
         } catch(IOException e) {
             Log.d(SexyTopo.TAG, "Error exporting survey: " + e);
             showSimpleToast("Error exporting survey");

--- a/src/main/java/org/hwyl/sexytopo/control/io/CompassExporter.java
+++ b/src/main/java/org/hwyl/sexytopo/control/io/CompassExporter.java
@@ -1,0 +1,80 @@
+package org.hwyl.sexytopo.control.io;
+
+import org.hwyl.sexytopo.control.util.GraphToListTranslator;
+import org.hwyl.sexytopo.model.survey.Leg;
+import org.hwyl.sexytopo.model.survey.Station;
+import org.hwyl.sexytopo.model.survey.Survey;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.List;
+
+
+/**
+ * Survey exporter which targets the Windows-only software Compass by Fountainware / Larry Fish.
+ *
+ * Created by driggs on 1/16/16.
+ */
+public class CompassExporter {
+
+    private static DateFormat dateFormat = new SimpleDateFormat("MM dd yyyy");
+    private static GraphToListTranslator graphToListTranslator = new GraphToListTranslator();
+    private Station currentFrom;
+    private int splayCount;
+
+    final public static double METERS_TO_FEET = 3.28084;
+
+    /**
+     * Export a SexyTopo Survey as a Compass .DAT file.
+     * @param survey
+     * @return
+     */
+    public String export(Survey survey) {
+        List<GraphToListTranslator.SurveyListEntry> data = graphToListTranslator.toListOfSurveyListEntries(survey);
+        String surveyDate = dateFormat.format(Calendar.getInstance().getTime());
+
+        StringBuilder sb = new StringBuilder(1024);
+        sb.append("SexyTopo Export\r\n");
+        sb.append(String.format("SURVEY NAME: %s\r\n", survey.getName()));
+        sb.append(String.format("SURVEY DATE: %s\tCOMMENT: \r\n", surveyDate));
+        sb.append("SURVEY TEAM:\r\n\r\n");
+        sb.append("DECLINATION: 0.00\tFORMAT: DMMDLRUDLADNF\tCORRECTIONS: 0.00 0.00 0.00\r\n");
+        sb.append("\r\n");
+        sb.append("FROM\tTO\tLENGTH\tBEARING\tINC\tLEFT\tUP\tDOWN\tRIGHT\tFLAGS\tCOMMENTS\r\n");
+        sb.append("\r\n");
+
+        for (GraphToListTranslator.SurveyListEntry entry : data) {
+            Leg leg = entry.getLeg();
+            Station from = entry.getFrom();
+            String to = leg.hasDestination() ? leg.getDestination().toString() : this.splayStationFrom(from);
+            double dist = leg.getDistance() * METERS_TO_FEET;  // all Compass lengths are decimal feet!
+            double azm = leg.getBearing();
+            double inc = leg.getInclination();
+
+            sb.append(String.format("%s\t%s\t%.2f\t%.2f\t%.2f\t", from, to, dist, azm, inc));
+            sb.append("-9.99\t-9.99\t-9.99\t-9.99\t");  // LUDR, must be in that order
+            if (!leg.hasDestination()) {
+                sb.append("#|L#");  // exclude splay shots from cave length calculations
+            }
+            sb.append("\t\t\r\n");  // empty comments field
+        }
+        sb.append('\f');  // ASCII formfeed denotes end of survey
+
+        return sb.toString();
+    }
+
+    /**
+     * Produce a unique TO station name for a splay shot (Compass doesn't allow anonymous stations).
+     * @param from
+     * @return A station label of, for example, `A53ss003` for the third splay off station A53
+     */
+    private String splayStationFrom(Station from) {
+        if (!from.equals(this.currentFrom)) {
+            this.currentFrom = from;
+            this.splayCount = 0;
+        }
+        return String.format("%sss%03d", from, this.splayCount++);
+    }
+
+}


### PR DESCRIPTION
This PR exports a Fountainware Compass .DAT survey file from the File->Export menu.

Compass support could be improved if the exporter had access to some additional metadata, including: date of the survey, cave name (as opposed to survey name), magnetic declination, per-survey comment, survey team, per-shot comment.

I did not try to define a common Java Interface for "survey exporters", but this would make for a better design once more formats are supported.

Compass .DAT file format specification: http://www.fountainware.com/compass/Documents/FileFormats/SurveyDataFormat.htm