### PR TITLE
Disable Rename Button While Station Name is Invalid

### DIFF
--- a/app/src/main/java/org/hwyl/sexytopo/control/table/Form.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/table/Form.java
@@ -4,6 +4,8 @@ import android.text.Editable;
 import android.text.TextWatcher;
 import android.widget.TextView;
 
+import androidx.annotation.Nullable;
+
 abstract public class Form {
     static class TextViewValidationTrigger implements TextWatcher {
         private final Form form;
@@ -24,10 +26,20 @@ abstract public class Form {
         }
     }
 
+    interface OnDidValidateCallback {
+        void onDidValidate(Boolean valid);
+    }
+
     private boolean valid;
+    @Nullable private OnDidValidateCallback onDidValidateCallback;
 
     Form() {
         this.valid = true;
+        this.onDidValidateCallback = null;
+    }
+
+    void setOnDidValidateCallback(@Nullable OnDidValidateCallback callback) {
+        this.onDidValidateCallback = callback;
     }
 
     public Boolean isValid() {
@@ -37,6 +49,10 @@ abstract public class Form {
     public void validate() {
         this.valid = true;
         performValidation();
+
+        if(this.onDidValidateCallback != null) {
+            this.onDidValidateCallback.onDidValidate(this.valid);
+        }
     }
 
     abstract protected void performValidation();

--- a/app/src/main/java/org/hwyl/sexytopo/control/table/Form.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/table/Form.java
@@ -1,0 +1,50 @@
+package org.hwyl.sexytopo.control.table;
+
+import android.text.Editable;
+import android.text.TextWatcher;
+import android.widget.TextView;
+
+abstract public class Form {
+    static class TextViewValidationTrigger implements TextWatcher {
+        private final Form form;
+
+        TextViewValidationTrigger(Form form) {
+            this.form = form;
+        }
+
+        @Override
+        public void beforeTextChanged(CharSequence charSequence, int start, int before, int count) {}
+
+        @Override
+        public void onTextChanged(CharSequence charSequence, int start, int count, int after) {}
+
+        @Override
+        public void afterTextChanged(Editable editable) {
+            this.form.validate();
+        }
+    }
+
+    private boolean valid;
+
+    Form() {
+        this.valid = true;
+    }
+
+    public Boolean isValid() {
+        return this.valid;
+    }
+
+    public void validate() {
+        this.valid = true;
+        performValidation();
+    }
+
+    abstract protected void performValidation();
+
+    protected void setError(TextView field, CharSequence error) {
+        boolean fieldValid = (error == null);
+
+        this.valid = this.valid  & fieldValid;
+        field.setError(error);
+    }
+}

--- a/app/src/main/java/org/hwyl/sexytopo/control/table/ManualEntry.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/table/ManualEntry.java
@@ -6,6 +6,7 @@ import android.content.DialogInterface;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.WindowManager;
+import android.widget.Button;
 import android.widget.TextView;
 
 import org.hwyl.sexytopo.R;
@@ -227,6 +228,11 @@ public class ManualEntry {
             renameAction.run();
             dialog.dismiss();
             return true;
+        });
+
+        form.setOnDidValidateCallback((valid) -> {
+            Button positiveButton = dialog.getButton(DialogInterface.BUTTON_POSITIVE);
+            positiveButton.setEnabled(valid);
         });
 
         dialog.getWindow().setSoftInputMode(

--- a/app/src/main/java/org/hwyl/sexytopo/control/table/ManualEntry.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/table/ManualEntry.java
@@ -4,6 +4,7 @@ import android.app.AlertDialog;
 import android.app.Dialog;
 import android.content.DialogInterface;
 import android.text.Editable;
+import android.text.InputType;
 import android.text.TextWatcher;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -209,6 +210,7 @@ public class ManualEntry {
                                      final Survey survey, final Station toRename) {
 
         final EditText renameField = new EditText(activity);
+        renameField.setInputType(InputType.TYPE_CLASS_TEXT);
         renameField.setText(toRename.getName());
 
 

--- a/app/src/main/java/org/hwyl/sexytopo/control/table/ManualEntry.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/table/ManualEntry.java
@@ -3,13 +3,9 @@ package org.hwyl.sexytopo.control.table;
 import android.app.AlertDialog;
 import android.app.Dialog;
 import android.content.DialogInterface;
-import android.text.Editable;
-import android.text.InputType;
-import android.text.TextWatcher;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.WindowManager;
-import android.widget.EditText;
 import android.widget.TextView;
 
 import org.hwyl.sexytopo.R;
@@ -208,13 +204,10 @@ public class ManualEntry {
 
     public static void renameStation(final TableActivity activity,
                                      final Survey survey, final Station toRename) {
-
-        final EditText renameField = new EditText(activity);
-        renameField.setInputType(InputType.TYPE_CLASS_TEXT);
-        renameField.setText(toRename.getName());
+        final RenameStationForm form = new RenameStationForm(activity, survey, toRename);
 
         Runnable renameAction = () -> {
-            String newName = renameField.getText().toString();
+            String newName = form.stationName.getText().toString();
             try {
                 SurveyUpdater.renameStation(survey, toRename, newName);
                 activity.syncTableWithSurvey();
@@ -223,41 +216,14 @@ public class ManualEntry {
             }
         };
 
-        renameField.addTextChangedListener(new TextWatcher() {
-            public void onTextChanged(CharSequence s, int start, int before, int count) {
-                // nothing
-            }
-
-            public void beforeTextChanged(CharSequence s, int start, int count, int after) {
-                // nothing
-            }
-
-            public void afterTextChanged(Editable s) {
-
-                String currentName = toRename.getName();
-                String currentText = renameField.getText().toString();
-
-                // only check for non-null or max length
-                if (currentText.isEmpty()) {
-                    renameField.setError("Cannot be blank");
-                } else if (currentText.equals("-")) {
-                    renameField.setError("Station cannot be named \"-\"");
-                } else if (!currentText.equals(currentName) && (survey.getStationByName(currentText) != null)) {
-                    renameField.setError("Station name must be unique");
-                } else {
-                    renameField.setError(null);
-                }
-            }
-        });
-
         AlertDialog dialog = new AlertDialog.Builder(activity)
                 .setTitle("Rename Station")
-                .setView(renameField)
-                .setPositiveButton("Rename", (ignore, buttonId) -> { renameAction.run(); })
+                .setView(form.stationName)
+                .setPositiveButton("Rename", (ignore, buttonId) -> renameAction.run())
                 .setNegativeButton("Cancel", (ignore, buttonId) -> { /* Do nothing */ })
                 .create();
 
-        renameField.setOnEditorActionListener((view, actionId, event) -> {
+        form.stationName.setOnEditorActionListener((view, actionId, event) -> {
             renameAction.run();
             dialog.dismiss();
             return true;

--- a/app/src/main/java/org/hwyl/sexytopo/control/table/ManualEntry.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/table/ManualEntry.java
@@ -213,6 +213,15 @@ public class ManualEntry {
         renameField.setInputType(InputType.TYPE_CLASS_TEXT);
         renameField.setText(toRename.getName());
 
+        Runnable renameAction = () -> {
+            String newName = renameField.getText().toString();
+            try {
+                SurveyUpdater.renameStation(survey, toRename, newName);
+                activity.syncTableWithSurvey();
+            } catch (Exception e) {
+                activity.showSimpleToast("Rename failed");
+            }
+        };
 
         renameField.addTextChangedListener(new TextWatcher() {
             public void onTextChanged(CharSequence s, int start, int before, int count) {
@@ -244,17 +253,15 @@ public class ManualEntry {
         AlertDialog dialog = new AlertDialog.Builder(activity)
                 .setTitle("Rename Station")
                 .setView(renameField)
-                .setPositiveButton("Rename", (ignore, buttonId) -> {
-                    String newName = renameField.getText().toString();
-                    try {
-                        SurveyUpdater.renameStation(survey, toRename, newName);
-                        activity.syncTableWithSurvey();
-                    } catch (Exception e) {
-                        activity.showSimpleToast("Rename failed");
-                    }
-                })
+                .setPositiveButton("Rename", (ignore, buttonId) -> { renameAction.run(); })
                 .setNegativeButton("Cancel", (ignore, buttonId) -> { /* Do nothing */ })
                 .create();
+
+        renameField.setOnEditorActionListener((view, actionId, event) -> {
+            renameAction.run();
+            dialog.dismiss();
+            return true;
+        });
 
         dialog.getWindow().setSoftInputMode(
                 WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE);

--- a/app/src/main/java/org/hwyl/sexytopo/control/table/ManualEntry.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/table/ManualEntry.java
@@ -225,9 +225,15 @@ public class ManualEntry {
                 .create();
 
         form.stationName.setOnEditorActionListener((view, actionId, event) -> {
-            renameAction.run();
-            dialog.dismiss();
-            return true;
+            form.validate();
+
+            if(form.isValid()) {
+                renameAction.run();
+                dialog.dismiss();
+                return true;
+            } else {
+                return false;
+            }
         });
 
         form.setOnDidValidateCallback((valid) -> {

--- a/app/src/main/java/org/hwyl/sexytopo/control/table/ManualEntry.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/table/ManualEntry.java
@@ -242,7 +242,7 @@ public class ManualEntry {
         });
 
         AlertDialog dialog = new AlertDialog.Builder(activity)
-                .setTitle("Edit name")
+                .setTitle("Rename Station")
                 .setView(renameField)
                 .setPositiveButton("Rename", (ignore, buttonId) -> {
                     String newName = renameField.getText().toString();

--- a/app/src/main/java/org/hwyl/sexytopo/control/table/RenameStationForm.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/table/RenameStationForm.java
@@ -1,0 +1,45 @@
+package org.hwyl.sexytopo.control.table;
+
+import android.content.Context;
+import android.text.Editable;
+import android.text.InputType;
+import android.widget.EditText;
+
+import org.hwyl.sexytopo.model.survey.Station;
+import org.hwyl.sexytopo.model.survey.Survey;
+
+public class RenameStationForm extends Form {
+    Survey survey;
+    Station station;
+
+    EditText stationName;
+
+    RenameStationForm(Context context, Survey survey, Station station) {
+        super();
+        this.survey = survey;
+        this.station = station;
+
+        this.stationName = new EditText(context);
+        this.stationName.setInputType(InputType.TYPE_CLASS_TEXT);
+        this.stationName.setText(this.station.getName());
+        this.stationName.addTextChangedListener(new TextViewValidationTrigger(this));
+    }
+
+    @Override
+    protected void performValidation() {
+        String currentName = this.station.getName();
+        Editable currentText = this.stationName.getText();
+        String currentTextString = currentText.toString();
+
+        // only check for non-null or max length
+        if (currentTextString.isEmpty()) {
+            setError(this.stationName, "Cannot be blank");
+        } else if (currentTextString.equals("-")) {
+            setError(this.stationName, "Station cannot be named \"-\"");
+        } else if (!currentTextString.equals(currentName) && (survey.getStationByName(currentTextString) != null)) {
+            setError(this.stationName, "Station name must be unique");
+        } else {
+            setError(this.stationName, null);
+        }
+    }
+}

--- a/app/src/test/java/org/hwyl/sexytopo/control/table/FormTest.java
+++ b/app/src/test/java/org/hwyl/sexytopo/control/table/FormTest.java
@@ -1,0 +1,80 @@
+package org.hwyl.sexytopo.control.table;
+
+import static org.mockito.Mockito.verify;
+
+import android.widget.EditText;
+
+import junit.framework.TestCase;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class FormTest extends TestCase {
+    class MockForm extends Form {
+        EditText name;
+        EditText phone;
+        boolean validName;
+        boolean validPhone;
+
+        MockForm() {
+            this.name = Mockito.mock(EditText.class);
+            this.phone = Mockito.mock(EditText.class);
+
+            this.validName = true;
+            this.validPhone = true;
+        }
+
+        @Override
+        protected void performValidation() {
+            if (!validName) {
+                this.setError(this.name, "invalid name");
+            } else {
+                this.setError(this.name, null);
+            }
+
+            if (!validPhone) {
+                this.setError(this.phone, "invalid phone");
+            } else {
+                this.setError(this.phone, null);
+            }
+        }
+    }
+
+    private MockForm form = new MockForm();
+
+    @Test
+    public void testValidateWithValidFields() {
+        form.validate();
+        assert(form.isValid());
+    }
+
+    @Test
+    public void testValidateWithSingleInvalidField() {
+        form.validName = false;
+
+        form.validate();
+        assert(!form.isValid());
+    }
+
+    @Test
+    public void testValidateWithMultipleInvalidFields() {
+        form.validName = false;
+        form.validPhone = false;
+
+        form.validate();
+        assert(!form.isValid());
+    }
+
+    @Test
+    public void testDelegatesSetErrorToFields() {
+        form.name = Mockito.mock(EditText.class);
+        form.validName = true;
+        form.phone = Mockito.mock(EditText.class);
+        form.validPhone = false;
+
+        form.validate();
+
+        verify(form.name).setError(null);
+        verify(form.phone).setError("invalid phone");
+    }
+}

--- a/app/src/test/java/org/hwyl/sexytopo/control/table/FormTest.java
+++ b/app/src/test/java/org/hwyl/sexytopo/control/table/FormTest.java
@@ -4,6 +4,8 @@ import static org.mockito.Mockito.verify;
 
 import android.widget.EditText;
 
+import androidx.annotation.Nullable;
+
 import junit.framework.TestCase;
 
 import org.junit.Test;
@@ -39,6 +41,15 @@ public class FormTest extends TestCase {
             }
         }
     }
+
+    class MockValidateCallback implements Form.OnDidValidateCallback {
+        @Nullable Boolean value = null;
+
+        @Override
+        public void onDidValidate(Boolean valid) {
+            this.value = valid;
+        }
+    };
 
     private MockForm form = new MockForm();
 
@@ -76,5 +87,25 @@ public class FormTest extends TestCase {
 
         verify(form.name).setError(null);
         verify(form.phone).setError("invalid phone");
+    }
+
+    @Test
+    public void testCallsOnDidValidateCallbackWithValidForm() {
+        MockValidateCallback callback = new MockValidateCallback();
+        form.setOnDidValidateCallback(callback);
+        form.validate();
+
+        assert(callback.value);
+    }
+
+    @Test
+    public void testCallsOnDidValidateCallbackWithInvalidForm() {
+        MockValidateCallback callback = new MockValidateCallback();
+        form.setOnDidValidateCallback(callback);
+
+        form.validPhone = false;
+        form.validate();
+
+        assert(!callback.value);
     }
 }


### PR DESCRIPTION
Building upon #183, this PR aims to prevent inconsistency when renaming a station by preventing the "Rename" button from being pressed when the form is invalid.

Previously the rename station dialog had the potential to cause an issue on different view sizes, as it seems it only coincidentally prevented an invalid rename by covering the "Rename" button with the `TextView` error message. This PR disables the button when the station name is invalid.

### The `Form` Concept

This PR introduces a new, abstract `Form` class, which currently is just responsible for grouping fields (although in this case the form only has a single field) and providing a structure for validating a form and firing callbacks.

A longer term vision might be to encapsulate each manual entry as a `Form` subclass, which can then be presented in a consistent manor (perhaps a [full-screen dialog](https://material.io/components/dialogs#full-screen-dialog) for phone-sized devices?), and also potentially encapsulate field labels & dynamically building the form views based on it's fields.

### The Result

https://user-images.githubusercontent.com/630/189769748-d790610f-c5c9-4435-b097-b17735df8e53.mp4

Note:

* the button (underneath the error message) is disabled when the field is invalid
* the "Done" editor action doesn't rename the station if it's invalid
* a valid rename works via both methods