### PR TITLE
Add SAP6/DiscoX BLE auto-reconnect

### DIFF
--- a/app/src/main/java/org/hwyl/sexytopo/control/activity/DeviceActivity.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/activity/DeviceActivity.java
@@ -299,7 +299,13 @@ public class DeviceActivity extends SexyTopoActivity {
     public void updateConnectionStatus() {
         SwitchCompat connectionSwitch = findViewById(R.id.connectionSwitch);
         boolean isActuallyConnected = requestComms().isConnected();
+        // Temporarily remove listener to avoid triggering toggleConnection()
+        // when the switch state is updated programmatically (e.g. after an
+        // unexpected disconnection), which would cancel auto-reconnect.
+        connectionSwitch.setOnCheckedChangeListener(null);
         connectionSwitch.setChecked(isActuallyConnected);
+        connectionSwitch.setOnCheckedChangeListener(
+                (buttonView, isChecked) -> toggleConnection(buttonView));
     }
 
 

--- a/app/src/main/java/org/hwyl/sexytopo/control/util/GeneralPreferences.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/util/GeneralPreferences.java
@@ -208,6 +208,12 @@ public class GeneralPreferences {
         return getInt("pref_survey_symbol_size", 25);
     }
 
+    // ********** Connection ***********
+
+    public static boolean isAutoReconnectOn() {
+        return getBoolean("pref_auto_reconnect", true);
+    }
+
     // ********** Calibration ***********
 
     public static String getCalibrationAlgorithm() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -276,6 +276,7 @@
     <string name="device_ble_device_ready">%1$s ready :)</string>
     <string name="device_ble_device_disconnecting">%1$s disconnecting</string>
     <string name="device_ble_device_disconnected">%1$s ready :)</string>
+    <string name="device_ble_auto_reconnecting">Auto-reconnecting to %1$s…</string>
     <string name="device_ble_failed_to_connect_to">Failed to connect to %1$s</string>
     <string name="device_ble_invalid_data">Invalid data received: %1$s</string>
     <string name="device_distox_name" translatable="false">DistoX</string>
@@ -428,6 +429,9 @@
     <string name="settings_max_distance_delta_summary">How much error tolerated when deciding whether to create a new station</string>
     <string name="settings_max_angle_delta_title">Max angle delta (degrees)</string>
     <string name="settings_max_angle_delta_summary">How much error tolerated when deciding whether to create a new station</string>
+    <string name="settings_connection_title">Connection</string>
+    <string name="settings_auto_reconnect_title">Auto-reconnect</string>
+    <string name="settings_auto_reconnect_summary">Automatically reconnect to BLE devices on unexpected disconnection</string>
     <string name="settings_calibration_title">Calibration</string>
     <string name="settings_calibration_algorithm_title">Disto-X calibration algorithm</string>
     <string name="settings_calibration_algorithm_summary">Override Disto-X calibration algorithm choice</string>

--- a/app/src/main/res/xml/general_preferences.xml
+++ b/app/src/main/res/xml/general_preferences.xml
@@ -42,6 +42,15 @@
     </PreferenceCategory>
 
     <PreferenceCategory
+        android:title="@string/settings_connection_title">
+        <CheckBoxPreference
+            android:key="pref_auto_reconnect"
+            android:title="@string/settings_auto_reconnect_title"
+            android:summary="@string/settings_auto_reconnect_summary"
+            android:defaultValue="true"/>
+    </PreferenceCategory>
+
+    <PreferenceCategory
         android:title="@string/settings_calibration_title">
         <ListPreference
             android:key="pref_calibration_algorithm"


### PR DESCRIPTION
## Summary
- Adds automatic reconnection for SAP6/DiscoX devices after unexpected BLE disconnections (including GATT errors like timeout)
- New user preference: **Settings > Connection > Auto-reconnect** (enabled by default)
- Does not reconnect when the user manually disconnects

## Changes
- **SAP6Communicator** — tracks whether the user requested the disconnect; on unexpected disconnection, schedules a reconnect attempt after 3 seconds. Also fixes a threading issue where BLE callbacks were updating the UI from a background thread.
- **DeviceActivity** — prevents the connection switch UI update from being misinterpreted as a user-initiated disconnect (which would cancel the pending reconnect)
- **GeneralPreferences** — new isAutoReconnectOn() getter
- **general_preferences.xml** — new Connection settings category with auto-reconnect checkbox
- **strings.xml** — new preference and log message strings

## Test plan
- [x] Unit tests pass (gradlew test)
- [x] Tested on OnePlus device with SAP6 instrument — auto-reconnect fires after unexpected BLE disconnection
- [x] Manual disconnect does not trigger auto-reconnect
- [x] Setting can be toggled off in preferences