### PR TITLE
Simplify sketch paths using Douglas-Peuker algorithm

### DIFF
--- a/app/src/main/java/org/hwyl/sexytopo/control/activity/SexyTopoActivity.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/activity/SexyTopoActivity.java
@@ -62,11 +62,12 @@ import androidx.core.content.ContextCompat;
 public abstract class SexyTopoActivity extends AppCompatActivity {
 
 
-    protected static SurveyManager dataManager;
+    protected SurveyManager dataManager;
 
     private static DistoXCommunicator comms;
 
     protected static boolean hasStarted = false;
+    private static boolean debugMode = false;
 
 
     @Override
@@ -187,21 +188,20 @@ public abstract class SexyTopoActivity extends AppCompatActivity {
             case R.id.action_file_exit:
                 confirmToProceedIfNotSaved(R.string.exit_question, "exit");
                 return true;
-
-
             case R.id.action_undo_last_leg:
                 undoLastLeg();
                 return true;
             case R.id.action_link_survey:
                 confirmToProceedIfNotSaved("linkExistingSurvey");
                 return true;
-
-
             case R.id.action_system_log:
                 startActivity(SystemLogActivity.class);
                 return true;
             case R.id.action_generate_test_survey:
                 generateTestSurvey();
+                return true;
+            case R.id.action_debug_mode:
+                toggleDebugMode();
                 return true;
             case R.id.action_kill_connection:
                 killConnection();
@@ -209,8 +209,6 @@ public abstract class SexyTopoActivity extends AppCompatActivity {
             case R.id.action_force_crash:
                 forceCrash();
                 return true;
-
-
 
             default:
                 return super.onOptionsItemSelected(item);
@@ -984,6 +982,15 @@ public abstract class SexyTopoActivity extends AppCompatActivity {
 
     }
 
+
+    private void toggleDebugMode() {
+        debugMode = !debugMode;
+        dataManager.broadcastSurveyUpdated();
+    }
+
+    public boolean isDebugMode() {
+        return debugMode;
+    }
 
     @SuppressLint("deprecated")
     private void killConnection() {

--- a/app/src/main/java/org/hwyl/sexytopo/control/graph/GraphView.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/graph/GraphView.java
@@ -67,8 +67,6 @@ import java.util.Set;
 
 public class GraphView extends View {
 
-    public static boolean DEBUG = false;
-
     private ScaleGestureDetector scaleGestureDetector;
     private GestureDetector longPressDetector;
 
@@ -791,7 +789,7 @@ public class GraphView extends View {
         drawLegend(canvas);
         drawHotCorners(canvas);
 
-        if (DEBUG) {
+        if (activity.isDebugMode()) {
             drawDebuggingInfo(canvas);
         }
     }
@@ -1200,6 +1198,8 @@ public class GraphView extends View {
         drawPaint.setColor(lastColour.intValue);
         drawPaint.setAlpha(alpha);
 
+        boolean isDebugMode = activity.isDebugMode();
+
         for (PathDetail pathDetail : sketch.getPathDetails()) {
 
             if (!couldBeOnScreen(pathDetail)) {
@@ -1228,6 +1228,10 @@ public class GraphView extends View {
                     //from = surveyCoordsToViewCoords(point);
                     fromX = (float)((point.x - viewpointOffset.x) * surveyToViewScale);
                     fromY = (float)((point.y - viewpointOffset.y) * surveyToViewScale);
+
+                    if (isDebugMode) {
+                        canvas.drawCircle(fromX, fromY, 3, drawPaint);
+                    }
                 } else {
                     //Coord2D to = surveyCoordsToViewCoords(point);
                     float toX = (float)((point.x - viewpointOffset.x) * surveyToViewScale);
@@ -1237,6 +1241,10 @@ public class GraphView extends View {
                     lines[lineIndex++] = fromY;
                     lines[lineIndex++] = toX;
                     lines[lineIndex++] = toY;
+
+                    if (isDebugMode) {
+                        canvas.drawCircle(toX, toY, 3, drawPaint);
+                    }
 
                     fromX = toX;
                     fromY = toY;

--- a/app/src/main/java/org/hwyl/sexytopo/control/io/basic/SketchJsonTranslater.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/io/basic/SketchJsonTranslater.java
@@ -161,8 +161,8 @@ public class SketchJsonTranslater {
 
         PathDetail pathDetail = new PathDetail(path, colour);
 
-        double epsilon = Space2DUtils.SketchEpsilon(pathDetail);
-        List<Coord2D> simplifiedPath = Space2DUtils.Simplify(path, epsilon);
+        double epsilon = Space2DUtils.simplificationEpsilon(pathDetail);
+        List<Coord2D> simplifiedPath = Space2DUtils.simplify(path, epsilon);
         pathDetail.setPath(simplifiedPath);
 
         return pathDetail;

--- a/app/src/main/java/org/hwyl/sexytopo/control/io/basic/SketchJsonTranslater.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/io/basic/SketchJsonTranslater.java
@@ -2,6 +2,7 @@ package org.hwyl.sexytopo.control.io.basic;
 
 import org.hwyl.sexytopo.control.Log;
 import org.hwyl.sexytopo.control.io.Util;
+import org.hwyl.sexytopo.control.util.Space2DUtils;
 import org.hwyl.sexytopo.model.graph.Coord2D;
 import org.hwyl.sexytopo.model.sketch.Colour;
 import org.hwyl.sexytopo.model.sketch.CrossSection;
@@ -18,9 +19,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 
 public class SketchJsonTranslater {
@@ -161,6 +160,11 @@ public class SketchJsonTranslater {
         }
 
         PathDetail pathDetail = new PathDetail(path, colour);
+
+        double epsilon = Space2DUtils.SketchEpsilon(pathDetail);
+        List<Coord2D> simplifiedPath = Space2DUtils.Simplify(path, epsilon);
+        pathDetail.setPath(simplifiedPath);
+
         return pathDetail;
     }
 

--- a/app/src/main/java/org/hwyl/sexytopo/control/util/Space2DUtils.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/util/Space2DUtils.java
@@ -116,8 +116,8 @@ public class Space2DUtils {
 
         // If max distance is greater than epsilon, recursively simplify
         if (distMax > epsilon) {
-            List<Coord2D> results1 = Simplify(path.subList(0, indexMax + 1), epsilon);
-            List<Coord2D> results2 = Simplify(path.subList(indexMax, pathSize), epsilon);
+            List<Coord2D> results1 = DouglasPeukerIteration(path.subList(0, indexMax + 1), epsilon);
+            List<Coord2D> results2 = DouglasPeukerIteration(path.subList(indexMax, pathSize), epsilon);
 
             simplifiedPath = new ArrayList<>(results1);
             simplifiedPath.addAll(results2.subList(1, results2.size()));

--- a/app/src/main/java/org/hwyl/sexytopo/control/util/Space2DUtils.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/util/Space2DUtils.java
@@ -97,7 +97,7 @@ public class Space2DUtils {
         return new Line<>(start.plus(point), end.plus(point));
     }
 
-    private static List<Coord2D> DouglasPeukerIteration(List<Coord2D> path, double epsilon) {
+    private static List<Coord2D> douglasPeukerIteration(List<Coord2D> path, double epsilon) {
 
         // Find the point with the maximum distance
         int pathSize = path.size();
@@ -116,8 +116,8 @@ public class Space2DUtils {
 
         // If max distance is greater than epsilon, recursively simplify
         if (distMax > epsilon) {
-            List<Coord2D> results1 = DouglasPeukerIteration(path.subList(0, indexMax + 1), epsilon);
-            List<Coord2D> results2 = DouglasPeukerIteration(path.subList(indexMax, pathSize), epsilon);
+            List<Coord2D> results1 = douglasPeukerIteration(path.subList(0, indexMax + 1), epsilon);
+            List<Coord2D> results2 = douglasPeukerIteration(path.subList(indexMax, pathSize), epsilon);
 
             simplifiedPath = new ArrayList<>(results1);
             simplifiedPath.addAll(results2.subList(1, results2.size()));
@@ -130,23 +130,23 @@ public class Space2DUtils {
         return simplifiedPath;
     }
 
-    public static double SketchEpsilon(double width, double height) {
+    public static double simplificationEpsilon(double width, double height) {
 
         // TODO: this is a pretty crude simplification factor but we can revisit after more testing
         double maxDim = Math.max(width, height);
         return Math.max(maxDim / 500, 0.001);
     }
 
-    public static double SketchEpsilon(PathDetail pathDetail) {
-        return SketchEpsilon(pathDetail.getWidth(), pathDetail.getHeight());
+    public static double simplificationEpsilon(PathDetail pathDetail) {
+        return simplificationEpsilon(pathDetail.getWidth(), pathDetail.getHeight());
     }
 
-    public static List<Coord2D> Simplify(List<Coord2D> path, double epsilon) {
+    public static List<Coord2D> simplify(List<Coord2D> path, double epsilon) {
 
         if (path.isEmpty() || epsilon <= 0)
             return path;
 
-        return DouglasPeukerIteration(path, epsilon);
+        return douglasPeukerIteration(path, epsilon);
     }
 
 }

--- a/app/src/main/java/org/hwyl/sexytopo/control/util/Space2DUtils.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/util/Space2DUtils.java
@@ -3,14 +3,16 @@ package org.hwyl.sexytopo.control.util;
 import org.hwyl.sexytopo.model.graph.Coord2D;
 import org.hwyl.sexytopo.model.graph.Line;
 import org.hwyl.sexytopo.model.graph.Space;
+import org.hwyl.sexytopo.model.sketch.PathDetail;
 import org.hwyl.sexytopo.model.survey.Leg;
 import org.hwyl.sexytopo.model.survey.Station;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 
 public class Space2DUtils {
-
 
     public static double getDistanceFromLine(Coord2D point, Coord2D lineStart, Coord2D lineEnd) {
 
@@ -94,4 +96,57 @@ public class Space2DUtils {
         Coord2D end = line.getEnd();
         return new Line<>(start.plus(point), end.plus(point));
     }
+
+    private static List<Coord2D> DouglasPeukerIteration(List<Coord2D> path, double epsilon) {
+
+        // Find the point with the maximum distance
+        int pathSize = path.size();
+        int indexMax = 0;
+        double distMax = 0;
+
+        for (int i = 1; i != pathSize; ++i) {
+            double dist = getDistanceFromLine(path.get(i), path.get(0), path.get(pathSize - 1));
+            if (dist > distMax) {
+                distMax = dist;
+                indexMax = i;
+            }
+        }
+
+        List<Coord2D> simplifiedPath;
+
+        // If max distance is greater than epsilon, recursively simplify
+        if (distMax > epsilon) {
+            List<Coord2D> results1 = Simplify(path.subList(0, indexMax + 1), epsilon);
+            List<Coord2D> results2 = Simplify(path.subList(indexMax, pathSize), epsilon);
+
+            simplifiedPath = new ArrayList<>(results1);
+            simplifiedPath.addAll(results2.subList(1, results2.size()));
+        } else {
+            simplifiedPath = new ArrayList<>();
+            simplifiedPath.add(path.get(0));
+            simplifiedPath.add(path.get(pathSize - 1));
+        }
+
+        return simplifiedPath;
+    }
+
+    public static double SketchEpsilon(double width, double height) {
+
+        // TODO: this is a pretty crude simplification factor but we can revisit after more testing
+        double maxDim = Math.max(width, height);
+        return Math.max(maxDim / 500, 0.001);
+    }
+
+    public static double SketchEpsilon(PathDetail pathDetail) {
+        return SketchEpsilon(pathDetail.getWidth(), pathDetail.getHeight());
+    }
+
+    public static List<Coord2D> Simplify(List<Coord2D> path, double epsilon) {
+
+        if (path.isEmpty() || epsilon <= 0)
+            return path;
+
+        return DouglasPeukerIteration(path, epsilon);
+    }
+
 }

--- a/app/src/main/java/org/hwyl/sexytopo/model/sketch/PathDetail.java
+++ b/app/src/main/java/org/hwyl/sexytopo/model/sketch/PathDetail.java
@@ -10,7 +10,7 @@ import java.util.List;
 public final class PathDetail extends SketchDetail {
 
 
-    private final List<Coord2D> path;
+    private List<Coord2D> path;
 
     public PathDetail(Coord2D start, Colour colour) {
         super(colour);
@@ -34,6 +34,10 @@ public final class PathDetail extends SketchDetail {
 
     public List<Coord2D> getPath() {
         return path;
+    }
+
+    public void setPath(List<Coord2D> path) {
+        this.path = path;
     }
 
     @Override

--- a/app/src/main/java/org/hwyl/sexytopo/model/sketch/Sketch.java
+++ b/app/src/main/java/org/hwyl/sexytopo/model/sketch/Sketch.java
@@ -1,15 +1,14 @@
 package org.hwyl.sexytopo.model.sketch;
 
 import org.apache.commons.lang3.NotImplementedException;
+import org.hwyl.sexytopo.control.Log;
 import org.hwyl.sexytopo.control.util.Space2DUtils;
 import org.hwyl.sexytopo.model.graph.Coord2D;
 import org.hwyl.sexytopo.model.survey.Station;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Set;
 
 
 public class Sketch extends SketchDetail {
@@ -81,6 +80,9 @@ public class Sketch extends SketchDetail {
     }
 
     public void finishPath() {
+        double epsilon = Space2DUtils.SketchEpsilon(activePath);
+        Log.d("Sketch epsilon = " + epsilon);
+        activePath.setPath(Space2DUtils.Simplify(activePath.getPath(), epsilon));
         activePath = null;
     }
 

--- a/app/src/main/java/org/hwyl/sexytopo/model/sketch/Sketch.java
+++ b/app/src/main/java/org/hwyl/sexytopo/model/sketch/Sketch.java
@@ -80,9 +80,9 @@ public class Sketch extends SketchDetail {
     }
 
     public void finishPath() {
-        double epsilon = Space2DUtils.SketchEpsilon(activePath);
+        double epsilon = Space2DUtils.simplificationEpsilon(activePath);
         Log.d("Sketch epsilon = " + epsilon);
-        activePath.setPath(Space2DUtils.Simplify(activePath.getPath(), epsilon));
+        activePath.setPath(Space2DUtils.simplify(activePath.getPath(), epsilon));
         activePath = null;
     }
 

--- a/app/src/main/res/menu/action_bar.xml
+++ b/app/src/main/res/menu/action_bar.xml
@@ -88,6 +88,8 @@
           android:orderInCategory="100"
           app:showAsAction="never">
         <menu>
+            <item android:id="@+id/action_debug_mode"
+                android:title="@string/action_debug_mode" />
             <item android:id="@+id/action_kill_connection"
                   android:title="@string/action_kill_connection" />
             <item android:id="@+id/action_force_crash"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -35,6 +35,7 @@
     <string name="action_link_to_existing_survey">Link to an Existing Survey</string>
     <string name="action_system_log">System Log</string>
     <string name="action_generate_test_survey">Generate Test Survey</string>
+    <string name="action_debug_mode">Debug mode</string>
     <string name="action_kill_connection">Kill comms thread (danger!)</string>
     <string name="action_force_crash">Force crash (danger!)</string>
     <string name="loaded">Loaded</string>

--- a/app/src/test/java/org/hwyl/sexytopo/control/util/Space2DUtilsTest.java
+++ b/app/src/test/java/org/hwyl/sexytopo/control/util/Space2DUtilsTest.java
@@ -1,0 +1,131 @@
+package org.hwyl.sexytopo.control.util;
+
+import org.hwyl.sexytopo.model.graph.Coord2D;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Space2DUtilsTest {
+
+    @Test
+    public void testSimplifyEmpty() {
+
+        ArrayList<Coord2D> path = new ArrayList<>();
+        List<Coord2D> simplifiedPath = Space2DUtils.Simplify(path, 1);
+        Assert.assertEquals(path, simplifiedPath);
+    }
+
+    @Test
+    public void testSimplifyPoint() {
+
+        ArrayList<Coord2D> path = new ArrayList<>();
+        path.add(new Coord2D(0,0));
+
+        List<Coord2D> simplifiedPath = Space2DUtils.Simplify(path, 1);
+
+        // a single point gets converted to a line with coincident points
+        ArrayList<Coord2D> expectedPath = new ArrayList<>();
+        expectedPath.add(new Coord2D(0,0));
+        expectedPath.add(new Coord2D(0,0));
+
+        Assert.assertEquals(expectedPath, simplifiedPath);
+    }
+
+    @Test
+    public void testSimplifyLine() {
+
+        ArrayList<Coord2D> path = new ArrayList<>();
+        path.add(new Coord2D(0,0));
+        path.add(new Coord2D(10,0));
+
+        List<Coord2D> simplifiedPath = Space2DUtils.Simplify(path, 0.01);
+
+        Assert.assertEquals(path, simplifiedPath);
+    }
+
+    @Test
+    public void testSimplifyStraightPath() {
+
+        ArrayList<Coord2D> path = new ArrayList<>();
+        path.add(new Coord2D(0,0));
+        path.add(new Coord2D(10,0));
+        path.add(new Coord2D(20,0));
+        path.add(new Coord2D(30,0));
+        path.add(new Coord2D(40,0));
+        path.add(new Coord2D(50,0));
+
+        double epsilon = Space2DUtils.SketchEpsilon(50, 50);
+        List<Coord2D> simplifiedPath = Space2DUtils.Simplify(path, epsilon);
+
+        ArrayList<Coord2D> expectedPath = new ArrayList<>();
+        expectedPath.add(new Coord2D(0,0));
+        expectedPath.add(new Coord2D(50,0));
+
+        Assert.assertEquals(expectedPath, simplifiedPath);
+    }
+
+    @Test
+    public void testSimplifyRightAngledPath() {
+
+        ArrayList<Coord2D> path = new ArrayList<>();
+        path.add(new Coord2D(0,0));
+        path.add(new Coord2D(5,0));
+        path.add(new Coord2D(10,0));
+        path.add(new Coord2D(10,5));
+        path.add(new Coord2D(10,10));
+
+        double epsilon = Space2DUtils.SketchEpsilon(10, 10);
+        List<Coord2D> simplifiedPath = Space2DUtils.Simplify(path, epsilon);
+
+        ArrayList<Coord2D> expectedPath = new ArrayList<>();
+        expectedPath.add(new Coord2D(0,0));
+        expectedPath.add(new Coord2D(10,0));
+        expectedPath.add(new Coord2D(10,10));
+
+        Assert.assertEquals(expectedPath, simplifiedPath);
+    }
+
+    @Test
+    public void testSimplifyDensifiedCircle() {
+
+        double pi2 = 2 * Math.PI;
+        double step = pi2/12;
+        double radius = 5;
+        int offset = 10;
+
+        // Make a 12 point circle approximation
+        ArrayList<Coord2D> path = new ArrayList<>();
+        for(double theta = 0; theta < pi2; theta += step)
+        {
+            double x = offset + radius * Math.cos(theta);
+            double y = offset - radius * Math.sin(theta);
+            path.add(new Coord2D(x, y));
+        }
+        path.add(path.get(0));
+
+        {
+            double epsilon = Space2DUtils.SketchEpsilon(10, 10);
+            List<Coord2D> simplifiedPath = Space2DUtils.Simplify(path, epsilon);
+
+            // Remains unchanged
+            Assert.assertEquals(path, simplifiedPath);
+        }
+
+        {
+            double epsilon = 4;
+            List<Coord2D> simplifiedPath = Space2DUtils.Simplify(path, epsilon);
+
+            // Aggressive epsilon simplifies to a diamond
+            ArrayList<Coord2D> expectedPath = new ArrayList<>();
+            expectedPath.add(new Coord2D(15,10));
+            expectedPath.add(new Coord2D(10, 5));
+            expectedPath.add(new Coord2D( 5,10));
+            expectedPath.add(new Coord2D(10,15));
+            expectedPath.add(new Coord2D(15,10));
+
+            Assert.assertEquals(expectedPath, simplifiedPath);
+        }
+    }
+}

--- a/app/src/test/java/org/hwyl/sexytopo/control/util/Space2DUtilsTest.java
+++ b/app/src/test/java/org/hwyl/sexytopo/control/util/Space2DUtilsTest.java
@@ -13,7 +13,7 @@ public class Space2DUtilsTest {
     public void testSimplifyEmpty() {
 
         ArrayList<Coord2D> path = new ArrayList<>();
-        List<Coord2D> simplifiedPath = Space2DUtils.Simplify(path, 1);
+        List<Coord2D> simplifiedPath = Space2DUtils.simplify(path, 1);
         Assert.assertEquals(path, simplifiedPath);
     }
 
@@ -23,7 +23,7 @@ public class Space2DUtilsTest {
         ArrayList<Coord2D> path = new ArrayList<>();
         path.add(new Coord2D(0,0));
 
-        List<Coord2D> simplifiedPath = Space2DUtils.Simplify(path, 1);
+        List<Coord2D> simplifiedPath = Space2DUtils.simplify(path, 1);
 
         // a single point gets converted to a line with coincident points
         ArrayList<Coord2D> expectedPath = new ArrayList<>();
@@ -40,7 +40,7 @@ public class Space2DUtilsTest {
         path.add(new Coord2D(0,0));
         path.add(new Coord2D(10,0));
 
-        List<Coord2D> simplifiedPath = Space2DUtils.Simplify(path, 0.01);
+        List<Coord2D> simplifiedPath = Space2DUtils.simplify(path, 0.01);
 
         Assert.assertEquals(path, simplifiedPath);
     }
@@ -56,8 +56,8 @@ public class Space2DUtilsTest {
         path.add(new Coord2D(40,0));
         path.add(new Coord2D(50,0));
 
-        double epsilon = Space2DUtils.SketchEpsilon(50, 50);
-        List<Coord2D> simplifiedPath = Space2DUtils.Simplify(path, epsilon);
+        double epsilon = Space2DUtils.simplificationEpsilon(50, 50);
+        List<Coord2D> simplifiedPath = Space2DUtils.simplify(path, epsilon);
 
         ArrayList<Coord2D> expectedPath = new ArrayList<>();
         expectedPath.add(new Coord2D(0,0));
@@ -76,8 +76,8 @@ public class Space2DUtilsTest {
         path.add(new Coord2D(10,5));
         path.add(new Coord2D(10,10));
 
-        double epsilon = Space2DUtils.SketchEpsilon(10, 10);
-        List<Coord2D> simplifiedPath = Space2DUtils.Simplify(path, epsilon);
+        double epsilon = Space2DUtils.simplificationEpsilon(10, 10);
+        List<Coord2D> simplifiedPath = Space2DUtils.simplify(path, epsilon);
 
         ArrayList<Coord2D> expectedPath = new ArrayList<>();
         expectedPath.add(new Coord2D(0,0));
@@ -106,8 +106,8 @@ public class Space2DUtilsTest {
         path.add(path.get(0));
 
         {
-            double epsilon = Space2DUtils.SketchEpsilon(10, 10);
-            List<Coord2D> simplifiedPath = Space2DUtils.Simplify(path, epsilon);
+            double epsilon = Space2DUtils.simplificationEpsilon(10, 10);
+            List<Coord2D> simplifiedPath = Space2DUtils.simplify(path, epsilon);
 
             // Remains unchanged
             Assert.assertEquals(path, simplifiedPath);
@@ -115,15 +115,15 @@ public class Space2DUtilsTest {
 
         {
             double epsilon = 4;
-            List<Coord2D> simplifiedPath = Space2DUtils.Simplify(path, epsilon);
+            List<Coord2D> simplifiedPath = Space2DUtils.simplify(path, epsilon);
 
             // Aggressive epsilon simplifies to a diamond
             ArrayList<Coord2D> expectedPath = new ArrayList<>();
-            expectedPath.add(new Coord2D(15,10));
-            expectedPath.add(new Coord2D(10, 5));
-            expectedPath.add(new Coord2D( 5,10));
-            expectedPath.add(new Coord2D(10,15));
-            expectedPath.add(new Coord2D(15,10));
+            expectedPath.add(new Coord2D(15, 10));
+            expectedPath.add(new Coord2D(10,  5));
+            expectedPath.add(new Coord2D( 5, 10));
+            expectedPath.add(new Coord2D(10, 15));
+            expectedPath.add(new Coord2D(15, 10));
 
             Assert.assertEquals(expectedPath, simplifiedPath);
         }


### PR DESCRIPTION
 * Added an implementation of the Douglas-Peuker algorithm for simplifying polylines/paths
 * This gets run on a sketch path a) each time a user lifts their finger after making a new sketch and b) when loading a saved survey. This means that older surveys saved before the addition of this enhancement can get the same performance gains.
 * The calculated epsilon value is quite crude but can be improved after additional testing if necessary
 * Added a "debug mode" option to the "Dev" menu to toggle the drawing of path points which is handy when analysing epsilon values
 * Using the current epsilon calculation there was a reduction of 54% of the total sketch coordinates after loading a large test project