### PR TITLE
Allow LRUDs to be looking at next station

### DIFF
--- a/app/src/main/java/org/hwyl/sexytopo/control/table/LegDialogs.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/table/LegDialogs.java
@@ -154,10 +154,11 @@ public class LegDialogs {
                         // Restore the active station back to the FROM station
                         survey.setActiveStation(fromStation);
 
-                        createLrudIfPresent(survey, fromStation, dialog, R.id.editDistanceLeft, LRUD.LEFT);
-                        createLrudIfPresent(survey, fromStation, dialog, R.id.editDistanceRight, LRUD.RIGHT);
-                        createLrudIfPresent(survey, fromStation, dialog, R.id.editDistanceUp, LRUD.UP);
-                        createLrudIfPresent(survey, fromStation, dialog, R.id.editDistanceDown, LRUD.DOWN);
+                        Leg useLeg = GeneralPreferences.isLrudBisectModeOn() ? null : leg;
+                        createLrudIfPresent(survey, fromStation, dialog, R.id.editDistanceLeft, LRUD.LEFT, useLeg);
+                        createLrudIfPresent(survey, fromStation, dialog, R.id.editDistanceRight, LRUD.RIGHT, useLeg);
+                        createLrudIfPresent(survey, fromStation, dialog, R.id.editDistanceUp, LRUD.UP, useLeg);
+                        createLrudIfPresent(survey, fromStation, dialog, R.id.editDistanceDown, LRUD.DOWN, useLeg);
 
                         // Move active station back to the TO station again
                         survey.setActiveStation(newStation);
@@ -318,10 +319,10 @@ public class LegDialogs {
 
     private static void createLrudIfPresent(Survey survey, Station station,
                                             AlertDialog dialog, int fieldId,
-                                            LRUD direction) {
+                                            LRUD direction, Leg useLeg) {
         Float value = getFieldValue(dialog, fieldId);
         if (value != null) {
-            Leg leg = direction.createSplay(survey, station, value);
+            Leg leg = direction.createSplay(survey, station, useLeg, value);
             SurveyUpdater.update(survey, leg);
         }
 

--- a/app/src/main/java/org/hwyl/sexytopo/control/util/GeneralPreferences.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/util/GeneralPreferences.java
@@ -148,6 +148,10 @@ public class GeneralPreferences {
         return getBoolean("pref_lrud_fields", false);
     }
 
+    public static boolean isLrudBisectModeOn() {
+        return getBoolean("pref_lrud_bisect_angle", true);
+    }
+
     public static boolean isDegMinsSecsModeOn() {
         return getBoolean("pref_deg_mins_secs", false);
     }

--- a/app/src/main/java/org/hwyl/sexytopo/model/table/LRUD.java
+++ b/app/src/main/java/org/hwyl/sexytopo/model/table/LRUD.java
@@ -12,31 +12,31 @@ import org.hwyl.sexytopo.model.survey.Survey;
  */
 public enum LRUD {
     LEFT {
-        public Leg createSplay(Survey survey, Station station, float distance) {
+        public Leg createSplay(Survey survey, Station station, Leg useLeg, float distance) {
             float angle = Space2DUtils.adjustAngle(
-                    CrossSectioner.getAngleOfSection(survey, station),
+                    useLeg!=null ? useLeg.getAzimuth() : CrossSectioner.getAngleOfSection(survey, station),
                     -90.0f);
             return new Leg(distance, angle, 0);
         }
     },
     RIGHT {
-        public Leg createSplay(Survey survey, Station station, float distance) {
+        public Leg createSplay(Survey survey, Station station, Leg useLeg, float distance) {
             float angle = Space2DUtils.adjustAngle(
-                    CrossSectioner.getAngleOfSection(survey, station),
+                    useLeg!=null ? useLeg.getAzimuth() : CrossSectioner.getAngleOfSection(survey, station),
                     90.0f);
             return new Leg(distance, angle, 0);
         }
     },
     UP {
-        public Leg createSplay(Survey survey, Station station, float distance) {
+        public Leg createSplay(Survey survey, Station station, Leg useLeg, float distance) {
             return new Leg(distance, 0, 90.0f);
         }
     },
     DOWN {
-        public Leg createSplay(Survey survey, Station station, float distance) {
+        public Leg createSplay(Survey survey, Station station, Leg useLeg, float distance) {
             return new Leg(distance, 0, -90.0f);
         }
     };
 
-    public abstract Leg createSplay(Survey survey, Station station, float distance);
+    public abstract Leg createSplay(Survey survey, Station station, Leg useLeg, float distance);
 }

--- a/app/src/main/java/org/hwyl/sexytopo/testutils/ExampleSurveyCreator.java
+++ b/app/src/main/java/org/hwyl/sexytopo/testutils/ExampleSurveyCreator.java
@@ -62,7 +62,7 @@ public class ExampleSurveyCreator {
 
     public static void createLruds(Survey survey, Station station) {
         for (LRUD lrud : LRUD.values()) {
-            Leg splay = lrud.createSplay(survey, station, 1 + random.nextInt(3));
+            Leg splay = lrud.createSplay(survey, station, null, 1 + random.nextInt(3));
             SurveyUpdater.update(survey, splay);
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -456,6 +456,8 @@
     <string name="settings_manual_data_entry_title">Manual Data Entry</string>
     <string name="settings_key_lrud_fields_title">LRUD entries</string>
     <string name="settings_key_lrud_fields_summary">Show fields for entering LRUDs (Left-Right-Up-Down) for each new station</string>
+    <string name="settings_lrud_bisect_angle_title">Left and Right bisect angle</string>
+    <string name="settings_lrud_bisect_angle_summary">Left and Right bisect angle between last station and the next one (as opposed to just being perpendicular to the direction to the next station)</string>
     <string name="settings_key_deg_mins_secs_title">Azimuth as degrees/minutes/seconds</string>
     <string name="settings_key_deg_mins_secs_summary">Enter azimuth values in deg/mins/secs (as opposed to the default of decimal)</string>
     <string name="settings_export_title">Export</string>

--- a/app/src/main/res/xml/general_preferences.xml
+++ b/app/src/main/res/xml/general_preferences.xml
@@ -131,6 +131,11 @@
             android:summary="@string/settings_key_lrud_fields_summary"
             android:defaultValue="false"/>
         <CheckBoxPreference
+            android:key="pref_lrud_bisect_angle"
+            android:title="@string/settings_lrud_bisect_angle_title"
+            android:summary="@string/settings_lrud_bisect_angle_summary"
+            android:defaultValue="true"/>
+        <CheckBoxPreference
             android:key="pref_deg_mins_secs"
             android:title="@string/settings_key_deg_mins_secs_title"
             android:summary="@string/settings_key_deg_mins_secs_summary"

--- a/app/src/test/java/org/hwyl/sexytopo/model/table/LrudTest.java
+++ b/app/src/test/java/org/hwyl/sexytopo/model/table/LrudTest.java
@@ -19,7 +19,7 @@ public class LrudTest {
 
         Station s2 = testSurvey.getStationByName("2");
         double angle = CrossSectioner.getAngleOfSection(testSurvey, s2);
-        Leg splay = LRUD.LEFT.createSplay(testSurvey, s2, 5);
+        Leg splay = LRUD.LEFT.createSplay(testSurvey, s2, null, 5);
 
         Assert.assertEquals(270.0, splay.getAzimuth(), SexyTopoConstants.ALLOWED_DOUBLE_DELTA);
     }
@@ -31,7 +31,7 @@ public class LrudTest {
 
         Station s2 = testSurvey.getStationByName("2");
         double angle = CrossSectioner.getAngleOfSection(testSurvey, s2);
-        Leg splay = LRUD.RIGHT.createSplay(testSurvey, s2, 5);
+        Leg splay = LRUD.RIGHT.createSplay(testSurvey, s2, null, 5);
 
         Assert.assertEquals(90.0, splay.getAzimuth(), SexyTopoConstants.ALLOWED_DOUBLE_DELTA);
     }


### PR DESCRIPTION
Added a new setting to allow LRUD to be specified as looking at the next station, not bisecting the angle between the last station and the next one. This seems to be a standard alternate way to measure LRUDs (though I only know people who use the former method)

Given this appears to be a little used function, I am wondering if I have over-engineered this and whether we shouldn't just change the behaviour and not bother with it being an option.

Happy to modify the pull request as required.