### PR TITLE
Sanitise Station Name on Rename

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -47,6 +47,7 @@ dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation 'androidx.appcompat:appcompat:1.3.0'
     implementation 'commons-io:commons-io:2.6'
+    implementation 'org.apache.commons:commons-text:1.9'
 
     testImplementation('org.powermock:powermock-api-mockito2:2.0.9')
     testImplementation('org.powermock:powermock-module-junit4:2.0.9')

--- a/app/src/main/java/org/hwyl/sexytopo/control/Log.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/Log.java
@@ -7,7 +7,8 @@ import android.os.AsyncTask;
 
 import com.google.firebase.crashlytics.FirebaseCrashlytics;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
+
 import org.hwyl.sexytopo.SexyTopo;
 import org.hwyl.sexytopo.control.io.Util;
 import org.hwyl.sexytopo.control.io.basic.Loader;

--- a/app/src/main/java/org/hwyl/sexytopo/control/Log.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/Log.java
@@ -7,6 +7,7 @@ import android.os.AsyncTask;
 
 import com.google.firebase.crashlytics.FirebaseCrashlytics;
 
+import org.apache.commons.lang3.StringEscapeUtils;
 import org.hwyl.sexytopo.SexyTopo;
 import org.hwyl.sexytopo.control.io.Util;
 import org.hwyl.sexytopo.control.io.basic.Loader;
@@ -69,6 +70,10 @@ public class Log {
         deviceLog.add(new Message(message));
         broadcast(SexyTopo.DEVICE_LOG_UPDATED_EVENT);
         android.util.Log.i(SexyTopo.TAG, message);
+    }
+
+    public static String formatDebugString(String value) {
+        return '"' + StringEscapeUtils.escapeJava(value) + '"';
     }
 
     public static synchronized void systemLog(String message, boolean isError) {

--- a/app/src/main/java/org/hwyl/sexytopo/control/util/SurveyUpdater.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/util/SurveyUpdater.java
@@ -222,12 +222,16 @@ public class SurveyUpdater {
 
 
     public static void renameStation(Survey survey, Station station, String name) {
+        String previousName = station.getName();
+        Log.d("Renaming station from: " + Log.formatDebugString(previousName) + " to: " + Log.formatDebugString(name));
+
         Station existing = survey.getStationByName(name);
         if (existing != null) {
             throw new IllegalArgumentException("New station name is not unique");
         }
+
         station.setName(name);
-        Log.d("Renamed station " + station.getName() + " -> " + name);
+        Log.d("Renamed station from: " + Log.formatDebugString(previousName) + " to: " + Log.formatDebugString(station.getName()));
     }
 
 

--- a/app/src/main/java/org/hwyl/sexytopo/model/survey/Station.java
+++ b/app/src/main/java/org/hwyl/sexytopo/model/survey/Station.java
@@ -47,7 +47,7 @@ public class Station extends SurveyComponent {
     }
 
     public void setName(String name) {
-        this.name = name;
+        this.name = sanitiseName(name);
     }
 
     public List<Leg> getOnwardLegs() {

--- a/app/src/test/java/org/hwyl/sexytopo/model/survey/StationTest.java
+++ b/app/src/test/java/org/hwyl/sexytopo/model/survey/StationTest.java
@@ -1,0 +1,13 @@
+package org.hwyl.sexytopo.model.survey;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class StationTest {
+    @Test
+    public void testSetNameSanitisesName() {
+        Station station = new Station("1");
+        station.setName("8\n");
+        Assert.assertEquals("8", station.getName());
+    }
+}


### PR DESCRIPTION
In #182 it appears a Survey Station was erroneously renamed an included a `\n` newline character. This appears to have been guarded against in the Station constructors:

https://github.com/richsmith/sexytopo/blob/ef7f19146425cfb7db78f1225a0bda1f51527b85/app/src/main/java/org/hwyl/sexytopo/model/survey/Station.java#L21-L28

but the `renameStation` method of `SurveyUpdater` calls `setName`, which doesn't utilise [`sanitiseName`](https://github.com/richsmith/sexytopo/blob/ef7f19146425cfb7db78f1225a0bda1f51527b85/app/src/main/java/org/hwyl/sexytopo/model/survey/Station.java#L30).

https://github.com/richsmith/sexytopo/blob/ef7f19146425cfb7db78f1225a0bda1f51527b85/app/src/main/java/org/hwyl/sexytopo/control/util/SurveyUpdater.java#L224-L231

This PR rectifies that by calling `sanitiseName` in the setter, ensuring the value is stored in its sanitised form.