### PR TITLE
Manually track connection status

### DIFF
--- a/app/src/main/java/org/hwyl/sexytopo/comms/sap6/CaveBLE.kt
+++ b/app/src/main/java/org/hwyl/sexytopo/comms/sap6/CaveBLE.kt
@@ -46,24 +46,28 @@ class CaveBLE(val device: BluetoothDevice,
     private var command: BluetoothGattCharacteristic? = null
     private var dataIn: BluetoothGattCharacteristic? = null
     private var bluetoothGatt: BluetoothGatt? = null
+    private var _isConnected = false
     private val callback = object: BluetoothGattCallback() {
         override fun onConnectionStateChange(gatt: BluetoothGatt, status: Int, newState: Int) {
             val deviceAddress = gatt.device.address
 
             if (status == BluetoothGatt.GATT_SUCCESS) {
                 if (newState == BluetoothProfile.STATE_CONNECTED) {
+                    _isConnected = true
                     bluetoothGatt = gatt
                     Handler(Looper.getMainLooper()).post {
                         bluetoothGatt?.discoverServices()
                     }
                 } else if (newState == BluetoothProfile.STATE_DISCONNECTED) {
                     Log.w("BluetoothGattCallback", "Successfully disconnected from $deviceAddress")
+                    _isConnected = false
                     gatt.close()
                     statusCallback?.invoke(DISCONNECTED, "Successful disconnection")
                 }
             } else {
                 val msg = "Error $status encountered for $deviceAddress! Disconnecting..."
                 Log.w("BluetoothGattCallback", msg)
+                _isConnected = false
                 gatt.close()
                 statusCallback?.invoke(CONNECTION_FAILED, msg)
             }
@@ -120,9 +124,7 @@ class CaveBLE(val device: BluetoothDevice,
     }
 
     fun isConnected(): Boolean {
-        val bluetoothMgr: BluetoothManager = context.getSystemService(Context.BLUETOOTH_SERVICE) as BluetoothManager
-        val devs = bluetoothMgr.getConnectedDevices(BluetoothProfile.GATT)
-        return (device in devs)
+        return _isConnected
     }
 
     fun sendCommand(value: Int) {

--- a/app/src/main/java/org/hwyl/sexytopo/comms/sap6/SAP6Communicator.java
+++ b/app/src/main/java/org/hwyl/sexytopo/comms/sap6/SAP6Communicator.java
@@ -22,6 +22,7 @@ public class SAP6Communicator implements Communicator {
     private final CaveBLE caveBLE;
 
     private final SurveyManager datamanager;
+    private boolean _isConnected = false;
 
     private static final int START_CALIBRATION_ID = View.generateViewId();
     private static final int STOP_CALIBRATION_ID = View.generateViewId();
@@ -29,7 +30,6 @@ public class SAP6Communicator implements Communicator {
     private static final int SHOT_ID = View.generateViewId();
     private static final int LASER_OFF_ID = View.generateViewId();
     private static final int DEVICE_OFF_ID = View.generateViewId();
-
 
     private static final Map<Integer, Integer> CUSTOM_COMMANDS = new HashMap<>();
 
@@ -50,7 +50,7 @@ public class SAP6Communicator implements Communicator {
 
     @Override
     public boolean isConnected() {
-        return caveBLE.isConnected();
+        return _isConnected;
     }
 
     @Override
@@ -100,13 +100,16 @@ public class SAP6Communicator implements Communicator {
     public Unit statusCallback(int status, String msg) {
         switch (status) {
             case CaveBLE.CONNECTED:
+                _isConnected = true;
                 Log.device("Connected");
                 break;
             case CaveBLE.DISCONNECTED:
+                _isConnected = false;
                 Log.device("Disconnected");
                 activity.updateConnectionStatus();
                 break;
             case CaveBLE.CONNECTION_FAILED:
+                _isConnected = false;
                 Log.device("Communication error: "+msg);
                 activity.updateConnectionStatus();
         }


### PR DESCRIPTION
The current method to get the BLE connection status (connected / disconnected) is unreliable, because it relies on Android updating it's information, which is not done quickly. So for example just after a disconnect, fetching the connection status usually returns a still connected status. This makes life hard when you're trying to keep the status correct in the display.

There are actually two fixes (which can sit side-by-side). The first fixes it in SAP6Communicator.java by no longer relying on caveBLE.isConnected() to get the status but just storing it in a variable.

The second commit is to put the change actually in CaveBLE.kt - this is where it really should go, but I understand that this is part of an external project: furbrain/CircuitPython_CaveBLE. I have submitted the patch there - but I am not sure he is monitoring the project at the moment.

You can only accept the first commit if you don't want to change the code in CaveBLE.kt

Once this is in, I will start work on making sure the status is much more accurate. I am also keen to see #286 implemented and am working on that (which also somewhat depends on this change).