### PR TITLE
Manual promotion of legs

### DIFF
--- a/app/src/main/java/org/hwyl/sexytopo/control/activity/SexyTopoActivity.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/activity/SexyTopoActivity.java
@@ -249,7 +249,7 @@ public abstract class SexyTopoActivity extends AppCompatActivity {
         } else if (itemId == R.id.action_stats) {
             startActivity(StatsActivity.class);
             return true;
-        } else if (itemId == R.id.action_trip) {
+        } else if (itemId == R.id.action_trip || itemId == R.id.action_trip_menu) {
             startActivity(TripActivity.class);
             return true;
         } else if (itemId == R.id.action_settings) {

--- a/app/src/main/java/org/hwyl/sexytopo/control/activity/SexyTopoActivity.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/activity/SexyTopoActivity.java
@@ -60,6 +60,7 @@ import org.hwyl.sexytopo.testutils.ExampleSurveyCreator;
 import org.hwyl.sexytopo.model.survey.Station;
 import org.hwyl.sexytopo.model.survey.Survey;
 import org.hwyl.sexytopo.model.survey.SurveyConnection;
+import org.hwyl.sexytopo.model.survey.Trip;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -475,9 +476,37 @@ public abstract class SexyTopoActivity extends AppCompatActivity {
 
 
     protected void startNewSurvey() {
+        // Save team from current survey before creating new one
+        Survey previousSurvey = getSurvey();
+        List<Trip.TeamEntry> previousTeam = new ArrayList<>();
+        String previousInstrument = "";
+        
+        if (previousSurvey != null && previousSurvey.getTrip() != null) {
+            Trip previousTrip = previousSurvey.getTrip();
+            // Copy team members
+            for (Trip.TeamEntry entry : previousTrip.getTeam()) {
+                previousTeam.add(new Trip.TeamEntry(entry.name, new ArrayList<>(entry.roles)));
+            }
+            // Copy instrument
+            if (previousTrip.hasInstrument()) {
+                previousInstrument = previousTrip.getInstrument();
+            }
+        }
+        
+        // Create new survey
         Survey survey = new Survey();
         setSurvey(survey);
         Log.i(R.string.file_started_new_survey);
+        
+        // Set up new trip with copied data
+        Trip newTrip = new Trip();
+        newTrip.setTeam(previousTeam);
+        newTrip.setInstrument(previousInstrument);
+        // Comments cleared (default)
+        // explorationDateSameAsSurvey defaults to true
+        survey.setTrip(newTrip);
+        
+        startActivity(TripActivity.class);
     }
 
 

--- a/app/src/main/java/org/hwyl/sexytopo/control/activity/SurveyEditorActivity.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/activity/SurveyEditorActivity.java
@@ -3,6 +3,7 @@ package org.hwyl.sexytopo.control.activity;
 import android.app.Dialog;
 import android.view.Gravity;
 import android.view.WindowManager;
+import android.widget.Toast;
 
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.android.material.textfield.TextInputEditText;
@@ -137,6 +138,20 @@ public abstract class SurveyEditorActivity extends SexyTopoActivity {
         }
 
         SurveyUpdater.upgradeSplay(getSurvey(), leg, InputMode.FORWARD);
+        getSurveyManager().broadcastSurveyUpdated();
+    }
+
+    public void onPromoteToAboveLeg(Leg splay) {
+        if (splay == null || splay.hasDestination()) {
+            return;
+        }
+
+        boolean success = SurveyUpdater.promoteToAboveLeg(getSurvey(), splay);
+        if (success) {
+            Toast.makeText(this, R.string.toast_splay_promoted, Toast.LENGTH_SHORT).show();
+        } else {
+            Toast.makeText(this, R.string.toast_no_leg_above, Toast.LENGTH_SHORT).show();
+        }
         getSurveyManager().broadcastSurveyUpdated();
     }
 

--- a/app/src/main/java/org/hwyl/sexytopo/control/graph/ContextMenuManager.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/graph/ContextMenuManager.java
@@ -224,6 +224,7 @@ public class ContextMenuManager {
             // Use provided leg, or infer from station if not provided
             Leg referringLeg = (leg != null) ? leg : survey.getReferringLeg(station);
             MenuItem upgradeItem = menu.findItem(R.id.action_upgrade_splay);
+            MenuItem promoteToAboveItem = menu.findItem(R.id.action_promote_to_above_leg);
             MenuItem downgradeItem = menu.findItem(R.id.action_downgrade_leg);
             MenuItem legSubmenu = menu.findItem(R.id.menu_leg);
 
@@ -232,6 +233,13 @@ public class ContextMenuManager {
                 if (upgradeItem != null) {
                     upgradeItem.setVisible(isSplay);
                 }
+                
+                // Show "Promote to Above Leg" for all splays (simplified for debugging)
+                if (promoteToAboveItem != null) {
+                    // Always show for splays to verify menu item works
+                    promoteToAboveItem.setVisible(isSplay);
+                }
+                
                 if (downgradeItem != null) {
                     // Only show downgrade if it's a full leg AND destination has no onward legs
                     boolean canDowngrade = !isSplay &&
@@ -246,6 +254,9 @@ public class ContextMenuManager {
                 // No referring leg (origin station) - hide both
                 if (upgradeItem != null) {
                     upgradeItem.setVisible(false);
+                }
+                if (promoteToAboveItem != null) {
+                    promoteToAboveItem.setVisible(false);
                 }
                 if (downgradeItem != null) {
                     downgradeItem.setVisible(false);
@@ -307,6 +318,10 @@ public class ContextMenuManager {
         // Special handling for actions that need the leg context
         if (itemId == R.id.action_upgrade_splay && currentLeg != null) {
             activity.onUpgradeSplay(currentLeg);
+            return true;
+        }
+        if (itemId == R.id.action_promote_to_above_leg && currentLeg != null) {
+            activity.onPromoteToAboveLeg(currentLeg);
             return true;
         }
         if (itemId == R.id.action_downgrade_leg && currentLeg != null) {

--- a/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/survex/SurvexExporter.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/survex/SurvexExporter.java
@@ -5,36 +5,38 @@ import android.content.Context;
 import org.hwyl.sexytopo.R;
 import org.hwyl.sexytopo.control.io.thirdparty.survextherion.SurvexTherionUtil;
 import org.hwyl.sexytopo.control.io.translation.SingleFileExporter;
-import org.hwyl.sexytopo.control.util.GraphToListTranslator;
 import org.hwyl.sexytopo.model.survey.Survey;
-
-import java.util.List;
 
 
 public class SurvexExporter extends SingleFileExporter {
 
     public static final char COMMENT_CHAR = ';';
-
-    protected static final GraphToListTranslator graphToListTranslator =
-            new GraphToListTranslator();
+    public static final String SYNTAX_MARKER = "*";
 
     public String getContent(Survey survey) {
-
         StringBuilder builder = new StringBuilder();
 
-        builder.append("*alias station - ..\n\n");
-
-        List<GraphToListTranslator.SurveyListEntry> list =
-                graphToListTranslator.toChronoListOfSurveyListEntries(survey);
-
-        for (GraphToListTranslator.SurveyListEntry entry : list) {
-            SurvexTherionUtil.formatEntry(builder, entry, COMMENT_CHAR);
-            builder.append("\n");
-        }
+        // Begin survey block
+        builder.append("*begin ").append(survey.getName()).append("\n");
+        
+        // Creation comment (no version info available without Context)
+        builder.append(SurvexTherionUtil.getCreationComment(COMMENT_CHAR, "SexyTopo")).append("\n\n");
+        
+        // Metadata (date, instrument, team, explo block)
+        builder.append(SurvexTherionUtil.getMetadata(survey, SYNTAX_MARKER, COMMENT_CHAR)).append("\n");
+        
+        // Centreline data
+        builder.append(SurvexTherionUtil.getCentrelineData(survey, SYNTAX_MARKER, COMMENT_CHAR, true));
+        
+        // Extended elevation
+        builder.append("\n");
+        builder.append(SurvexTherionUtil.getExtendedElevationExtensions(survey, SYNTAX_MARKER));
+        
+        // End survey block
+        builder.append("*end ").append(survey.getName()).append("\n");
 
         return builder.toString();
     }
-
 
 
     @Override

--- a/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/survex/SurvexExporter.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/survex/SurvexExporter.java
@@ -3,6 +3,7 @@ package org.hwyl.sexytopo.control.io.thirdparty.survex;
 import android.content.Context;
 
 import org.hwyl.sexytopo.R;
+import org.hwyl.sexytopo.control.io.thirdparty.survextherion.ExportFormat;
 import org.hwyl.sexytopo.control.io.thirdparty.survextherion.SurvexTherionUtil;
 import org.hwyl.sexytopo.control.io.translation.SingleFileExporter;
 import org.hwyl.sexytopo.model.survey.Survey;
@@ -11,8 +12,9 @@ import org.hwyl.sexytopo.model.survey.Survey;
 public class SurvexExporter extends SingleFileExporter {
 
     public static final char COMMENT_CHAR = ';';
-    public static final String SYNTAX_MARKER = "*";
 
+    // StringBuilder is more efficient than string concatenation for multiple appends
+    @SuppressWarnings("StringBufferReplaceableByString")
     public String getContent(Survey survey) {
         StringBuilder builder = new StringBuilder();
 
@@ -23,14 +25,14 @@ public class SurvexExporter extends SingleFileExporter {
         builder.append(SurvexTherionUtil.getCreationComment(COMMENT_CHAR, "SexyTopo")).append("\n\n");
         
         // Metadata (date, instrument, team, explo block)
-        builder.append(SurvexTherionUtil.getMetadata(survey, SYNTAX_MARKER, COMMENT_CHAR)).append("\n");
+        builder.append(SurvexTherionUtil.getMetadata(survey, COMMENT_CHAR, ExportFormat.SURVEX)).append("\n");
         
         // Centreline data
-        builder.append(SurvexTherionUtil.getCentrelineData(survey, SYNTAX_MARKER, COMMENT_CHAR, true));
+        builder.append(SurvexTherionUtil.getCentrelineData(survey, COMMENT_CHAR, ExportFormat.SURVEX));
         
         // Extended elevation
         builder.append("\n");
-        builder.append(SurvexTherionUtil.getExtendedElevationExtensions(survey, SYNTAX_MARKER));
+        builder.append(SurvexTherionUtil.getExtendedElevationExtensions(survey, ExportFormat.SURVEX));
         
         // End survey block
         builder.append("*end ").append(survey.getName()).append("\n");

--- a/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/survex/SurvexExporter.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/survex/SurvexExporter.java
@@ -3,7 +3,7 @@ package org.hwyl.sexytopo.control.io.thirdparty.survex;
 import android.content.Context;
 
 import org.hwyl.sexytopo.R;
-import org.hwyl.sexytopo.control.io.thirdparty.survextherion.ExportFormat;
+import org.hwyl.sexytopo.control.io.thirdparty.survextherion.SurveyFormat;
 import org.hwyl.sexytopo.control.io.thirdparty.survextherion.SurvexTherionUtil;
 import org.hwyl.sexytopo.control.io.translation.SingleFileExporter;
 import org.hwyl.sexytopo.model.survey.Survey;
@@ -24,17 +24,17 @@ public class SurvexExporter extends SingleFileExporter {
         builder.append(SurvexTherionUtil.getCreationComment(COMMENT_CHAR, "SexyTopo")).append("\n\n");
 
         // Metadata (instrument is now in Trip, not passed separately)
-        builder.append(SurvexTherionUtil.getMetadata(survey, COMMENT_CHAR, ExportFormat.SURVEX)).append("\n");
+        builder.append(SurvexTherionUtil.getMetadata(survey, COMMENT_CHAR, SurveyFormat.SURVEX)).append("\n");
 
         // Station comments data block
-        builder.append(SurvexTherionUtil.getStationCommentsData(survey, ExportFormat.SURVEX));
+        builder.append(SurvexTherionUtil.getStationCommentsData(survey, SurveyFormat.SURVEX));
 
         // Centreline data
-        builder.append(SurvexTherionUtil.getCentrelineData(survey, COMMENT_CHAR, ExportFormat.SURVEX));
+        builder.append(SurvexTherionUtil.getCentrelineData(survey, COMMENT_CHAR, SurveyFormat.SURVEX));
 
         // Extended elevation
         builder.append("\n");
-        builder.append(SurvexTherionUtil.getExtendedElevationExtensions(survey, ExportFormat.SURVEX));
+        builder.append(SurvexTherionUtil.getExtendedElevationExtensions(survey, SurveyFormat.SURVEX));
 
         // End survey block
         builder.append("*end ").append(survey.getName()).append("\n");

--- a/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/survex/SurvexExporter.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/survex/SurvexExporter.java
@@ -25,6 +25,9 @@ public class SurvexExporter extends SingleFileExporter {
         // Metadata (instrument is now in Trip, not passed separately)
         builder.append(SurvexTherionUtil.getMetadata(survey, SYNTAX_MARKER, COMMENT_CHAR)).append("\n");
         
+        // Station comments data block
+        builder.append(SurvexTherionUtil.getStationCommentsData(survey, SYNTAX_MARKER));
+        
         // Centreline data
         builder.append(SurvexTherionUtil.getCentrelineData(survey, SYNTAX_MARKER, COMMENT_CHAR, true));
         

--- a/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/survex/SurvexExporter.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/survex/SurvexExporter.java
@@ -22,7 +22,7 @@ public class SurvexExporter extends SingleFileExporter {
         // Creation comment (no version info available without Context)
         builder.append(SurvexTherionUtil.getCreationComment(COMMENT_CHAR, "SexyTopo")).append("\n\n");
         
-        // Metadata (date, instrument, team, explo block)
+        // Metadata (instrument is now in Trip, not passed separately)
         builder.append(SurvexTherionUtil.getMetadata(survey, SYNTAX_MARKER, COMMENT_CHAR)).append("\n");
         
         // Centreline data

--- a/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/survex/SurvexImporter.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/survex/SurvexImporter.java
@@ -4,152 +4,36 @@ import android.content.Context;
 
 import androidx.documentfile.provider.DocumentFile;
 
-import org.hwyl.sexytopo.SexyTopoConstants;
-import org.hwyl.sexytopo.control.Log;
 import org.hwyl.sexytopo.control.io.IoUtils;
+import org.hwyl.sexytopo.control.io.thirdparty.survextherion.SurvexTherionImporter;
 import org.hwyl.sexytopo.control.io.translation.Importer;
-import org.hwyl.sexytopo.model.survey.Leg;
-import org.hwyl.sexytopo.model.survey.Station;
 import org.hwyl.sexytopo.model.survey.Survey;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 
 public class SurvexImporter extends Importer {
 
-    @SuppressWarnings("RegExpRedundantEscape") // can't be that redundant, as it crashes without it
-    public static final Pattern COMMENT_INSTRUCTION_REGEX = Pattern.compile("(\\{.*?\\})");
-
-
-    @Override
     public Survey toSurvey(Context context, DocumentFile file) throws Exception {
         Survey survey = new Survey();
         String text = IoUtils.slurpFile(context, file);
-        parse(text, survey);
+        
+        // Parse passage data first to extract station comments
+        Map<String, String> passageComments = SurvexTherionImporter.parsePassageData(text, true);
+        
+        // Parse centreline data
+        SurvexTherionImporter.parseCentreline(text, survey);
+        
+        // Merge passage comments with station comments
+        SurvexTherionImporter.mergePassageComments(survey, passageComments);
+        
         return survey;
-    }
-
-    public static void parse(String text, Survey survey) throws Exception {
-
-        Map<String, Station> nameToStation = new HashMap<>();
-
-        String[] lines = text.split("\n");
-        for (String line : lines) {
-
-            String trimmed = line.trim();
-            if (trimmed.equals("") || trimmed.startsWith(";") || trimmed.startsWith("*")) {
-                continue;
-            }
-
-            try {
-                String comment = "";
-                if (line.contains(";")) {
-                    comment = line.substring(line.indexOf(";") + 1).trim();
-                }
-
-                String[] fields = line.trim().split("\\s+");
-                addLegToSurvey(survey, nameToStation, fields, comment);
-
-            } catch (Exception exception) {
-                throw new Exception("Error importing this line: " + line);
-            }
-        }
-    }
-
-    private static void addLegToSurvey(
-            Survey survey, Map<String, Station> nameToStation, String[] fields, String comment) {
-
-        String fromName = fields[0];
-        String toName = fields[1];
-        float distance = Float.parseFloat(fields[2]);
-        float azimuth = Float.parseFloat(fields[3]);
-        float inclination = Float.parseFloat(fields[4]);
-
-        if (nameToStation.isEmpty()) {
-            Station origin = new Station(fromName);
-            survey.setOrigin(origin);
-            nameToStation.put(origin.getName(), origin);
-        }
-
-        String commentInstructions = extractCommentInstructions(comment);
-        if (commentInstructions != null) {
-            comment = comment.replace(commentInstructions, "").trim();
-        }
-
-        Station from = retrieveOrCreateStation(nameToStation, fromName, "");
-        Station to = retrieveOrCreateStation(nameToStation, toName, comment);
-
-        Leg[] promotedFrom = parseAnyPromotedLegs(commentInstructions);
-        Leg leg = (to == Survey.NULL_STATION)?
-                new Leg(distance, azimuth, inclination) :
-                new Leg(distance, azimuth, inclination, to, promotedFrom);
-
-        from.addOnwardLeg(leg);
-
-        // bit of a hack; hopefully the last station processed will be the active one
-        survey.setActiveStation(from);
-    }
-
-    private static Station retrieveOrCreateStation(Map<String, Station> nameToStation,
-                                                   String name, String comment) {
-        if (name.equals(SexyTopoConstants.BLANK_STATION_NAME)) {
-            return Survey.NULL_STATION;
-        } else if (nameToStation.containsKey(name)) {
-            return nameToStation.get(name);
-        } else {
-            Station station = new Station(name, comment);
-            nameToStation.put(name, station);
-            return station;
-        }
-    }
-
-    private static String extractCommentInstructions(String comment) {
-        Matcher matcher = COMMENT_INSTRUCTION_REGEX.matcher(comment);
-        String instructions = null;
-        if (matcher.find()) {
-            instructions = matcher.group(1);
-        }
-        return instructions;
-    }
-
-    public static Leg[] parseAnyPromotedLegs(String instructions) {
-        try {
-            List<Leg> legs = new ArrayList<>();
-
-            instructions = instructions.replace("{", "");
-            instructions = instructions.replace("}", "");
-            if (instructions.contains("from:")) {
-                instructions = instructions.replace("from:", "");
-            } else {
-                throw new Exception("Not an instruction we understand");
-            }
-
-            String[] legStrings = instructions.split(",");
-
-            for (String legString : legStrings) {
-                legString = legString.trim();
-                String[] fieldStrings = legString.split(" ");
-                float distance = Float.parseFloat(fieldStrings[0].trim());
-                float azimuth = Float.parseFloat(fieldStrings[1].trim());
-                float inclination = Float.parseFloat(fieldStrings[2].trim());
-                legs.add(new Leg(distance, azimuth, inclination));
-            }
-
-            return legs.toArray(new Leg[]{});
-        } catch (Exception exception) {
-            Log.e("Error parsing promoted leg (ignoring and carrying on): " + exception);
-            return new Leg[]{}; // seems to be corrupted... feature not mission-critical so bail
-        }
     }
 
 
     @Override
     public boolean canHandleFile(DocumentFile file) {
-        return file.isFile() && !file.isDirectory() && file.getName().endsWith("svx");
+        return file.getName().endsWith(".svx");
     }
+
 }

--- a/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/survex/SurvexImporter.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/survex/SurvexImporter.java
@@ -5,9 +5,11 @@ import android.content.Context;
 import androidx.documentfile.provider.DocumentFile;
 
 import org.hwyl.sexytopo.control.io.IoUtils;
+import org.hwyl.sexytopo.control.io.thirdparty.survextherion.SurveyFormat;
 import org.hwyl.sexytopo.control.io.thirdparty.survextherion.SurvexTherionImporter;
 import org.hwyl.sexytopo.control.io.translation.Importer;
 import org.hwyl.sexytopo.model.survey.Survey;
+import org.hwyl.sexytopo.model.survey.Trip;
 
 import java.util.Map;
 
@@ -19,14 +21,20 @@ public class SurvexImporter extends Importer {
         String text = IoUtils.slurpFile(context, file);
         
         // Parse passage data first to extract station comments
-        Map<String, String> passageComments = SurvexTherionImporter.parsePassageData(text, true);
+        Map<String, String> passageComments = SurvexTherionImporter.parsePassageData(text, SurveyFormat.SURVEX);
         
         // Parse centreline data
         SurvexTherionImporter.parseCentreline(text, survey);
         
         // Merge passage comments with station comments
         SurvexTherionImporter.mergePassageComments(survey, passageComments);
-        
+
+        // Parse trip metadata (date, instrument, team, etc.)
+        Trip trip = SurvexTherionImporter.parseMetadata(text, SurveyFormat.SURVEX);
+        if (trip != null) {
+            survey.setTrip(trip);
+        }
+
         return survey;
     }
 

--- a/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/survextherion/ExportFormat.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/survextherion/ExportFormat.java
@@ -1,6 +1,0 @@
-package org.hwyl.sexytopo.control.io.thirdparty.survextherion;
-
-public enum ExportFormat {
-    SURVEX,
-    THERION
-}

--- a/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/survextherion/ExportFormat.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/survextherion/ExportFormat.java
@@ -1,0 +1,6 @@
+package org.hwyl.sexytopo.control.io.thirdparty.survextherion;
+
+public enum ExportFormat {
+    SURVEX,
+    THERION
+}

--- a/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/survextherion/SurvexTherionImporter.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/survextherion/SurvexTherionImporter.java
@@ -376,7 +376,7 @@ public class SurvexTherionImporter {
 
         if (!rolesStr.isEmpty()) {
             for (String roleStr : rolesStr.split("\\s+")) {
-                Trip.Role role = parseRole(roleStr, format);
+                Trip.Role role = parseRole(roleStr);
                 if (role != null && !roles.contains(role)) {
                     roles.add(role);
                 }
@@ -385,7 +385,7 @@ public class SurvexTherionImporter {
     }
 
 
-    private static Trip.Role parseRole(String roleStr, SurveyFormat format) {
+    private static Trip.Role parseRole(String roleStr) {
         switch (roleStr.toLowerCase()) {
             case "notes":
                 return Trip.Role.BOOK;

--- a/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/survextherion/SurvexTherionImporter.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/survextherion/SurvexTherionImporter.java
@@ -25,13 +25,13 @@ public class SurvexTherionImporter {
 
     /**
      * Parse centreline data from Survex/Therion format.
-     * 
+     *
      * Handles:
      * - Forward and backward legs (detects based on station order)
      * - Promoted legs in inline{} format: {from: d1 a1 i1, d2 a2 i2, ...}
      * - Promoted legs in commented new lines format (below main leg)
      * - Both Survex (;) and Therion (#) comment styles
-     * 
+     *
      * @param text The centreline data text
      * @param survey The survey to populate
      * @throws Exception if parsing fails
@@ -152,12 +152,12 @@ public class SurvexTherionImporter {
 
     /**
      * Merge passage data comments with existing station comments.
-     * 
+     *
      * If a station has both a passage comment and a leg-line comment,
      * combine them with " :: " separator.
-     * 
+     *
      * Format: <passage comment> :: <leg-line comment>
-     * 
+     *
      * @param survey The survey with stations
      * @param passageComments Map of station name to passage comment
      */
@@ -237,7 +237,6 @@ public class SurvexTherionImporter {
         if (isBackward) {
             // This leg was shot backwards (from new station to existing station)
             // Store with swapped stations and wasShotBackwards = true
-            // IMPORTANT: Do NOT reverse the measurements - store original data!
             
             legFrom = to;
             legTo = from;
@@ -254,7 +253,7 @@ public class SurvexTherionImporter {
                 from.setComment(comment);
             }
         } else {
-            // Normal forward leg
+            // Forward leg
             legFrom = from;
             legTo = to;
             
@@ -303,7 +302,7 @@ public class SurvexTherionImporter {
 
     /**
      * Parse promoted legs from commented new lines format.
-     * 
+     *
      * These are shots on commented lines that come AFTER the main leg line.
      * 
      * Example:
@@ -320,7 +319,7 @@ public class SurvexTherionImporter {
         for (int i = startIndex + 1; i < lines.length; i++) {
             String line = lines[i].trim();
             
-            // Stop if we hit a non-comment line or empty line
+            // Stop if a non-comment line or empty line
             if (line.isEmpty() || (!line.startsWith("#") && !line.startsWith(";"))) {
                 break;
             }

--- a/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/survextherion/SurvexTherionImporter.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/survextherion/SurvexTherionImporter.java
@@ -1,0 +1,449 @@
+package org.hwyl.sexytopo.control.io.thirdparty.survextherion;
+
+import org.hwyl.sexytopo.SexyTopoConstants;
+import org.hwyl.sexytopo.control.Log;
+import org.hwyl.sexytopo.model.survey.Leg;
+import org.hwyl.sexytopo.model.survey.Station;
+import org.hwyl.sexytopo.model.survey.Survey;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+
+/**
+ * Shared importer for Survex and Therion data.
+ */
+public class SurvexTherionImporter {
+
+    @SuppressWarnings("RegExpRedundantEscape") // can't be that redundant, as it crashes without it
+    public static final Pattern COMMENT_INSTRUCTION_REGEX = Pattern.compile("(\\{.*?\\})");
+
+
+    /**
+     * Parse centreline data from Survex/Therion format.
+     * 
+     * Handles:
+     * - Forward and backward legs (detects based on station order)
+     * - Promoted legs in inline{} format: {from: d1 a1 i1, d2 a2 i2, ...}
+     * - Promoted legs in commented new lines format (below main leg)
+     * - Both Survex (;) and Therion (#) comment styles
+     * 
+     * @param text The centreline data text
+     * @param survey The survey to populate
+     * @throws Exception if parsing fails
+     */
+    public static void parseCentreline(String text, Survey survey) throws Exception {
+
+        Map<String, Station> nameToStation = new HashMap<>();
+
+        String[] lines = text.split("\n");
+        for (int lineIndex = 0; lineIndex < lines.length; lineIndex++) {
+            String line = lines[lineIndex];
+
+            String trimmed = line.trim();
+            if (trimmed.equals("") || trimmed.startsWith("*")) {
+                continue;
+            }
+
+            // Skip pure comment lines (but not lines with data and comments)
+            if (trimmed.startsWith(";") || trimmed.startsWith("#")) {
+                // Don't skip if it looks like commented new lines promoted leg
+                String[] parts = trimmed.substring(1).trim().split("\\s+");
+                if (parts.length < 5) {
+                    continue; // Just a comment, skip it
+                }
+                // Might be commented new lines promoted leg, let it fall through
+                continue;
+            }
+
+            try {
+                // Extract comment - support both ; (Survex) and # (Therion)
+                String comment = extractCommentFromLine(line);
+
+                String[] fields = line.trim().split("\\s+");
+                
+                // Check for commented new lines promoted legs in subsequent lines
+                List<Leg> commentedNewLineLegs = parseCommentedNewLinePromotedLegs(
+                    lines, lineIndex, fields[0], fields[1]);
+                
+                addLegToSurvey(survey, nameToStation, fields, comment, commentedNewLineLegs);
+
+            } catch (Exception exception) {
+                throw new Exception("Error importing this line: " + line);
+            }
+        }
+    }
+
+
+    /**
+     * Parse passage data section to extract station comments.
+     * 
+     * Supports both formats:
+     * - Therion: "data passage station ignoreall"
+     * - Survex:  "*data passage station ignoreall"
+     * 
+     * @param text The full file text (may contain multiple sections)
+     * @param isSurvex true if parsing Survex format (uses *), false for Therion
+     * @return Map of station name to passage comment
+     */
+    public static Map<String, String> parsePassageData(String text, boolean isSurvex) {
+        Map<String, String> passageComments = new HashMap<>();
+        
+        String[] lines = text.split("\n");
+        boolean inPassageBlock = false;
+        
+        for (String line : lines) {
+            String trimmed = line.trim();
+            
+            if (trimmed.isEmpty()) {
+                continue;
+            }
+            
+            // Check if entering passage data block
+            // Therion: "data passage"
+            // Survex:  "*data passage"
+            String dataPassagePrefix = isSurvex ? "*data passage" : "data passage";
+            String dataNormalPrefix = isSurvex ? "*data normal" : "data normal";
+            
+            if (trimmed.startsWith(dataPassagePrefix)) {
+                inPassageBlock = true;
+                continue;
+            }
+            
+            // Check if exiting passage data block (entering a different data block)
+            if (inPassageBlock && trimmed.startsWith(dataNormalPrefix)) {
+                inPassageBlock = false;
+                continue;
+            }
+            
+            // Also exit if we hit another *data command in Survex
+            if (isSurvex && inPassageBlock && trimmed.startsWith("*data ") 
+                && !trimmed.startsWith(dataPassagePrefix)) {
+                inPassageBlock = false;
+                continue;
+            }
+            
+            // If in passage block, parse station and comment
+            if (inPassageBlock) {
+                // Skip comment lines and command lines
+                if (trimmed.startsWith(";") || trimmed.startsWith("#") || 
+                    trimmed.startsWith("*") || trimmed.startsWith("extend")) {
+                    continue;
+                }
+                
+                // Parse: <station> <comment text>
+                // Station name is first token, rest is comment
+                String[] parts = trimmed.split("\\s+", 2);
+                if (parts.length == 2) {
+                    String stationName = parts[0];
+                    String comment = parts[1].trim();
+                    passageComments.put(stationName, comment);
+                }
+            }
+        }
+        
+        return passageComments;
+    }
+
+
+    /**
+     * Merge passage data comments with existing station comments.
+     * 
+     * If a station has both a passage comment and a leg-line comment,
+     * combine them with " :: " separator.
+     * 
+     * Format: <passage comment> :: <leg-line comment>
+     * 
+     * @param survey The survey with stations
+     * @param passageComments Map of station name to passage comment
+     */
+    public static void mergePassageComments(Survey survey, Map<String, String> passageComments) {
+        for (Map.Entry<String, String> entry : passageComments.entrySet()) {
+            String stationName = entry.getKey();
+            String passageComment = entry.getValue();
+            
+            try {
+                Station station = survey.getStationByName(stationName);
+                if (station != null) {
+                    String existingComment = station.getComment();
+                    
+                    if (existingComment == null || existingComment.trim().isEmpty()) {
+                        // No existing comment, just use passage comment
+                        station.setComment(passageComment);
+                    } else {
+                        // Both exist, combine with " :: " separator
+                        // Format: passage comment :: leg-line comment
+                        String combinedComment = passageComment + " :: " + existingComment;
+                        station.setComment(combinedComment);
+                    }
+                }
+            } catch (Exception e) {
+                Log.e("Failed to merge passage comment for station " + stationName + ": " + e);
+            }
+        }
+    }
+
+
+    private static void addLegToSurvey(
+            Survey survey, Map<String, Station> nameToStation, String[] fields, 
+            String comment, List<Leg> commentedNewLineLegs) {
+
+        String fromName = fields[0];
+        String toName = fields[1];
+        float distance = Float.parseFloat(fields[2]);
+        float azimuth = Float.parseFloat(fields[3]);
+        float inclination = Float.parseFloat(fields[4]);
+
+        if (nameToStation.isEmpty()) {
+            Station origin = new Station(fromName);
+            survey.setOrigin(origin);
+            nameToStation.put(fromName, origin);
+        }
+
+        Station from = nameToStation.get(fromName);
+        if (from == null) {
+            from = new Station(fromName);
+            nameToStation.put(fromName, from);
+        }
+
+        Station to = Survey.NULL_STATION;
+        if (!toName.equals(SexyTopoConstants.BLANK_STATION_NAME)) {
+            to = nameToStation.get(toName);
+            if (to == null) {
+                to = new Station(toName);
+                nameToStation.put(toName, to);
+            }
+        }
+
+        // Extract promoted legs from inline{} comment
+        String commentInstructions = extractCommentInstructions(comment);
+        Leg[] promotedFrom = parseInlinePromotedLegs(commentInstructions);
+        
+        // If no inline{} promoted legs, use commented new lines if available
+        if (promotedFrom.length == 0 && !commentedNewLineLegs.isEmpty()) {
+            promotedFrom = commentedNewLineLegs.toArray(new Leg[0]);
+        }
+
+        // Detect if this is a backward leg
+        boolean isBackward = isBackwardLeg(fromName, toName, nameToStation);
+
+        Leg leg;
+        Station legFrom, legTo;
+
+        if (isBackward) {
+            // This leg was shot backwards (from new station to existing station)
+            // Store with swapped stations and wasShotBackwards = true
+            // IMPORTANT: Do NOT reverse the measurements - store original data!
+            
+            legFrom = to;
+            legTo = from;
+            
+            // Create leg with original measurements and wasShotBackwards = true
+            if (legTo == Survey.NULL_STATION) {
+                leg = new Leg(distance, azimuth, inclination, true);
+            } else {
+                leg = new Leg(distance, azimuth, inclination, legTo, promotedFrom, true);
+            }
+            
+            // Station comment goes on the TO station (the new one in the file)
+            if (!comment.isEmpty() && from != Survey.NULL_STATION) {
+                from.setComment(comment);
+            }
+        } else {
+            // Normal forward leg
+            legFrom = from;
+            legTo = to;
+            
+            if (to == Survey.NULL_STATION) {
+                leg = new Leg(distance, azimuth, inclination);
+            } else {
+                leg = new Leg(distance, azimuth, inclination, to, promotedFrom);
+            }
+            
+            // Station comment goes on the TO station
+            if (!comment.isEmpty() && to != Survey.NULL_STATION) {
+                to.setComment(comment);
+            }
+        }
+
+        legFrom.addOnwardLeg(leg);
+        survey.setActiveStation(legFrom);
+    }
+
+
+    /**
+     * Detect if a leg was shot backwards.
+     * 
+     * A leg is backward if the FROM station is new (not seen before).
+     * Detection is based on POSITION (from/to), not station names/numbers.
+     */
+    private static boolean isBackwardLeg(String fromName, String toName, 
+                                        Map<String, Station> seenStations) {
+        boolean fromIsNew = !seenStations.containsKey(fromName);
+        boolean toIsNew = !seenStations.containsKey(toName);
+        
+        if (fromIsNew && toIsNew) {
+            // Both new - shouldn't happen in valid survey, assume forward
+            return false;
+        }
+        
+        if (!fromIsNew && !toIsNew) {
+            // Both exist - this is a loop/connection, assume forward
+            return false;
+        }
+        
+        // Backward if FROM position has the new station
+        return fromIsNew;
+    }
+
+
+    /**
+     * Parse promoted legs from commented new lines format.
+     * 
+     * These are shots on commented lines that come AFTER the main leg line.
+     * 
+     * Example:
+     * 1  2  5.541  253.93  4.67
+     * #1 2  5.542  73.95   -4.64
+     * #1 2  5.541  73.93   -4.69
+     */
+    private static List<Leg> parseCommentedNewLinePromotedLegs(
+            String[] lines, int startIndex, String expectedFrom, String expectedTo) {
+        
+        List<Leg> shots = new ArrayList<>();
+        
+        // Look at subsequent lines
+        for (int i = startIndex + 1; i < lines.length; i++) {
+            String line = lines[i].trim();
+            
+            // Stop if we hit a non-comment line or empty line
+            if (line.isEmpty() || (!line.startsWith("#") && !line.startsWith(";"))) {
+                break;
+            }
+            
+            // Remove the comment character and parse
+            String content = line.substring(1).trim();
+            String[] fields = content.split("\\s+");
+            
+            // Check if this is a matching shot
+            if (fields.length >= 5 && 
+                fields[0].equals(expectedFrom) && 
+                fields[1].equals(expectedTo)) {
+                
+                try {
+                    float distance = Float.parseFloat(fields[2]);
+                    float azimuth = Float.parseFloat(fields[3]);
+                    float inclination = Float.parseFloat(fields[4]);
+                    shots.add(new Leg(distance, azimuth, inclination));
+                } catch (NumberFormatException e) {
+                    Log.e("Failed to parse commented new line promoted leg: " + line);
+                }
+            } else {
+                // Different leg, stop looking
+                break;
+            }
+        }
+        
+        return shots;
+    }
+
+
+    private static String extractCommentInstructions(String comment) {
+        Matcher matcher = COMMENT_INSTRUCTION_REGEX.matcher(comment);
+        if (matcher.find()) {
+            return matcher.group(1);
+        } else {
+            return "";
+        }
+    }
+
+
+    private static String extractCommentFromLine(String line) {
+        String comment = "";
+        
+        // Try semicolon first (Survex style)
+        if (line.contains(";")) {
+            comment = line.substring(line.indexOf(";") + 1).trim();
+        } 
+        // Try hash (Therion style)
+        else if (line.contains("#")) {
+            comment = line.substring(line.indexOf("#") + 1).trim();
+        }
+        
+        return comment;
+    }
+
+
+    /**
+     * Parse promoted legs from inline{} format.
+     * 
+     * Example: {from: 5.542 73.95 -4.64, 5.541 73.93 -4.69, 5.541 73.92 -4.67}
+     */
+    private static Leg[] parseInlinePromotedLegs(String commentInstructions) {
+        try {
+            return parse(commentInstructions);
+        } catch (Exception exception) {
+            Log.e(exception);
+            return new Leg[]{};
+        }
+    }
+
+
+    private static Leg[] parse(String instructions) throws Exception {
+
+        if (instructions.equals("")) {
+            return new Leg[]{};
+        }
+
+        instructions = instructions
+                .replaceFirst("\\{", "")
+                .replaceFirst("\\}", "")
+                .trim();
+
+        String[] components = instructions.split(":", 2);
+        if (components.length < 2) {
+            throw new Exception("Cannot parse instructions");
+        }
+        String tag = components[0];
+        String content = components[1];
+        List<Leg> legs;
+        if (tag.equals("from")) {
+            legs = parseFrom(content);
+        } else if (tag.equals("backsight")) {
+            legs = parseFrom(content);
+        } else {
+            throw new Exception("Unknown tag: " + tag);
+        }
+
+        return legs.toArray(new Leg[]{});
+    }
+
+
+    private static List<Leg> parseFrom(String text) throws Exception {
+        List<Leg> legs = new ArrayList<>();
+        String[] shotTexts = text.trim().split(",");
+        for (String shotText : shotTexts) {
+            Leg leg = parseLeg(shotText);
+            legs.add(leg);
+        }
+        return legs;
+    }
+
+
+    private static Leg parseLeg(String text) throws Exception {
+        String[] fields = text.trim().split("\\s+");
+        if (fields.length != 3) {
+            throw new Exception("Expected 3 fields but received " + fields.length);
+        }
+        float distance = Float.parseFloat(fields[0]);
+        float azimuth = Float.parseFloat(fields[1]);
+        float inclination = Float.parseFloat(fields[2]);
+
+        return new Leg(distance, azimuth, inclination);
+    }
+
+}

--- a/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/survextherion/SurvexTherionUtil.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/survextherion/SurvexTherionUtil.java
@@ -72,14 +72,21 @@ public class SurvexTherionUtil {
             builder.append("\n");
             
             // Exploration date handling:
-            // Output ACTUAL date ONLY if:
-            //   - "same as survey" checkbox is NOT ticked AND
-            //   - exploration date is provided
-            // Otherwise output commented placeholder
+            // - If "same as survey" is ticked: use survey date as exploration date
+            // - If "same as survey" NOT ticked AND exploration date provided: use exploration date
+            // - If "same as survey" NOT ticked AND no date provided: commented placeholder
             boolean sameAsSurvey = trip.isExplorationDateSameAsSurvey();
             Date exploDate = trip.getExplorationDate();
             
-            if (!sameAsSurvey && exploDate != null) {
+            if (sameAsSurvey) {
+                // Use survey date as exploration date
+                String formattedDate = formatDate(trip.getDate()).substring(5); // Remove "date " prefix
+                if (isSurvex) {
+                    builder.append(marker).append("date explored ").append(formattedDate).append("\n");
+                } else {
+                    builder.append("explo-date ").append(formattedDate).append("\n");
+                }
+            } else if (exploDate != null) {
                 // User has unchecked "same as survey" AND provided a specific date
                 String formattedExploDate = formatDate(exploDate).substring(5); // Remove "date " prefix
                 if (isSurvex) {
@@ -88,8 +95,7 @@ public class SurvexTherionUtil {
                     builder.append("explo-date ").append(formattedExploDate).append("\n");
                 }
             } else {
-                // Either "same as survey" is ticked, or no specific date provided
-                // Output commented placeholder
+                // No specific date provided - output commented placeholder
                 if (isSurvex) {
                     builder.append(commentChar).append("*date explored yyyy.mm.dd\n");
                 } else {

--- a/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/survextherion/SurvexTherionUtil.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/survextherion/SurvexTherionUtil.java
@@ -38,13 +38,13 @@ public class SurvexTherionUtil {
         return builder.toString();
     }
 
-    public static String getMetadata(Survey survey, char commentChar, ExportFormat format) {
+    public static String getMetadata(Survey survey, char commentChar, SurveyFormat format) {
         StringBuilder builder = new StringBuilder();
 
         Trip trip = survey.getTrip();
         if (trip != null) {
-            String marker = (format == ExportFormat.SURVEX) ? "*" : "";
-            boolean isSurvex = (format == ExportFormat.SURVEX);
+            String marker = (format == SurveyFormat.SURVEX) ? "*" : "";
+            boolean isSurvex = (format == SurveyFormat.SURVEX);
 
             // Date
             builder.append(marker).append(formatDate(trip.getDate())).append("\n");
@@ -135,10 +135,10 @@ public class SurvexTherionUtil {
         return entry.roles.size() == 1 && entry.roles.contains(Trip.Role.EXPLORATION);
     }
 
-    public static String getStationCommentsData(Survey survey, ExportFormat format) {
+    public static String getStationCommentsData(Survey survey, SurveyFormat format) {
 
         StringBuilder builder = new StringBuilder();
-        String marker = (format == ExportFormat.SURVEX) ? "*" : "";
+        String marker = (format == SurveyFormat.SURVEX) ? "*" : "";
 
         // Collect all stations with comments
         List<Station> stationsWithComments = new ArrayList<>();
@@ -174,13 +174,13 @@ public class SurvexTherionUtil {
     public static String getCentrelineData(
             Survey survey,
             char commentChar,
-            ExportFormat format) {
+            SurveyFormat format) {
 
         GraphToListTranslator graphToListTranslator = new GraphToListTranslator();
         StringBuilder builder = new StringBuilder();
 
         // Add data declaration line with optional syntax marker
-        String marker = (format == ExportFormat.SURVEX) ? "*" : "";
+        String marker = (format == SurveyFormat.SURVEX) ? "*" : "";
         builder.append(marker).append("data normal from to tape compass clino ignoreall\n");
 
         // Get chronological list of survey entries
@@ -199,8 +199,8 @@ public class SurvexTherionUtil {
         return builder.toString();
     }
 
-    private static String formatMember(Trip.TeamEntry member, ExportFormat format) {
-        boolean isSurvex = (format == ExportFormat.SURVEX);
+    private static String formatMember(Trip.TeamEntry member, SurveyFormat format) {
+        boolean isSurvex = (format == SurveyFormat.SURVEX);
         // For Therion, skip team members who only have EXPLORATION role
         if (!isSurvex && hasOnlyExplorerRole(member)) {
             return null;
@@ -218,7 +218,7 @@ public class SurvexTherionUtil {
         return TextUtils.join(" ", fields);
     }
 
-    private static String getRoleDescription(Trip.Role role, ExportFormat format) {
+    private static String getRoleDescription(Trip.Role role, SurveyFormat format) {
         switch(role) {
             case BOOK:
                 return "notes";
@@ -226,7 +226,7 @@ public class SurvexTherionUtil {
                 return "instruments";
             case EXPLORATION:
                 // Survex can use "explorer", Therion cannot (uses explo-team separately)
-                return (format == ExportFormat.SURVEX) ? "explorer" : null;
+                return (format == SurveyFormat.SURVEX) ? "explorer" : null;
             case DOG:
             default:
                 return "assistant";
@@ -253,7 +253,7 @@ public class SurvexTherionUtil {
             StringBuilder builder,
             GraphToListTranslator.SurveyListEntry entry,
             char commentChar,
-            ExportFormat format) {
+            SurveyFormat format) {
 
         Station from = entry.getFrom();
         String fromName = from.getName();
@@ -263,7 +263,7 @@ public class SurvexTherionUtil {
         String toName = to.getName();
 
         // Replace "-" with ".." for Survex splay syntax
-        if (format == ExportFormat.SURVEX && toName.equals("-")) {
+        if (format == SurveyFormat.SURVEX && toName.equals("-")) {
             toName = "..";
         }
 
@@ -298,9 +298,9 @@ public class SurvexTherionUtil {
         builder.append(formatted);
     }
 
-    public static String getExtendedElevationExtensions(Survey survey, ExportFormat format) {
+    public static String getExtendedElevationExtensions(Survey survey, SurveyFormat format) {
         StringBuilder builder = new StringBuilder();
-        String marker = (format == ExportFormat.SURVEX) ? "*" : "";
+        String marker = (format == SurveyFormat.SURVEX) ? "*" : "";
         generateExtendCommandsFromStation(builder, survey.getOrigin(), null, marker);
         return builder.toString();
     }

--- a/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/survextherion/SurvexTherionUtil.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/survextherion/SurvexTherionUtil.java
@@ -1,20 +1,193 @@
 package org.hwyl.sexytopo.control.io.thirdparty.survextherion;
 
+import android.annotation.SuppressLint;
+import android.text.TextUtils;
+
 import org.hwyl.sexytopo.control.util.GraphToListTranslator;
+import org.hwyl.sexytopo.model.graph.Direction;
 import org.hwyl.sexytopo.model.survey.Leg;
 import org.hwyl.sexytopo.model.survey.Station;
+import org.hwyl.sexytopo.model.survey.Survey;
+import org.hwyl.sexytopo.model.survey.Trip;
 import org.hwyl.sexytopo.model.table.TableCol;
 
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
 import java.util.Locale;
 
 
 public class SurvexTherionUtil {
 
+    public static final String TRIP_DATE_PATTERN = "yyyy.MM.dd";
+
+    public static String getCreationComment(char commentChar, String versionInfo) {
+        String dateOnly = new SimpleDateFormat("yyyy-MM-dd").format(new Date());
+        return commentChar + " Created with " + versionInfo + " on " + dateOnly;
+    }
+
+    public static String getInputText(List<String> th2Files) {
+        if (th2Files == null || th2Files.isEmpty()) {
+            return "";
+        }
+        StringBuilder builder = new StringBuilder();
+        for (String filename : th2Files) {
+            builder.append("input \"").append(filename).append("\"\n");
+        }
+        return builder.toString();
+    }
+
+    public static String getMetadata(Survey survey, String syntaxMarker, char commentChar) {
+        StringBuilder builder = new StringBuilder();
+        
+        Trip trip = survey.getTrip();
+        if (trip != null) {
+            String marker = (syntaxMarker != null) ? syntaxMarker : "";
+            boolean isSurvex = (syntaxMarker != null);
+            
+            // Date
+            builder.append(marker).append(formatDate(trip.getDate())).append("\n");
+            
+            // Instrument line (commented out)
+            builder.append(commentChar).append(marker).append("instrument inst \"\"\n");
+            
+            // Team members (only include if they have roles other than just EXPLORATION for TH)
+            for (Trip.TeamEntry entry : trip.getTeam()) {
+                String teamLine = formatMember(entry, isSurvex);
+                if (teamLine != null) {
+                    builder.append(marker).append(teamLine).append("\n");
+                }
+            }
+            
+            // Blank line before explo block
+            builder.append("\n");
+            
+            // Exploration date comment
+            if (isSurvex) {
+                builder.append(commentChar).append("*date explored yyyy.mm.dd\n");
+            } else {
+                builder.append(commentChar).append("explo-date yyyy.mm.dd\n");
+            }
+            
+            // Explo-team lines for Therion (not commented)
+            if (!isSurvex) {
+                for (Trip.TeamEntry entry : trip.getTeam()) {
+                    if (hasExplorerRole(entry)) {
+                        builder.append("explo-team \"").append(entry.name).append("\"\n");
+                    }
+                }
+            }
+            
+            // Trip comments block if any
+            if (!trip.getComments().isEmpty()) {
+                builder.append("\n");
+                builder.append(commentChar).append("Comment from SexyTopo trip information\n");
+                builder.append(commentMultiline(trip.getComments(), commentChar));
+            }
+        }
+        
+        return builder.toString();
+    }
+
+    private static boolean hasExplorerRole(Trip.TeamEntry entry) {
+        for (Trip.Role role : entry.roles) {
+            if (role == Trip.Role.EXPLORATION) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean hasOnlyExplorerRole(Trip.TeamEntry entry) {
+        return entry.roles.size() == 1 && entry.roles.contains(Trip.Role.EXPLORATION);
+    }
+
+    public static String getCentrelineData(
+            Survey survey, 
+            String syntaxMarker, 
+            char commentChar,
+            boolean useSurvexStationSyntax) {
+        
+        GraphToListTranslator graphToListTranslator = new GraphToListTranslator();
+        StringBuilder builder = new StringBuilder();
+        
+        // Add data declaration line with optional syntax marker
+        String marker = (syntaxMarker != null) ? syntaxMarker : "";
+        builder.append(marker).append("data normal from to tape compass clino ignoreall\n");
+        
+        // Get chronological list of survey entries
+        List<GraphToListTranslator.SurveyListEntry> list =
+                graphToListTranslator.toChronoListOfSurveyListEntries(survey);
+        
+        // Format each entry
+        for (GraphToListTranslator.SurveyListEntry entry : list) {
+            formatEntry(builder, entry, commentChar, useSurvexStationSyntax);
+            builder.append("\n");
+        }
+        
+        // Blank line after data block
+        builder.append("\n");
+        
+        return builder.toString();
+    }
+
+    private static String formatMember(Trip.TeamEntry member, boolean isSurvex) {
+        // For Therion, skip team members who only have EXPLORATION role
+        if (!isSurvex && hasOnlyExplorerRole(member)) {
+            return null;
+        }
+        
+        List<String> fields = new ArrayList<>();
+        fields.add("team");
+        fields.add("\"" + member.name + "\"");
+        for (Trip.Role role : member.roles) {
+            String roleDesc = getRoleDescription(role, isSurvex);
+            if (roleDesc != null) {
+                fields.add(roleDesc);
+            }
+        }
+        return TextUtils.join(" ", fields);
+    }
+
+    private static String getRoleDescription(Trip.Role role, boolean isSurvex) {
+        switch(role) {
+            case BOOK:
+                return "notes";
+            case INSTRUMENTS:
+                return "instruments";
+            case EXPLORATION:
+                // Survex can use "explorer", Therion cannot (uses explo-team separately)
+                return isSurvex ? "explorer" : null;
+            case DOG:
+            default:
+                return "assistant";
+        }
+    }
+
+    @SuppressLint("SimpleDateFormat")
+    private static String formatDate(Date date) {
+        DateFormat dateFormat = new SimpleDateFormat(TRIP_DATE_PATTERN);
+        String dateString = dateFormat.format(date);
+        return "date " + dateString;
+    }
+
+    private static String commentMultiline(String raw, char commentChar) {
+        StringBuilder builder = new StringBuilder();
+        String[] lines = raw.split("\n");
+        for (String line : lines) {
+            builder.append(commentChar).append(line).append("\n");
+        }
+        return builder.toString();
+    }
+
 
     public static void formatEntry(
             StringBuilder builder,
             GraphToListTranslator.SurveyListEntry entry,
-            char commentChar) {
+            char commentChar,
+            boolean useSurvexStationSyntax) {
 
         Station from = entry.getFrom();
         String fromName = from.getName();
@@ -23,10 +196,9 @@ public class SurvexTherionUtil {
         Station to = leg.getDestination();
         String toName = to.getName();
 
-        if (leg.wasShotBackwards()) {
-            leg = leg.reverse();
-            fromName = to.getName();
-            toName = from.getName();
+        // Replace "-" with ".." for Survex splay syntax
+        if (useSurvexStationSyntax && toName.equals("-")) {
+            toName = "..";
         }
 
         formatField(builder, fromName);
@@ -35,41 +207,26 @@ public class SurvexTherionUtil {
         formatField(builder, TableCol.AZIMUTH.format(leg.getAzimuth(), Locale.UK));
         formatField(builder, TableCol.INCLINATION.format(leg.getInclination(), Locale.UK));
 
-        if (leg.wasPromoted() || to.hasComment()) {
+        // Add comment for station comment
+        if (to.hasComment()) {
             builder.append("\t").append(commentChar).append(" ");
-            if (leg.wasPromoted()) {
-                builder.append(" ");
-                formatPromotedFrom(builder, leg.getPromotedFrom());
-            }
-            if (to.hasComment()) {
-                builder.append(" ");
-                formatComment(builder, to.getComment());
-
+            formatComment(builder, to.getComment());
+        }
+        
+        // Handle promoted legs - put readings on subsequent lines
+        if (leg.wasPromoted()) {
+            Leg[] precursors = leg.getPromotedFrom();
+            for (Leg precursor : precursors) {
+                builder.append("\n");
+                builder.append(commentChar);
+                builder.append(fromName).append("\t");
+                builder.append(toName).append("\t");
+                builder.append(TableCol.DISTANCE.format(precursor.getDistance(), Locale.UK)).append("\t");
+                builder.append(TableCol.AZIMUTH.format(precursor.getAzimuth(), Locale.UK)).append("\t");
+                builder.append(TableCol.INCLINATION.format(precursor.getInclination(), Locale.UK));
             }
         }
-
-
     }
-
-    private static void formatPromotedFrom(StringBuilder builder, Leg[] precursors) {
-        builder.append("{from: ");
-        boolean first = true;
-        for (Leg precursor : precursors) {
-            if (first) {
-                first = false;
-            } else {
-                builder.append(", ");
-            }
-            builder.append(TableCol.DISTANCE.format(precursor.getDistance(), Locale.UK));
-            builder.append(" ");
-            builder.append(TableCol.AZIMUTH.format(precursor.getAzimuth(), Locale.UK));
-            builder.append(" ");
-            builder.append(TableCol.INCLINATION.format(precursor.getInclination(), Locale.UK));
-        }
-        builder.append("}");
-    }
-
-
 
     private static void formatField(StringBuilder builder, Object value) {
         builder.append(value.toString());
@@ -79,5 +236,32 @@ public class SurvexTherionUtil {
     private static void formatComment(StringBuilder builder, String comment) {
         String formatted = comment.replaceAll("(\\r|\\n|\\r\\n)+", "\\\\n");
         builder.append(formatted);
+    }
+    
+    public static String getExtendedElevationExtensions(Survey survey, String syntaxMarker) {
+        StringBuilder builder = new StringBuilder();
+        String marker = (syntaxMarker != null) ? syntaxMarker : "";
+        generateExtendCommandsFromStation(builder, survey.getOrigin(), null, marker);
+        return builder.toString();
+    }
+
+    private static void generateExtendCommandsFromStation(
+            StringBuilder builder, Station station, Direction lastDirection, String marker) {
+
+        Direction currentDirection = station.getExtendedElevationDirection();
+        if (lastDirection == null) {
+            builder.append(getExtendCommand(station, "start", marker));
+        } else if (currentDirection != lastDirection) {
+            builder.append(getExtendCommand(station, currentDirection.name().toLowerCase(), marker));
+        }
+
+        for (Leg leg : station.getConnectedOnwardLegs()) {
+            generateExtendCommandsFromStation(
+                    builder, leg.getDestination(), station.getExtendedElevationDirection(), marker);
+        }
+    }
+
+    private static String getExtendCommand(Station station, String direction, String marker) {
+        return marker + "extend " + direction + " " + station.getName() + "\n";
     }
 }

--- a/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/survextherion/SurveyFormat.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/survextherion/SurveyFormat.java
@@ -1,6 +1,6 @@
 package org.hwyl.sexytopo.control.io.thirdparty.survextherion;
 
-public enum ExportFormat {
+public enum SurveyFormat {
     SURVEX,
     THERION
 }

--- a/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/therion/ThExporter.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/therion/ThExporter.java
@@ -4,6 +4,7 @@ import android.content.Context;
 
 import org.hwyl.sexytopo.SexyTopoConstants;
 import org.hwyl.sexytopo.control.activity.SexyTopoActivity;
+import org.hwyl.sexytopo.control.io.thirdparty.survextherion.ExportFormat;
 import org.hwyl.sexytopo.control.io.thirdparty.survextherion.SurvexTherionUtil;
 import org.hwyl.sexytopo.model.survey.Survey;
 
@@ -29,12 +30,12 @@ public class ThExporter {
         builder.append(SurvexTherionUtil.getInputText(th2Files)).append("\n\n");
         
         // Metadata (date, instrument, team, explo block)
-        builder.append(SurvexTherionUtil.getMetadata(survey, null, TherionExporter.COMMENT_CHAR)).append("\n");
+        builder.append(SurvexTherionUtil.getMetadata(survey, TherionExporter.COMMENT_CHAR, ExportFormat.THERION)).append("\n");
         
         // Centreline block
         builder.append("centreline\n");
-        builder.append(SurvexTherionUtil.getCentrelineData(survey, null, TherionExporter.COMMENT_CHAR, false));
-        builder.append(SurvexTherionUtil.getExtendedElevationExtensions(survey, null));
+        builder.append(SurvexTherionUtil.getCentrelineData(survey, TherionExporter.COMMENT_CHAR, ExportFormat.THERION));
+        builder.append(SurvexTherionUtil.getExtendedElevationExtensions(survey, ExportFormat.THERION));
         builder.append("endcentreline\n");
         
         // End survey
@@ -49,8 +50,8 @@ public class ThExporter {
         // Replace centreline block
         String centrelineText = 
             "centreline\n" +
-            SurvexTherionUtil.getCentrelineData(survey, null, TherionExporter.COMMENT_CHAR, false) +
-            SurvexTherionUtil.getExtendedElevationExtensions(survey, null) +
+            SurvexTherionUtil.getCentrelineData(survey, TherionExporter.COMMENT_CHAR, ExportFormat.THERION) +
+            SurvexTherionUtil.getExtendedElevationExtensions(survey, ExportFormat.THERION) +
             "endcentreline\n";
         String newContent = replaceCentreline(originalFileContent, centrelineText);
 

--- a/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/therion/ThExporter.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/therion/ThExporter.java
@@ -28,7 +28,7 @@ public class ThExporter {
         // Input files
         builder.append(SurvexTherionUtil.getInputText(th2Files)).append("\n\n");
         
-        // Metadata (date, instrument, team, explo block)
+        // Metadata (instrument is now in Trip, not passed separately)
         builder.append(SurvexTherionUtil.getMetadata(survey, null, TherionExporter.COMMENT_CHAR)).append("\n");
         
         // Centreline block

--- a/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/therion/ThExporter.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/therion/ThExporter.java
@@ -4,7 +4,7 @@ import android.content.Context;
 
 import org.hwyl.sexytopo.SexyTopoConstants;
 import org.hwyl.sexytopo.control.activity.SexyTopoActivity;
-import org.hwyl.sexytopo.control.io.thirdparty.survextherion.ExportFormat;
+import org.hwyl.sexytopo.control.io.thirdparty.survextherion.SurveyFormat;
 import org.hwyl.sexytopo.control.io.thirdparty.survextherion.SurvexTherionUtil;
 import org.hwyl.sexytopo.model.survey.Survey;
 
@@ -29,13 +29,13 @@ public class ThExporter {
         builder.append(SurvexTherionUtil.getInputText(th2Files)).append("\n\n");
 
         // Metadata (instrument is now in Trip, not passed separately)
-        builder.append(SurvexTherionUtil.getMetadata(survey, TherionExporter.COMMENT_CHAR, ExportFormat.THERION)).append("\n");
+        builder.append(SurvexTherionUtil.getMetadata(survey, TherionExporter.COMMENT_CHAR, SurveyFormat.THERION)).append("\n");
 
         // Centreline block
         builder.append("centreline\n");
-        builder.append(SurvexTherionUtil.getStationCommentsData(survey, ExportFormat.THERION));
-        builder.append(SurvexTherionUtil.getCentrelineData(survey, TherionExporter.COMMENT_CHAR, ExportFormat.THERION));
-        builder.append(SurvexTherionUtil.getExtendedElevationExtensions(survey, ExportFormat.THERION));
+        builder.append(SurvexTherionUtil.getStationCommentsData(survey, SurveyFormat.THERION));
+        builder.append(SurvexTherionUtil.getCentrelineData(survey, TherionExporter.COMMENT_CHAR, SurveyFormat.THERION));
+        builder.append(SurvexTherionUtil.getExtendedElevationExtensions(survey, SurveyFormat.THERION));
         builder.append("endcentreline\n");
 
         // End survey
@@ -50,9 +50,9 @@ public class ThExporter {
         // Replace centreline block
         String centrelineText =
             "centreline\n" +
-            SurvexTherionUtil.getStationCommentsData(survey, ExportFormat.THERION) +
-            SurvexTherionUtil.getCentrelineData(survey, TherionExporter.COMMENT_CHAR, ExportFormat.THERION) +
-            SurvexTherionUtil.getExtendedElevationExtensions(survey, ExportFormat.THERION) +
+            SurvexTherionUtil.getStationCommentsData(survey, SurveyFormat.THERION) +
+            SurvexTherionUtil.getCentrelineData(survey, TherionExporter.COMMENT_CHAR, SurveyFormat.THERION) +
+            SurvexTherionUtil.getExtendedElevationExtensions(survey, SurveyFormat.THERION) +
             "endcentreline\n";
         String newContent = replaceCentreline(originalFileContent, centrelineText);
 

--- a/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/therion/ThExporter.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/therion/ThExporter.java
@@ -1,214 +1,74 @@
 package org.hwyl.sexytopo.control.io.thirdparty.therion;
 
-import android.annotation.SuppressLint;
 import android.content.Context;
-import android.text.TextUtils;
 
 import org.hwyl.sexytopo.SexyTopoConstants;
 import org.hwyl.sexytopo.control.activity.SexyTopoActivity;
 import org.hwyl.sexytopo.control.io.thirdparty.survextherion.SurvexTherionUtil;
-import org.hwyl.sexytopo.control.util.GraphToListTranslator;
-import org.hwyl.sexytopo.control.util.TextTools;
-import org.hwyl.sexytopo.model.graph.Direction;
-import org.hwyl.sexytopo.model.survey.Leg;
-import org.hwyl.sexytopo.model.survey.Station;
 import org.hwyl.sexytopo.model.survey.Survey;
-import org.hwyl.sexytopo.model.survey.Trip;
 
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 
 
-@SuppressWarnings("UnnecessaryLocalVariable")
 public class ThExporter {
 
-    public static final String TRIP_DATE_PATTERN = "yyyy.MM.dd";
-
-
     public static String getContent(Context context, Survey survey, List<String> th2Files) {
-        String text =
-            TherionExporter.getEncodingText() + "\n" +
-            getSurveyText(context, survey, th2Files) + "\n";
-
-        return text;
+        StringBuilder builder = new StringBuilder();
+        
+        // Encoding
+        builder.append(TherionExporter.getEncodingText()).append("\n\n");
+        
+        // Survey block
+        builder.append("survey ").append(survey.getName()).append("\n");
+        
+        // Creation comment
+        String versionInfo = SexyTopoConstants.APP_NAME + " " + SexyTopoActivity.getVersionName(context);
+        builder.append(SurvexTherionUtil.getCreationComment(TherionExporter.COMMENT_CHAR, versionInfo)).append("\n\n");
+        
+        // Input files
+        builder.append(SurvexTherionUtil.getInputText(th2Files)).append("\n\n");
+        
+        // Metadata (date, instrument, team, explo block)
+        builder.append(SurvexTherionUtil.getMetadata(survey, null, TherionExporter.COMMENT_CHAR)).append("\n");
+        
+        // Centreline block
+        builder.append("centreline\n");
+        builder.append(SurvexTherionUtil.getCentrelineData(survey, null, TherionExporter.COMMENT_CHAR, false));
+        builder.append(SurvexTherionUtil.getExtendedElevationExtensions(survey, null));
+        builder.append("endcentreline\n");
+        
+        // End survey
+        builder.append("endsurvey\n");
+        
+        return builder.toString();
     }
 
     public static String updateOriginalContent(
             Survey survey, String originalFileContent, List<String> th2Files) {
-        String centrelineText = getCentrelineText(survey);
+        
+        // Replace centreline block
+        String centrelineText = 
+            "centreline\n" +
+            SurvexTherionUtil.getCentrelineData(survey, null, TherionExporter.COMMENT_CHAR, false) +
+            SurvexTherionUtil.getExtendedElevationExtensions(survey, null) +
+            "endcentreline\n";
         String newContent = replaceCentreline(originalFileContent, centrelineText);
 
-        String inputText = getInputText(th2Files);
+        // Replace input statements
+        String inputText = SurvexTherionUtil.getInputText(th2Files);
         newContent = replaceInputsText(newContent, inputText);
 
         return newContent;
     }
 
-    public static String replaceCentreline(String original, String replacementText) {
-        String newContent = original.replaceFirst(
+    private static String replaceCentreline(String original, String replacementText) {
+        return original.replaceFirst(
                 "(?s)(\\s*?(centreline|centerline)(.*)(endcentreline|endcenterline)\\s*)",
                 replacementText);
-        return newContent;
     }
 
-    public static String replaceInputsText(String original, String replacementText) {
-        String newContent = original.replaceFirst("(?m)(^input .*\\n)+", replacementText);
-        return newContent;
-    }
-
-    private static String getSurveyText(Context context, Survey survey, List<String> th2Files) {
-
-        String attribution = "created with " +
-                SexyTopoConstants.APP_NAME + " " + SexyTopoActivity.getVersionName(context);
-
-        String surveyText =
-            TherionExporter.COMMENT_CHAR + " " + attribution + "\n\n" +
-            "survey " + survey.getName() + "\n\n" +
-            getInputText(th2Files) + "\n\n" +
-            indent(getCentrelineText(survey)) + "\n\n" +
-            "endsurvey";
-        return surveyText;
-    }
-
-    private static String getInputText(List<String> th2Files) {
-        List<String> lines = new ArrayList<>();
-        for (String filename: th2Files) {
-            lines.add("input \"" + filename + "\"");
-        }
-        return TextTools.join("\n", lines);
-    }
-
-    private static String getCentrelineText(Survey survey) {
-        String centrelineText =
-            "\ncentreline\n\n" +
-            indent(getCentreline(survey)) + "\n\n" +
-            indent(getExtendedElevationExtensions(survey)) + "\n\n" +
-            "endcentreline\n";
-        return centrelineText;
-    }
-
-    public static String indent(String text) {
-        StringBuilder indented = new StringBuilder();
-
-        if (text.trim().equals("")) {
-            return "";
-        }
-
-        String[] lines = text.split("\n");
-        for (String line : lines) {
-            indented.append("\t").append(line).append("\n");
-        }
-        return indented.toString();
-    }
-
-    private static String getCentreline(Survey survey) {
-        GraphToListTranslator graphToListTranslator = new GraphToListTranslator();
-
-        StringBuilder builder = new StringBuilder();
-
-        Trip trip = survey.getTrip();
-        if (trip != null) {
-            builder.append(formatTrip(trip));
-        }
-
-        builder.append("data normal from to length compass clino\n\n");
-
-        List<GraphToListTranslator.SurveyListEntry> list =
-                graphToListTranslator.toChronoListOfSurveyListEntries(survey);
-
-        for (GraphToListTranslator.SurveyListEntry entry : list) {
-            SurvexTherionUtil.formatEntry(builder, entry, TherionExporter.COMMENT_CHAR);
-            builder.append("\n");
-        }
-
-        return builder.toString();
-    }
-
-
-    private static String formatTrip(Trip trip) {
-        StringBuilder builder = new StringBuilder();
-
-        builder.append(formatDate(trip.getDate()));
-        builder.append("\n");
-
-        if (!trip.getComments().isEmpty()) {
-            builder.append(commentMultiline(trip.getComments()));
-        }
-
-        for (Trip.TeamEntry entry : trip.getTeam()) {
-            builder.append(formatMember(entry));
-            builder.append("\n");
-        }
-        builder.append("\n");
-        return builder.toString();
-    }
-
-    private static String formatMember(Trip.TeamEntry member) {
-        List<String> fields = new ArrayList<>();
-        fields.add("team");
-        fields.add("\"" + member.name + "\"");
-        for (Trip.Role role : member.roles) {
-            fields.add(getRoleDescription(role));
-        }
-        return TextUtils.join(" ", fields);
-    }
-
-    private static String getRoleDescription(Trip.Role role) {
-        switch(role) {
-            case BOOK:
-                return "notes";
-            case INSTRUMENTS:
-                return "instruments";
-            case DOG:
-            case EXPLORATION: // FIXME Therion actually handles explo-team differently
-            default:
-                return "assistant";
-        }
-    }
-
-    private static String commentMultiline(String raw) {
-        StringBuilder builder = new StringBuilder();
-        String[] lines = raw.split("\n");
-        for (String line : lines) {
-            builder.append("# ").append(line).append("\n");
-        }
-        return builder.toString();
-    }
-
-    @SuppressLint("SimpleDateFormat")
-    private static String formatDate(Date date) {
-        DateFormat dateFormat = new SimpleDateFormat(TRIP_DATE_PATTERN);
-        String dateString = dateFormat.format(date);
-        return "date " + dateString;
-    }
-
-    private static String getExtendedElevationExtensions(Survey survey) {
-        StringBuilder builder = new StringBuilder();
-        generateExtendCommandsFromStation(builder, survey.getOrigin(), null);
-        return builder.toString();
-    }
-
-    private static void generateExtendCommandsFromStation(
-            StringBuilder builder, Station station, Direction lastDirection) {
-
-        Direction currentDirection = station.getExtendedElevationDirection();
-        if (lastDirection == null) {
-            builder.append(getExtendCommand(station, "start"));
-        } else if (currentDirection != lastDirection) {
-            builder.append(getExtendCommand(station, currentDirection.name().toLowerCase()));
-        }
-
-        for (Leg leg : station.getConnectedOnwardLegs()) {
-            generateExtendCommandsFromStation(
-                    builder, leg.getDestination(), station.getExtendedElevationDirection());
-        }
-    }
-
-    private static String getExtendCommand(Station station, String direction) {
-        return "extend " + direction + " " + station.getName() + "\n";
+    private static String replaceInputsText(String original, String replacementText) {
+        return original.replaceFirst("(?m)(^input .*\\n)+", replacementText);
     }
 
 }

--- a/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/therion/ThExporter.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/therion/ThExporter.java
@@ -16,7 +16,7 @@ public class ThExporter {
         StringBuilder builder = new StringBuilder();
         
         // Encoding
-        builder.append(TherionExporter.getEncodingText()).append("\n\n");
+        builder.append(TherionExporter.getEncodingText()).append("\n");
         
         // Survey block
         builder.append("survey ").append(survey.getName()).append("\n");
@@ -33,6 +33,7 @@ public class ThExporter {
         
         // Centreline block
         builder.append("centreline\n");
+        builder.append(SurvexTherionUtil.getStationCommentsData(survey, null));
         builder.append(SurvexTherionUtil.getCentrelineData(survey, null, TherionExporter.COMMENT_CHAR, false));
         builder.append(SurvexTherionUtil.getExtendedElevationExtensions(survey, null));
         builder.append("endcentreline\n");
@@ -49,6 +50,7 @@ public class ThExporter {
         // Replace centreline block
         String centrelineText = 
             "centreline\n" +
+            SurvexTherionUtil.getStationCommentsData(survey, null) +
             SurvexTherionUtil.getCentrelineData(survey, null, TherionExporter.COMMENT_CHAR, false) +
             SurvexTherionUtil.getExtendedElevationExtensions(survey, null) +
             "endcentreline\n";
@@ -61,13 +63,13 @@ public class ThExporter {
         return newContent;
     }
 
-    private static String replaceCentreline(String original, String replacementText) {
+    static String replaceCentreline(String original, String replacementText) {
         return original.replaceFirst(
                 "(?s)(\\s*?(centreline|centerline)(.*)(endcentreline|endcenterline)\\s*)",
                 replacementText);
     }
 
-    private static String replaceInputsText(String original, String replacementText) {
+    static String replaceInputsText(String original, String replacementText) {
         return original.replaceFirst("(?m)(^input .*\\n)+", replacementText);
     }
 

--- a/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/therion/TherionExporter.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/therion/TherionExporter.java
@@ -74,6 +74,8 @@ public class TherionExporter extends Exporter {
             thContent = ThExporter.updateOriginalContent(survey, originalThFileContent, th2Files);
         }
         SurveyFile th = getOutputFile(TH);
+        // FIXED: Removed 'attribution +' to prevent duplicate "Created with SexyTopo" comment
+        // ThExporter now handles the creation comment in the correct location
         th.save(context, thContent);
     }
 

--- a/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/therion/TherionExporter.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/therion/TherionExporter.java
@@ -74,7 +74,7 @@ public class TherionExporter extends Exporter {
             thContent = ThExporter.updateOriginalContent(survey, originalThFileContent, th2Files);
         }
         SurveyFile th = getOutputFile(TH);
-        th.save(context, attribution + thContent);
+        th.save(context, thContent);
     }
 
 

--- a/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/therion/TherionImporter.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/therion/TherionImporter.java
@@ -8,7 +8,7 @@ import org.apache.commons.io.FilenameUtils;
 import org.hwyl.sexytopo.SexyTopoConstants;
 import org.hwyl.sexytopo.control.Log;
 import org.hwyl.sexytopo.control.io.IoUtils;
-import org.hwyl.sexytopo.control.io.thirdparty.survex.SurvexImporter;
+import org.hwyl.sexytopo.control.io.thirdparty.survextherion.SurvexTherionImporter;
 import org.hwyl.sexytopo.control.io.thirdparty.xvi.XviImporter;
 import org.hwyl.sexytopo.control.io.translation.Importer;
 import org.hwyl.sexytopo.control.util.SurveyUpdater;
@@ -21,6 +21,7 @@ import org.hwyl.sexytopo.model.survey.Survey;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 
 public class TherionImporter extends Importer {
@@ -74,9 +75,13 @@ public class TherionImporter extends Importer {
 
     public static void updateCentreline(List<String> lines, Survey survey) throws Exception {
         List<String> block = getContentsOfBeginEndBlock(lines, "centreline");
+        
+        // Parse passage data from the block (Therion format - no * prefix)
+        String blockText = TextTools.join("\n", block);
+        Map<String, String> passageComments = SurvexTherionImporter.parsePassageData(blockText, false);
+        
         List<String> sanitisedCentrelineData = new ArrayList<>();
         List<String> sanitisedElevationDirectionData = new ArrayList<>();
-
 
         boolean inDataBlock = false;
         for (String line: block) {
@@ -100,8 +105,11 @@ public class TherionImporter extends Importer {
         }
 
         String centrelineText = TextTools.join("\n", sanitisedCentrelineData);
-        SurvexImporter.parse(centrelineText, survey);
+        SurvexTherionImporter.parseCentreline(centrelineText, survey);
         handleElevationDirectionData(sanitisedElevationDirectionData, survey);
+        
+        // Merge passage comments with station comments
+        SurvexTherionImporter.mergePassageComments(survey, passageComments);
     }
 
 

--- a/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/therion/TherionImporter.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/therion/TherionImporter.java
@@ -8,10 +8,12 @@ import org.apache.commons.io.FilenameUtils;
 import org.hwyl.sexytopo.SexyTopoConstants;
 import org.hwyl.sexytopo.control.Log;
 import org.hwyl.sexytopo.control.io.IoUtils;
+import org.hwyl.sexytopo.control.io.thirdparty.survextherion.SurveyFormat;
 import org.hwyl.sexytopo.control.io.thirdparty.survextherion.SurvexTherionImporter;
 import org.hwyl.sexytopo.control.io.thirdparty.xvi.XviImporter;
 import org.hwyl.sexytopo.control.io.translation.Importer;
 import org.hwyl.sexytopo.control.util.SurveyUpdater;
+import org.hwyl.sexytopo.model.survey.Trip;
 import org.hwyl.sexytopo.control.util.TextTools;
 import org.hwyl.sexytopo.model.graph.Direction;
 import org.hwyl.sexytopo.model.sketch.Sketch;
@@ -56,9 +58,14 @@ public class TherionImporter extends Importer {
         String contents = IoUtils.slurpFile(context, file);
         List<String> lines = Arrays.asList(contents.split("\n"));
         updateCentreline(lines, survey);
+
+        Trip trip = SurvexTherionImporter.parseMetadata(contents, SurveyFormat.THERION);
+        if (trip != null) {
+            survey.setTrip(trip);
+        }
+
         return survey;
     }
-
 
     public boolean canHandleFile(DocumentFile directory) {
         if (!directory.isDirectory()) {
@@ -72,18 +79,16 @@ public class TherionImporter extends Importer {
         return false;
     }
 
-
     public static void updateCentreline(List<String> lines, Survey survey) throws Exception {
         List<String> block = getContentsOfBeginEndBlock(lines, "centreline");
-        
-        // Parse passage data from the block (Therion format - no * prefix)
+
         String blockText = TextTools.join("\n", block);
-        Map<String, String> passageComments = SurvexTherionImporter.parsePassageData(blockText, false);
-        
+        Map<String, String> passageComments = SurvexTherionImporter.parsePassageData(blockText, SurveyFormat.THERION);
+
         List<String> sanitisedCentrelineData = new ArrayList<>();
         List<String> sanitisedElevationDirectionData = new ArrayList<>();
 
-        boolean inDataBlock = false;
+        boolean inNormalDataBlock = false;
         for (String line: block) {
             String trimmed = line.trim();
             if (trimmed.equals("")) {
@@ -91,9 +96,12 @@ public class TherionImporter extends Importer {
             }
 
             if (trimmed.startsWith("data")) {
-                inDataBlock = true;
+                inNormalDataBlock = trimmed.startsWith("data normal");
                 continue;
-            } else if (!inDataBlock) {
+            } else if (!inNormalDataBlock) {
+                if (trimmed.startsWith("extend")) {
+                    sanitisedElevationDirectionData.add(trimmed);
+                }
                 continue;
             }
 
@@ -107,11 +115,9 @@ public class TherionImporter extends Importer {
         String centrelineText = TextTools.join("\n", sanitisedCentrelineData);
         SurvexTherionImporter.parseCentreline(centrelineText, survey);
         handleElevationDirectionData(sanitisedElevationDirectionData, survey);
-        
-        // Merge passage comments with station comments
+
         SurvexTherionImporter.mergePassageComments(survey, passageComments);
     }
-
 
     private static void handleElevationDirectionData(List<String> lines, Survey survey) {
         try {
@@ -138,7 +144,6 @@ public class TherionImporter extends Importer {
             Log.e("corrupted survey extended elevation directions: " + exception);
         }
     }
-
 
     public static List<String> getContentsOfBeginEndBlock(List<String> lines, String tag)
             throws Exception {

--- a/app/src/main/java/org/hwyl/sexytopo/model/survey/Trip.java
+++ b/app/src/main/java/org/hwyl/sexytopo/model/survey/Trip.java
@@ -61,15 +61,25 @@ public class Trip {
             }
             return result;
         }
+        
+        // Helper to check if this team entry has any roles
+        public boolean hasRoles() {
+            return roles != null && !roles.isEmpty();
+        }
     }
 
     private Date date;
     private List<TeamEntry> team = new ArrayList<>();
     private String comments;
+    private String instrument;  // Instrument name/description
+    private Date explorationDate;  // Exploration date field
+    private boolean explorationDateSameAsSurvey = true;  // Default to same as survey
 
 
     public Trip() {
         this.date = new Date();
+        this.instrument = "";  // Default to empty string
+        this.comments = "";  // Default to empty string
     }
 
     public List<TeamEntry> getTeam() {
@@ -96,6 +106,36 @@ public class Trip {
 
     public void setDate(Date date) {
         this.date = date;
+    }
+
+    // Instrument methods
+    public String getInstrument() {
+        return instrument;
+    }
+
+    public void setInstrument(String instrument) {
+        this.instrument = instrument;
+    }
+
+    public boolean hasInstrument() {
+        return instrument != null && !instrument.trim().isEmpty();
+    }
+
+    // Exploration date methods
+    public Date getExplorationDate() {
+        return explorationDate;
+    }
+
+    public void setExplorationDate(Date explorationDate) {
+        this.explorationDate = explorationDate;
+    }
+
+    public boolean isExplorationDateSameAsSurvey() {
+        return explorationDateSameAsSurvey;
+    }
+
+    public void setExplorationDateSameAsSurvey(boolean sameAsSurvey) {
+        this.explorationDateSameAsSurvey = sameAsSurvey;
     }
 
     public boolean equalsTripData(Trip trip) {

--- a/app/src/main/java/org/hwyl/sexytopo/model/survey/Trip.java
+++ b/app/src/main/java/org/hwyl/sexytopo/model/survey/Trip.java
@@ -141,11 +141,23 @@ public class Trip {
     public boolean equalsTripData(Trip trip) {
         // Note, not "equals" method because the trips could have same data but not the same ID
 
-        if (! trip.date.equals(date)) {
+        if (objectsNotEqual(trip.date, date)) {
             return false;
         }
 
-        if (! trip.comments.equals(comments)) {
+        if (objectsNotEqual(trip.comments, comments)) {
+            return false;
+        }
+
+        if (objectsNotEqual(trip.instrument, instrument)) {
+            return false;
+        }
+
+        if (objectsNotEqual(trip.explorationDate, explorationDate)) {
+            return false;
+        }
+
+        if (trip.explorationDateSameAsSurvey != explorationDateSameAsSurvey) {
             return false;
         }
 
@@ -162,6 +174,11 @@ public class Trip {
         }
 
         return true;
+    }
+
+    private static boolean objectsNotEqual(Object a, Object b) {
+        if (a == null) return b != null;
+        return !a.equals(b);
     }
 
 }

--- a/app/src/main/res/drawable/trip_list.xml
+++ b/app/src/main/res/drawable/trip_list.xml
@@ -1,0 +1,29 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    
+    <!-- Box/Rectangle border -->
+    <path
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="1.5"
+        android:fillColor="@android:color/transparent"
+        android:pathData="M3,3h18v18H3z"/>
+    
+    <!-- List lines with varying lengths, left-aligned with gap from edge -->
+    <!-- Line 1 - longest -->
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M6,7h12v1.5H6z"/>
+    
+    <!-- Line 2 - short -->
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M6,11h6v1.5H6z"/>
+    
+    <!-- Line 3 - medium -->
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M6,15h9v1.5H6z"/>
+</vector>

--- a/app/src/main/res/layout/activity_trip.xml
+++ b/app/src/main/res/layout/activity_trip.xml
@@ -115,13 +115,17 @@
             android:text="@string/exploration_date_label"
             android:textStyle="bold"/>
 
-        <TextView
-            android:id="@+id/exploration_date_display"
+        <EditText
+            android:id="@+id/exploration_date_field"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
             android:gravity="end"
-            android:textStyle="bold"/>
+            android:textStyle="bold"
+            android:inputType="date"
+            android:hint="@string/exploration_date_hint"
+            android:background="@android:color/transparent"
+            android:enabled="false"/>
     </LinearLayout>
 
     <CheckBox
@@ -131,18 +135,11 @@
         android:text="@string/same_as_survey_date"
         android:checked="true"/>
 
-    <EditText
-        android:id="@+id/exploration_date_field"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:inputType="date"
-        android:hint="@string/exploration_date_hint"
-        android:visibility="gone"/>
 
     <EditText
         android:id="@+id/trip_comments"
         android:layout_width="match_parent"
-        android:layout_height="60dp"
+        android:layout_height="96dp"
         android:inputType="textMultiLine"
         android:gravity="top"
         android:hint="@string/trip_comments"

--- a/app/src/main/res/layout/activity_trip.xml
+++ b/app/src/main/res/layout/activity_trip.xml
@@ -72,19 +72,87 @@
             />
     </LinearLayout>
 
+    <!-- Instrument Section -->
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/instrument_label"
+        android:textStyle="bold"
+        android:layout_marginTop="8dp"/>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+        <EditText
+            android:id="@+id/instrument_field"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:inputType="text"
+            android:hint="@string/instrument_hint"/>
+
+        <Button
+            android:id="@+id/instrument_get_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/instrument_get_button"
+            android:onClick="onGetInstrumentClicked"
+            android:enabled="false"/>
+    </LinearLayout>
+
+    <!-- Exploration Date Section -->
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:layout_marginTop="8dp">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/exploration_date_label"
+            android:textStyle="bold"/>
+
+        <TextView
+            android:id="@+id/exploration_date_display"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:gravity="end"
+            android:textStyle="bold"/>
+    </LinearLayout>
+
+    <CheckBox
+        android:id="@+id/exploration_date_same_as_survey"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/same_as_survey_date"
+        android:checked="true"/>
+
+    <EditText
+        android:id="@+id/exploration_date_field"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:inputType="date"
+        android:hint="@string/exploration_date_hint"
+        android:visibility="gone"/>
+
     <EditText
         android:id="@+id/trip_comments"
         android:layout_width="match_parent"
+        android:layout_height="60dp"
         android:inputType="textMultiLine"
-        android:layout_height="0dp"
-        android:layout_weight="30"
         android:gravity="top"
-        android:hint="@string/trip_comments"/>
+        android:hint="@string/trip_comments"
+        android:layout_marginTop="8dp"/>
 
     <LinearLayout
         android:layout_width="match_parent"
         android:padding="0dp"
-        android:layout_height="wrap_content">
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp">
 
         <Button
             android:id="@+id/set_trip"
@@ -94,7 +162,7 @@
             android:textAlignment="gravity"
             android:gravity="center"
             android:text="@string/trip_save_trip"
-            android:enabled="true"
+            android:enabled="false"
             android:onClick="requestSaveTrip"
             />
         <Button

--- a/app/src/main/res/menu/action_bar.xml
+++ b/app/src/main/res/menu/action_bar.xml
@@ -10,6 +10,11 @@
         app:showAsAction="always"
         tools:ignore="AlwaysShowAction"/>
     <item
+        android:id="@+id/action_trip"
+        android:title="@string/action_trip"
+        android:icon="@drawable/trip_list"
+        app:showAsAction="always"/>
+    <item
         android:id="@+id/action_table"
         android:title="@string/action_table"
         android:icon="@drawable/table"
@@ -65,7 +70,7 @@
                 <item android:id="@+id/action_elevation"
                       android:title="@string/action_elevation"
                       tools:ignore="DuplicateIds"/>
-                <item android:id="@+id/action_trip"
+                <item android:id="@+id/action_trip_menu"
                       android:title="@string/action_trip"/>
                 <item android:id="@+id/action_stats"
                       android:title="@string/action_stats"/>

--- a/app/src/main/res/menu/station_context.xml
+++ b/app/src/main/res/menu/station_context.xml
@@ -54,6 +54,11 @@
                 android:visible="false"/>
 
             <item
+                android:id="@+id/action_promote_to_above_leg"
+                android:title="@string/menu_promote_to_above_leg"
+                android:visible="false"/>
+
+            <item
                 android:id="@+id/action_downgrade_leg"
                 android:title="@string/menu_downgrade_leg"
                 android:visible="false"/>

--- a/app/src/main/res/menu/table_splay_selected.xml
+++ b/app/src/main/res/menu/table_splay_selected.xml
@@ -12,6 +12,9 @@
         android:id="@+id/upgradeRow"
         android:title="@string/menu_upgrade_row"/>
     <item
+        android:id="@+id/promoteToAboveLeg"
+        android:title="@string/menu_promote_to_above_leg"/>
+    <item
         android:id="@+id/deleteSplay"
         android:title="@string/menu_delete_splay"/>
     <item

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -547,8 +547,8 @@
     <string name="menu_rename_station">Rename</string>
     <string name="menu_edit_leg">Edit</string>
     <string name="menu_upgrade_row">Force New Station</string>
-    <string name="menu_promote_to_above_leg">Promote to Above Leg</string>
-    <string name="toast_no_leg_above">Station is not a leg station</string>
+    <string name="menu_promote_to_above_leg">Add to Leg Above</string>
+    <string name="toast_no_leg_above">Splay has no Leg above</string>
     <string name="toast_splay_promoted">Splay promoted to leg</string>
     <string name="menu_upgrade_splay">Upgrade to Leg</string>
     <string name="menu_downgrade_leg">Downgrade to Splay</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -537,6 +537,9 @@
     <string name="menu_rename_station">Rename</string>
     <string name="menu_edit_leg">Edit</string>
     <string name="menu_upgrade_row">Force New Station</string>
+    <string name="menu_promote_to_above_leg">Promote to Above Leg</string>
+    <string name="toast_no_leg_above">Station is not a leg station</string>
+    <string name="toast_splay_promoted">Splay promoted to leg</string>
     <string name="menu_upgrade_splay">Upgrade to Leg</string>
     <string name="menu_downgrade_leg">Downgrade to Splay</string>
     <string name="menu_delete_leg">Delete</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -375,6 +375,7 @@
     <!-- Trip -->
     <string name="trip">Trip</string>
     <string name="trip_team">Team</string>
+    <string name="trip_header">%1$s %2$s. %3$s:</string>
     <string name="trip_dialog_title_add_to_team">Add to Team</string>
     <string name="trip_dialog_add_to_team_name_hint">Name</string>
     <string name="trip_dialog_confirm_clear_trip">Clear Trip Data?</string>
@@ -383,7 +384,7 @@
     <string name="trip_role_book">Book (drawing)</string>
     <string name="trip_role_instruments">Instruments</string>
     <string name="trip_role_dog">Dog (assistant)</string>
-    <string name="trip_role_exploration">Exploration Team</string>
+    <string name="trip_role_exploration">Explorer</string>
     
     <!-- NEW: Instrument field strings -->
     <string name="instrument_label">Instrument:</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -385,18 +385,12 @@
     <string name="trip_role_instruments">Instruments</string>
     <string name="trip_role_dog">Dog (assistant)</string>
     <string name="trip_role_exploration">Explorer</string>
-    
-    <!-- NEW: Instrument field strings -->
     <string name="instrument_label">Instrument:</string>
     <string name="instrument_hint">Enter instrument name</string>
     <string name="instrument_get_button">Get</string>
-    
-    <!-- NEW: Exploration date strings -->
     <string name="exploration_date_label">Exploration Date:</string>
     <string name="same_as_survey_date">Same as survey date</string>
     <string name="exploration_date_hint">yyyy-mm-dd</string>
-    
-    <!-- NEW: Copy team string -->
     <string name="copy_team_from_last_trip">Copy team from last trip</string>
 
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -384,6 +384,20 @@
     <string name="trip_role_instruments">Instruments</string>
     <string name="trip_role_dog">Dog (assistant)</string>
     <string name="trip_role_exploration">Exploration Team</string>
+    
+    <!-- NEW: Instrument field strings -->
+    <string name="instrument_label">Instrument:</string>
+    <string name="instrument_hint">Enter instrument name</string>
+    <string name="instrument_get_button">Get</string>
+    
+    <!-- NEW: Exploration date strings -->
+    <string name="exploration_date_label">Exploration Date:</string>
+    <string name="same_as_survey_date">Same as survey date</string>
+    <string name="exploration_date_hint">yyyy-mm-dd</string>
+    
+    <!-- NEW: Copy team string -->
+    <string name="copy_team_from_last_trip">Copy team from last trip</string>
+
 
     <!-- Stats -->
     <string name="stats_title_this_survey">Current Survey</string>

--- a/app/src/test/java/org/hwyl/sexytopo/control/io/thirdparty/survex/SurvexExporterTest.java
+++ b/app/src/test/java/org/hwyl/sexytopo/control/io/thirdparty/survex/SurvexExporterTest.java
@@ -27,9 +27,8 @@ public class SurvexExporterTest {
         Survey oneNorth = BasicTestSurveyCreator.createStraightNorthThroughRepeats();
         String content = survexExporter.getContent(oneNorth);
         Assert.assertTrue(content.contains("1\t2\t5.000\t0.00\t0.00"));
-        Assert.assertTrue(content.contains(
-                "{from: 5.000 0.00 0.00, 5.000 0.00 0.00, 5.000 0.00 0.00}"));
-
+        // Promoted leg original readings are output as commented lines
+        Assert.assertTrue(content.contains(";1\t2\t5.000\t0.00\t0.00"));
     }
 
     @Test

--- a/app/src/test/java/org/hwyl/sexytopo/control/io/thirdparty/survex/SurvexImporterTest.java
+++ b/app/src/test/java/org/hwyl/sexytopo/control/io/thirdparty/survex/SurvexImporterTest.java
@@ -1,6 +1,6 @@
 package org.hwyl.sexytopo.control.io.thirdparty.survex;
 
-import org.hwyl.sexytopo.SexyTopoConstants;
+import org.hwyl.sexytopo.control.io.thirdparty.survextherion.SurvexTherionImporter;
 import org.hwyl.sexytopo.model.survey.Leg;
 import org.hwyl.sexytopo.model.survey.Station;
 import org.hwyl.sexytopo.model.survey.Survey;
@@ -16,7 +16,7 @@ public class SurvexImporterTest {
         final String testContent =
                 "1\t2\t5.0\t0.0\t0.0";
         Survey survey = new Survey();
-        SurvexImporter.parse(testContent, survey);
+        SurvexTherionImporter.parseCentreline(testContent, survey);
         Assert.assertEquals(2, survey.getAllStations().size());
     }
 
@@ -25,7 +25,7 @@ public class SurvexImporterTest {
         final String testContent =
                 "1\t2\t5.0\t0.0\t0.0\t; {from: 5.0 0.0 0.0, 5.0 0.0 0.0, 5.0 0.0 0.0}";
         Survey survey = new Survey();
-        SurvexImporter.parse(testContent, survey);
+        SurvexTherionImporter.parseCentreline(testContent, survey);
         Leg leg = survey.getOrigin().getConnectedOnwardLegs().get(0);
         Assert.assertEquals(3, leg.getPromotedFrom().length);
     }
@@ -35,24 +35,8 @@ public class SurvexImporterTest {
         final String testContent =
                 "1\t2\t5.0\t0.0\t0.0\t; {from: 5.0 0.0 0.0, 5.0 0.0 0.0, 5.0 0.0 0.0} testComment";
         Survey survey = new Survey();
-        SurvexImporter.parse(testContent, survey);
+        SurvexTherionImporter.parseCentreline(testContent, survey);
         Station created = survey.getStationByName("2");
         Assert.assertEquals("testComment", created.getComment());
     }
-
-
-    @Test
-    public void testCommentInstructionParsing() {
-        Leg[] legs = SurvexImporter.parseAnyPromotedLegs(
-                "{from: 1 0 0, 1.0 0.0 0.0, 1.0 0.0 0.0}");
-        Assert.assertEquals(3, legs.length);
-        for (Leg leg : legs) {
-            Assert.assertEquals(1.0, leg.getDistance(), SexyTopoConstants.ALLOWED_DOUBLE_DELTA);
-            Assert.assertEquals(0.0, leg.getAzimuth(), SexyTopoConstants.ALLOWED_DOUBLE_DELTA);
-            Assert.assertEquals(0.0, leg.getInclination(), SexyTopoConstants.ALLOWED_DOUBLE_DELTA);
-        }
-    }
 }
-
-
-


### PR DESCRIPTION
In table view a splay can be added to the leg directly above it, so long as the splay station is one of the leg stations.

WARNING: sexytopo averages legs as individual components, in otherwords take the average  distances, the average of the bearings and the average of the incline. This can lead to weird results if the legs are not reasonably close together!

Things that could be improved. Check to see if it is in the tolerance, this can occur if a middle reading was missed, but then deleted. If the added splay is not in tolerance a comment should be added to the averaged leg.
It might be useful to have a second tear of tolerance for legs, and not allow promotion if above this higher tolerance. This would reduce really silly things happening to the averaged leg.