### PR TITLE
Remove unnecessary Coord2D to Point conversions

### DIFF
--- a/app/src/main/java/org/hwyl/sexytopo/control/graph/GraphView.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/graph/GraphView.java
@@ -97,6 +97,7 @@ public class GraphView extends View {
     private Map<Survey, Space<Coord2D>> translatedConnectedSurveys = new HashMap<>();
 
     // cached for performance
+    private Coord2D canvasBottomRight;
     private Coord2D viewpointTopLeftOnSurvey;
     private Coord2D viewpointBottomRightOnSurvey;
     private double surveyLength = 0;
@@ -742,8 +743,10 @@ public class GraphView extends View {
 
         super.onDraw(canvas);
 
+        canvasBottomRight = new Coord2D(getWidth(), getHeight());
+
         viewpointTopLeftOnSurvey = viewCoordsToSurveyCoords(Coord2D.ORIGIN);
-        viewpointBottomRightOnSurvey = viewCoordsToSurveyCoords(new Coord2D(getWidth(), getHeight()));
+        viewpointBottomRightOnSurvey = viewCoordsToSurveyCoords(canvasBottomRight);
 
         if (getDisplayPreference(GraphActivity.DisplayPreference.SHOW_GRID)) {
             drawGrid(canvas);
@@ -1002,7 +1005,7 @@ public class GraphView extends View {
 
     private boolean isLineOnCanvas(Coord2D start, Coord2D end) {
         return !CohenSutherlandAlgorithm.whollyOutside(
-                start, end, viewpointTopLeftOnSurvey, viewpointBottomRightOnSurvey);
+                start, end, Coord2D.ORIGIN, canvasBottomRight);
     }
 
 

--- a/app/src/main/java/org/hwyl/sexytopo/control/graph/GraphView.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/graph/GraphView.java
@@ -966,7 +966,7 @@ public class GraphView extends View {
             Coord2D start = surveyCoordsToViewCoords(line.getStart());
             Coord2D end = surveyCoordsToViewCoords(line.getEnd());
 
-            if (!isLineOnCanvas(canvas, start, end)) {
+            if (!isLineOnCanvas(start, end)) {
                 continue;
             }
 
@@ -1000,15 +1000,9 @@ public class GraphView extends View {
         return survey.getActiveStation().getOnwardLegs().contains(leg);
     }
 
-    private boolean isLineOnCanvas(Canvas canvas, Coord2D start, Coord2D end) {
-        Point point0 = new Point((int)start.x, (int)start.y);
-        Point point1 = new Point((int)end.x, (int)end.y);
-
-        Point rectangleTopLeft = new Point(0, 0);
-        Point rectangleBottomRight = new Point(canvas.getWidth(), canvas.getHeight());
-
+    private boolean isLineOnCanvas(Coord2D start, Coord2D end) {
         return !CohenSutherlandAlgorithm.whollyOutside(
-                point0, point1, rectangleTopLeft, rectangleBottomRight);
+                start, end, viewpointTopLeftOnSurvey, viewpointBottomRightOnSurvey);
     }
 
 

--- a/app/src/main/java/org/hwyl/sexytopo/control/util/CohenSutherlandAlgorithm.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/util/CohenSutherlandAlgorithm.java
@@ -17,7 +17,7 @@ package org.hwyl.sexytopo.control.util;
  *   only ones actually used here.
  */
 
-import android.graphics.Point;
+import org.hwyl.sexytopo.model.graph.Coord2D;
 
 public class CohenSutherlandAlgorithm
 {
@@ -27,14 +27,14 @@ public class CohenSutherlandAlgorithm
 
 
     /* Determines if line(p1,p2) lies entirely inside rect(cp1,cp2) */
-    public static boolean whollyInside(Point p1, Point p2, Point cp1, Point cp2)
+    public static boolean whollyInside(Coord2D p1, Coord2D p2, Coord2D cp1, Coord2D cp2)
     {
         return ((bitcode(cp1, cp2, p1) | bitcode(cp1, cp2, p2)) == 0);
     }
 
     /* Determines if line(p1,p2) is entirely outside rect(cp1,cp2) */
-    public static boolean whollyOutside(Point p1, Point p2, Point cp1,
-                                        Point cp2)
+    public static boolean whollyOutside(Coord2D p1, Coord2D p2, Coord2D cp1,
+                                        Coord2D cp2)
     {
         int p1code, p2code, icode;
         p1code = bitcode(cp1, cp2, p1);
@@ -55,7 +55,7 @@ public class CohenSutherlandAlgorithm
      * nonzero2) == nonzero3), or if it crosses the clipping rectangle (any
      * other possibility).
      */
-    public static boolean clips(Point p1, Point p2, Point cp1, Point cp2)
+    public static boolean clips(Coord2D p1, Coord2D p2, Coord2D cp1, Coord2D cp2)
     {
         int p1code, p2code, icode;
         boolean r;
@@ -76,14 +76,14 @@ public class CohenSutherlandAlgorithm
     /* Computes the 4-bit code for a point p with respect
      * to line(p1,p2)
      */
-    public static int bitcode(Point p1, Point p2, Point p)
+    public static int bitcode(Coord2D p1, Coord2D p2, Coord2D p)
     {
         return (above(p1, p2, p) | below(p1, p2, p) |
                 left(p1, p2, p) | right(p1, p2, p));
     }
 
     /* Gives the 2**3 bit (point above line(p1,p2)) */
-    public static int above(Point p1, Point p2, Point p)
+    public static int above(Coord2D p1, Coord2D p2, Coord2D p)
     {
         if (p.y < Math.min(p1.y, p2.y))
             return 0x8;
@@ -91,7 +91,7 @@ public class CohenSutherlandAlgorithm
     }
 
     /* Gives the 2**2 bit (point below line(p1,p2)) */
-    public static int below(Point p1, Point p2, Point p)
+    public static int below(Coord2D p1, Coord2D p2, Coord2D p)
     {
         if (p.y > Math.max(p1.y, p2.y))
         {
@@ -101,7 +101,7 @@ public class CohenSutherlandAlgorithm
     }
 
     /* Gives the 2**1 bit (point right of line(p1,p2)) */
-    public static int right(Point p1, Point p2, Point p)
+    public static int right(Coord2D p1, Coord2D p2, Coord2D p)
     {
         if (p.x > Math.max(p1.x, p2.x))
             return 0x2;
@@ -109,7 +109,7 @@ public class CohenSutherlandAlgorithm
     }
 
     /* Gives the 2**0 bit (point left of line(p1,p2)) */
-    public static int left(Point p1, Point p2, Point p)
+    public static int left(Coord2D p1, Coord2D p2, Coord2D p)
     {
         if (p.x < Math.min(p1.x, p2.x))
             return 0x1;


### PR DESCRIPTION
 * The largest amount of memory allocations during the draw phase are unnecessary conversions from `Coord2D` to `android.graphics.Point`, simply updating the Cohen Sutherland algorithm to take `Coord2D` instead gets rid of these
 * When panning I now no longer get the same jank I was seeing each time the GC ran