### PR TITLE
Add early return in the case of getBitmap() failure

### DIFF
--- a/app/src/main/java/org/hwyl/sexytopo/control/activity/GraphActivity.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/activity/GraphActivity.java
@@ -169,8 +169,8 @@ public abstract class GraphActivity extends SexyTopoActivity
         syncGraphWithSurvey();
         initialiseSketchTool();
         initialiseBrushColour();
-        // initialiseSymbolToolbar();
-        // initialiseSymbolTool();
+        initialiseSymbolToolbar();
+        initialiseSymbolTool();
 
         setSketchButtonsStatus();
         setViewLocation();

--- a/app/src/main/java/org/hwyl/sexytopo/model/sketch/Symbol.java
+++ b/app/src/main/java/org/hwyl/sexytopo/model/sketch/Symbol.java
@@ -51,8 +51,13 @@ public enum Symbol {
         }
 
         if (buttonBitmap == null) {
+            Bitmap bitmap = getBitmap();
+            if (bitmap == null) {
+                return null;
+            }
+
             int dimen = (int)resources.getDimension(R.dimen.toolbar_button_height);
-            buttonBitmap = Bitmap.createScaledBitmap(getBitmap(), dimen, dimen, true);
+            buttonBitmap = Bitmap.createScaledBitmap(bitmap, dimen, dimen, true);
         }
 
         return buttonBitmap;


### PR DESCRIPTION
Crash was being caused by getBitmap() returning null (probably failing to load the bitmap resource) and passing a null Bitmap to createScaledBitmap(). 

This return early is however silently masking the fact that we have a resource issue. Should we at least log this / add an assertion?