### PR TITLE
Only set graph viewLocation on creation

### DIFF
--- a/app/src/main/java/org/hwyl/sexytopo/control/activity/GraphActivity.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/activity/GraphActivity.java
@@ -173,7 +173,6 @@ public abstract class GraphActivity extends SexyTopoActivity
         // initialiseSymbolTool();
 
         setSketchButtonsStatus();
-        setViewLocation();
     }
 
     private void setViewLocation() {


### PR DESCRIPTION
Previously setViewLocation() was being called every time we switched between the Plan and Elevation graph views. When sketching underground it is typical to frequently flip between these two modes and having it constantly snap to the active station loses the position where the user is trying to sketch. Therefore we now only set the view location during graph creation. This change is compatible with the "Jump" functionality from the table view as the graph gets recreated in this case.

This is unrelated to, and does not affect, the "Auto-Recentre" feature as this performs its action on the addition of new survey stations only.