### PR TITLE
Change storage of sketch details from HashSet to ArrayList

### DIFF
--- a/app/src/main/java/org/hwyl/sexytopo/control/graph/GraphView.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/graph/GraphView.java
@@ -11,7 +11,6 @@ import android.graphics.Canvas;
 import android.graphics.DashPathEffect;
 import android.graphics.Paint;
 import android.graphics.Path;
-import android.graphics.Point;
 import android.graphics.Rect;
 import android.util.AttributeSet;
 import android.view.GestureDetector;
@@ -901,7 +900,7 @@ public class GraphView extends View {
     }
 
     private void drawCrossSections(
-            Canvas canvas, Set<CrossSectionDetail> crossSectionDetails, int alpha) {
+            Canvas canvas, List<CrossSectionDetail> crossSectionDetails, int alpha) {
 
         boolean showStationLabels =
                 getDisplayPreference(GraphActivity.DisplayPreference.SHOW_STATION_LABELS);

--- a/app/src/main/java/org/hwyl/sexytopo/control/io/basic/SketchJsonTranslater.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/io/basic/SketchJsonTranslater.java
@@ -89,7 +89,7 @@ public class SketchJsonTranslater {
 
         try {
             JSONArray pathsArray = json.getJSONArray(PATHS_TAG);
-            Set<PathDetail> pathDetails = new HashSet<>();
+            List<PathDetail> pathDetails = new ArrayList<>();
             for (JSONObject object : Util.toList(pathsArray)) {
                 pathDetails.add(toPathDetail(object));
             }
@@ -100,7 +100,7 @@ public class SketchJsonTranslater {
 
         try {
             JSONArray symbolsArray = json.getJSONArray(SYMBOLS_TAG);
-            Set<SymbolDetail> symbolDetails = new HashSet<>();
+            List<SymbolDetail> symbolDetails = new ArrayList<>();
             for (JSONObject object : Util.toList(symbolsArray)) {
                 symbolDetails.add(toSymbolDetail(object));
             }
@@ -111,7 +111,7 @@ public class SketchJsonTranslater {
 
         try {
             JSONArray labelsArray = json.getJSONArray(LABELS_TAG);
-            Set<TextDetail> textDetails = new HashSet<>();
+            List<TextDetail> textDetails = new ArrayList<>();
             for (JSONObject object : Util.toList(labelsArray)) {
                 textDetails.add(toTextDetail(object));
             }
@@ -122,7 +122,7 @@ public class SketchJsonTranslater {
 
         try {
             JSONArray crossSectionsArray = json.getJSONArray(CROSS_SECTIONS_TAG);
-            Set<CrossSectionDetail> crossSectionDetails = new HashSet<>();
+            List<CrossSectionDetail> crossSectionDetails = new ArrayList<>();
             for (JSONObject object : Util.toList(crossSectionsArray)) {
                 crossSectionDetails.add(toCrossSectionDetail(survey, object));
             }

--- a/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/pockettopo/PocketTopoTxtImporter.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/pockettopo/PocketTopoTxtImporter.java
@@ -16,6 +16,7 @@ import org.hwyl.sexytopo.model.survey.Station;
 import org.hwyl.sexytopo.model.survey.Survey;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -112,7 +113,7 @@ public class PocketTopoTxtImporter extends Importer {
     private static Sketch parseSketch(Survey survey, String text, Space<Coord2D> projection) {
         Sketch sketch = new Sketch();
         Coord2D offset = extractOffset(survey, text, projection);
-        Set<PathDetail> pathDetails = parsePolylines(text, offset);
+        List<PathDetail> pathDetails = parsePolylines(text, offset);
         sketch.setPathDetails(pathDetails);
         return sketch;
     }
@@ -203,8 +204,8 @@ public class PocketTopoTxtImporter extends Importer {
         return TextTools.join("\n", subSection);
     }
 
-    public static Set<PathDetail> parsePolylines(String text, Coord2D offset) {
-        Set<PathDetail> paths = new HashSet<>();
+    public static List<PathDetail> parsePolylines(String text, Coord2D offset) {
+        List<PathDetail> paths = new ArrayList<>();
         boolean inPolyline = false;
         Colour currentPathColour = null;
         PathDetail currentPathDetail = null;

--- a/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/xvi/XviImporter.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/xvi/XviImporter.java
@@ -41,7 +41,7 @@ public class XviImporter extends Importer {
         Grid grid = instance.parseGrid(contents);
         double scale = grid.dy;
 
-        Set<PathDetail> pathDetails = parseSketchlineBlock(scale, contents);
+        List<PathDetail> pathDetails = parseSketchlineBlock(scale, contents);
         sketch.setPathDetails(pathDetails);
 
         return sketch;
@@ -70,10 +70,10 @@ public class XviImporter extends Importer {
     }
 
 
-    public static Set<PathDetail> parseSketchlineBlock(double scale, String contents) throws Exception {
+    public static List<PathDetail> parseSketchlineBlock(double scale, String contents) throws Exception {
         String sketchBlock = getBlockContents(contents, SKETCHLINE_COMMAND);
         List<String> entries = parseBlockEntries(sketchBlock);
-        Set<PathDetail> pathDetails = new HashSet<>();
+        List<PathDetail> pathDetails = new ArrayList<>();
         for (String entry : entries) {
             PathDetail pathDetail = parseSketchEntry(scale, entry);
             pathDetails.add(pathDetail);

--- a/app/src/main/java/org/hwyl/sexytopo/model/sketch/Sketch.java
+++ b/app/src/main/java/org/hwyl/sexytopo/model/sketch/Sketch.java
@@ -14,13 +14,13 @@ import java.util.Set;
 
 public class Sketch extends SketchDetail {
 
-    private Set<PathDetail> pathDetails = new HashSet<>();
-    private Set<SymbolDetail> symbolDetails = new HashSet<>();
-    private Set<TextDetail> textDetails = new HashSet<>();
-    private Set<CrossSectionDetail> crossSectionDetails = new HashSet<>();
+    private List<PathDetail> pathDetails = new ArrayList<>();
+    private List<SymbolDetail> symbolDetails = new ArrayList<>();
+    private List<TextDetail> textDetails = new ArrayList<>();
+    private List<CrossSectionDetail> crossSectionDetails = new ArrayList<>();
 
-    private List<SketchDetail> sketchHistory = new ArrayList<>();
-    private List<SketchDetail> undoneHistory = new ArrayList<>();
+    private final List<SketchDetail> sketchHistory = new ArrayList<>();
+    private final List<SketchDetail> undoneHistory = new ArrayList<>();
 
     private PathDetail activePath;
     private Colour activeColour = Colour.BLACK;
@@ -35,23 +35,23 @@ public class Sketch extends SketchDetail {
         this.isSaved = isSaved;
     }
 
-    public void setPathDetails(Set<PathDetail> pathDetails) {
+    public void setPathDetails(List<PathDetail> pathDetails) {
         this.pathDetails = pathDetails;
         recalculateBoundingBox();
     }
 
-    public void setSymbolDetails(Set<SymbolDetail> symbolDetails) {
+    public void setSymbolDetails(List<SymbolDetail> symbolDetails) {
         this.symbolDetails = symbolDetails;
         recalculateBoundingBox();
     }
 
-    public void setTextDetails(Set<TextDetail> textDetails) {
+    public void setTextDetails(List<TextDetail> textDetails) {
         this.textDetails = textDetails;
         recalculateBoundingBox();
     }
 
 
-    public Set<PathDetail> getPathDetails() {
+    public List<PathDetail> getPathDetails() {
         return pathDetails;
     }
 
@@ -90,7 +90,7 @@ public class Sketch extends SketchDetail {
         addSketchDetail(textDetail);
     }
 
-    public Set<SymbolDetail> getSymbolDetails() {
+    public List<SymbolDetail> getSymbolDetails() {
         return symbolDetails;
     }
 
@@ -100,7 +100,7 @@ public class Sketch extends SketchDetail {
         addSketchDetail(symbolDetail);
     }
 
-    public Set<TextDetail> getTextDetails() {
+    public List<TextDetail> getTextDetails() {
         return textDetails;
     }
 
@@ -220,13 +220,12 @@ public class Sketch extends SketchDetail {
     }
 
 
-    private Set<SketchDetail> allSketchDetails() {
-        Set[] allSketchDetailSets = new Set[] {
-                pathDetails, symbolDetails, textDetails, crossSectionDetails};
-        Set<SketchDetail> all = new HashSet<>();
-        for (Set set : allSketchDetailSets) {
-            all.addAll(set);
-        }
+    private List<SketchDetail> allSketchDetails() {
+        List<SketchDetail> all = new ArrayList<>();
+        all.addAll(pathDetails);
+        all.addAll(symbolDetails);
+        all.addAll(textDetails);
+        all.addAll(crossSectionDetails);
         return all;
     }
 
@@ -253,11 +252,11 @@ public class Sketch extends SketchDetail {
         addSketchDetail(sectionDetail);
     }
 
-    public Set<CrossSectionDetail> getCrossSectionDetails() {
+    public List<CrossSectionDetail> getCrossSectionDetails() {
         return crossSectionDetails;
     }
 
-    public void setCrossSectionDetails(Set<CrossSectionDetail> crossSectionDetails) {
+    public void setCrossSectionDetails(List<CrossSectionDetail> crossSectionDetails) {
         this.crossSectionDetails = crossSectionDetails;
     }
 
@@ -276,25 +275,25 @@ public class Sketch extends SketchDetail {
     public Sketch getTranslatedCopy(Coord2D point) {
         Sketch sketch = new Sketch();
 
-        Set<PathDetail> newPathDetails = new HashSet<>();
+        List<PathDetail> newPathDetails = new ArrayList<>();
         for (PathDetail pathDetail : pathDetails) {
             newPathDetails.add(pathDetail.translate(point));
         }
         sketch.setPathDetails(newPathDetails);
 
-        Set<SymbolDetail> newSymbolDetails = new HashSet<>();
+        List<SymbolDetail> newSymbolDetails = new ArrayList<>();
         for (SymbolDetail symbolDetail : symbolDetails) {
             newSymbolDetails.add(symbolDetail.translate(point));
         }
         sketch.setSymbolDetails(newSymbolDetails);
 
-        Set<TextDetail> newTextDetails = new HashSet<>();
+        List<TextDetail> newTextDetails = new ArrayList<>();
         for (TextDetail textDetail : textDetails) {
             newTextDetails.add(textDetail.translate(point));
         }
         sketch.setTextDetails(newTextDetails);
 
-        Set<CrossSectionDetail> newCrossSectionDetails = new HashSet<>();
+        List<CrossSectionDetail> newCrossSectionDetails = new ArrayList<>();
         for (CrossSectionDetail crossSectionDetail : crossSectionDetails) {
             newCrossSectionDetails.add(crossSectionDetail.translate(point));
         }

--- a/app/src/test/java/org/hwyl/sexytopo/control/io/thirdparty/pockettopo/PocketTopoTxtImporterTest.java
+++ b/app/src/test/java/org/hwyl/sexytopo/control/io/thirdparty/pockettopo/PocketTopoTxtImporterTest.java
@@ -6,6 +6,7 @@ import org.hwyl.sexytopo.model.sketch.PathDetail;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -60,7 +61,7 @@ public class PocketTopoTxtImporterTest {
     @Test
     public void testParsePolylines() {
         String section = PocketTopoTxtImporter.getSection(FAKE_TEXT, "PLAN");
-        Set<PathDetail> paths = PocketTopoTxtImporter.parsePolylines(section, Coord2D.ORIGIN);
+        List<PathDetail> paths = PocketTopoTxtImporter.parsePolylines(section, Coord2D.ORIGIN);
 
         PathDetail brownPath = null;
         for (PathDetail path : paths) {


### PR DESCRIPTION
 * Changed the storage of all four sketch detail types from `HashSet` to `ArrayList`
 * This a) decreases iteration time from `O(h/n)`, (where `h` is the capacity) to `O(1)` and b) retains the original ordering 
 * Also removed an unused `import`