### PR TITLE
Issue#266-LRUDs-assigned-to-wrong-station

### DIFF
--- a/app/src/main/java/org/hwyl/sexytopo/control/table/LegDialogs.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/table/LegDialogs.java
@@ -143,10 +143,16 @@ public class LegDialogs {
 
                     // Add LRUDs if requested
                     if (includeLruds) {
+                        // Restore the active station back to the FROM station
+                        survey.setActiveStation(fromStation);
+
                         createLrudIfPresent(survey, fromStation, dialog, R.id.editDistanceLeft, LRUD.LEFT);
                         createLrudIfPresent(survey, fromStation, dialog, R.id.editDistanceRight, LRUD.RIGHT);
                         createLrudIfPresent(survey, fromStation, dialog, R.id.editDistanceUp, LRUD.UP);
                         createLrudIfPresent(survey, fromStation, dialog, R.id.editDistanceDown, LRUD.DOWN);
+
+                        // Move active station back to the TO station again
+                        survey.setActiveStation(newStation);
                     }
                 }
 


### PR DESCRIPTION
The active station was being moved to the To station before the LRUDs were added. Solution was to restore the activeStation to the FROM, before adding the LRUDs and then putting it back afterwards. We could not just change the order because the
TO station is needed in order to work out the angle of the left/right component.