### PR TITLE
Fix failing unit tests and update libraries/deps to latest versions

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,13 +3,13 @@ apply plugin: 'com.google.gms.google-services'
 apply plugin: 'com.google.firebase.crashlytics'
 
 android {
-    compileSdkVersion 29
-    buildToolsVersion '29.0.2'
+    compileSdkVersion 30
+    buildToolsVersion '30.0.3'
 
     defaultConfig {
         applicationId "org.hwyl.sexytopo"
         minSdkVersion 18
-        targetSdkVersion 29
+        targetSdkVersion 30
         versionCode 62
         versionName "1.5.0"
     }
@@ -36,16 +36,13 @@ dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'commons-io:commons-io:2.6'
-    testImplementation('org.powermock:powermock-api-mockito:1.6.2') {
-        exclude module: 'hamcrest-core'
-        exclude module: 'objenesis'
-    }
-    testImplementation('org.powermock:powermock-module-junit4:1.6.2') {
-        exclude module: 'hamcrest-core'
-        exclude module: 'objenesis'
-    }
+
+    testImplementation('org.powermock:powermock-api-mockito2:2.0.9')
+    testImplementation('org.powermock:powermock-module-junit4:2.0.9')
+
     testImplementation 'org.json:json:20180813'
     implementation 'org.apache.commons:commons-lang3:3.8.1'
-    implementation 'com.google.firebase:firebase-analytics:18.0.2'
-    implementation 'com.google.firebase:firebase-crashlytics:17.4.1'
+    implementation 'com.google.firebase:firebase-analytics:19.0.0'
+    implementation 'com.google.firebase:firebase-crashlytics:18.0.0'
 }
+

--- a/app/src/test/java/org/hwyl/sexytopo/control/graph/ConnectedSurveysTest.java
+++ b/app/src/test/java/org/hwyl/sexytopo/control/graph/ConnectedSurveysTest.java
@@ -35,8 +35,9 @@ public class ConnectedSurveysTest {
 
         Survey currentSurvey = getBasicSurvey("not-connected");
 
-        Sketch fakeSketch = new Sketch();
-        when(mockActivity.getSketch(currentSurvey)).thenReturn(fakeSketch);
+        // As of v2 of Mockito the following emits an 'UnnecessaryStubbingException'
+        //Sketch fakeSketch = new Sketch();
+        //when(mockActivity.getSketch(currentSurvey)).thenReturn(fakeSketch);
 
         Map<Survey, Space<Coord2D>> translated =
                 ConnectedSurveys.getTranslatedConnectedSurveys(

--- a/build.gradle
+++ b/build.gradle
@@ -6,14 +6,14 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.0'
+        classpath 'com.android.tools.build:gradle:4.2.1'
     }
 }
 
 
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
         maven {
             url 'https://maven.google.com/'
             name 'Google'
@@ -21,7 +21,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.0'
+        classpath 'com.android.tools.build:gradle:4.2.1'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }
@@ -32,14 +32,14 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.google.gms:google-services:4.3.5'
-        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.5.2'
+        classpath 'com.google.gms:google-services:4.3.8'
+        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.6.1'
     }
 }
 
 allprojects {
     repositories {
-        jcenter()
+        mavenCentral()
         maven {
             url 'https://maven.google.com/'
             name 'Google'


### PR DESCRIPTION
 * Updated the Powermock/Mockito library to version 2.0.9 which gets the failing unit tests passing again. There is however a new warning emitted as a result but this appears to be ignorable:
 ```
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by org.powermock.reflect.internal.WhiteboxImpl (file:/Users/Dan/.gradle/caches/modules-2/files-2.1/org.powermock/powermock-reflect/2.0.9/4bb9ed43e5221926fb86cae44b445de110a51d05/powermock-reflect-2.0.9.jar) to method java.lang.Object.clone()
WARNING: Please consider reporting this to the maintainers of org.powermock.reflect.internal.WhiteboxImpl
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
```
 * Updated target SDK to latest
 * Updated a number of other dependencies to their latest version
 * [Replaced deprecated `jcenter()` with `mavenCentral()`](https://blog.gradle.org/jcenter-shutdown#:~:text=The%20jcenter()%20method%20will,may%20only%20publish%20new%20versions.)
 * [Commented out a stub that was throwing an error under the latest version of Mockito](https://www.baeldung.com/mockito-unnecessary-stubbing-exception)
