### PR TITLE
Issue#263-Cannot-Rename-Origin-Station

### DIFF
--- a/app/src/main/java/org/hwyl/sexytopo/control/table/LegDialogs.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/table/LegDialogs.java
@@ -125,6 +125,14 @@ public class LegDialogs {
                 Leg leg = form.getUpdatedLeg();
                 Station fromStation = form.getUpdatedFromStation();
 
+                // Get the new station names from the form
+                String newFromStationName = form.getUpdatedFromStationName();
+                String oldFromStationName = fromStation.getName();
+                if (!newFromStationName.equals(oldFromStationName) && survey.isOrigin(fromStation)) {
+                    // Just rename the origin station
+                    SurveyUpdater.renameOrigin(survey, newFromStationName);
+                }
+
                 if (isSplay) {
                     // Add splay to from station
                     SurveyUpdater.addLegFromStation(survey, fromStation, leg);
@@ -254,15 +262,21 @@ public class LegDialogs {
 
                 // Get the new station names from the form
                 Station newFromStation = form.getUpdatedFromStation();
+                String newFromStationName = form.getUpdatedFromStationName();
                 String oldFromStationName = fromStation.getName();
 
                 // Apply changes in the correct order:
                 // 1. First, edit the leg measurements
                 SurveyUpdater.editLeg(survey, toEdit, edited);
 
-                // 2. Move leg if from station changed
-                if (!newFromStation.getName().equals(oldFromStationName)) {
-                    SurveyUpdater.moveLeg(survey, edited, newFromStation);
+                // 2. Move leg (or rename origin station) if from station changed
+                if (!newFromStationName.equals(oldFromStationName)) {
+                    if (newFromStation == fromStation && survey.isOrigin(newFromStation)) {
+                        // If the station hasn't changed and it is the origin, then just rename the origin
+                        SurveyUpdater.renameOrigin(survey, newFromStationName);
+                    } else {
+                        SurveyUpdater.moveLeg(survey, edited, newFromStation);
+                    }
                 }
 
                 // 3. Rename destination station if to station name changed (for full legs)

--- a/app/src/main/java/org/hwyl/sexytopo/control/util/SurveyUpdater.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/util/SurveyUpdater.java
@@ -235,6 +235,9 @@ public class SurveyUpdater {
         Log.i(R.string.survey_update_renamed_station, previousName, name);
     }
 
+    public static void renameOrigin(Survey survey, String name) {
+        renameStation(survey, survey.getOrigin(), name);
+    }
 
     public static void moveLeg(Survey survey, Leg leg, Station newSource) {
         Station originating = survey.getOriginatingStation(leg);
@@ -246,15 +249,13 @@ public class SurveyUpdater {
 
 
     public static void deleteStation(final Survey survey, final Station toDelete) {
-        if (toDelete == survey.getOrigin()) {
-            return;
+        if (!survey.isOrigin(toDelete)) {
+            // Station comes as a package with the leg that forms it, so
+            // remove that to delete the station from the graph
+            Leg referringLeg = survey.getReferringLeg(toDelete);
+            Station fromStation = survey.getOriginatingStation(referringLeg);
+            deleteLeg(survey, fromStation, referringLeg);
         }
-
-        // Station comes as a package with the leg that forms it, so
-        // remove that to delete the station from the graph
-        Leg referringLeg = survey.getReferringLeg(toDelete);
-        Station fromStation = survey.getOriginatingStation(referringLeg);
-        deleteLeg(survey, fromStation, referringLeg);
     }
 
 

--- a/app/src/main/java/org/hwyl/sexytopo/model/survey/Survey.java
+++ b/app/src/main/java/org/hwyl/sexytopo/model/survey/Survey.java
@@ -155,6 +155,10 @@ public class Survey {
         this.origin = origin;
     }
 
+    public boolean isOrigin(Station station) {
+        return station == origin;
+    }
+
     public List<Station> getAllStations() {
         return getAllStations(origin);
     }


### PR DESCRIPTION
Work out if we are updating the origin station in the form and if so we allow renaming of it (and check it does not already exist). It does lead to a slightly wierd side effect. If you enter a non-existent from station and the current from station happens is the origin, the station will just be renamed to that rather than erroring out. Not sure if a warning dialog might make sense.