### PR TITLE
Removed the menu restriction that stopped comments on the first station

### DIFF
--- a/app/src/main/java/org/hwyl/sexytopo/control/graph/ContextMenuManager.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/graph/ContextMenuManager.java
@@ -165,12 +165,6 @@ public class ContextMenuManager {
             if (unlinkItem != null) unlinkItem.setEnabled(hasLinks);
         }
 
-        // Disable comment for origin station
-        MenuItem commentItem = menu.findItem(R.id.action_comment);
-        if (commentItem != null && survey != null) {
-            commentItem.setEnabled(station != survey.getOrigin());
-        }
-
         if (survey != null) {
             currentLeg = (leg != null) ? leg : survey.getReferringLeg(station);
 


### PR DESCRIPTION
I'm reasonably sure that the only reason that the first station could not be commented on was that it was exported on a leg so there was not place to export it to. This is possibly the most important station to get a comment as it connects to previous, probably historic, data. With the latest export this is no longer a restriction so comments now should be able to be added to the first station. The PR removes the menu restriction that stopped the comment on the first station. It appears to have no ill effects as expected my logic for the original inclusion is correct. If there was another reason this might need revisiting.
Closes #166