### PR TITLE
Hide splay in sketch

### DIFF
--- a/app/src/main/assets/guide/index.html
+++ b/app/src/main/assets/guide/index.html
@@ -243,13 +243,14 @@
 	<li><strong>Delete Station</strong> removes the station and all dependent legs and stations</li>
 </ul>
 
-<h3>Leg Actions</h3>
+<h3>Readings Actions</h3>
 <ul>
 	<li><strong>Edit Leg</strong> modifies the distance, azimuth, and inclination</li>
 	<li><strong>Reverse</strong> inverts the measurement as if taken from target back to origin</li>
 	<li><strong>Upgrade Splay</strong> (splays only) converts a splay to a full leg, creating a new station</li>
 	<li><strong>Add to Leg Above</strong> (splays only) merges the splay's measurements into the most recent full leg, averaging them together. This is useful when you have taken an additional shot along an existing leg and want to incorporate it for better accuracy</li>
 	<li><strong>Downgrade Leg</strong> (legs only) converts a leg to a splay</li>
+	<li><strong>Hide on Sketch</strong> (splays only) Splay does not get plotted on the sketches, indicated by being crossed throw.</li>
 	<li><strong>Delete Leg</strong> removes the selected leg or splay</li>
 </ul>
 

--- a/app/src/main/java/org/hwyl/sexytopo/control/activity/SurveyEditorActivity.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/activity/SurveyEditorActivity.java
@@ -83,6 +83,13 @@ public abstract class SurveyEditorActivity extends SexyTopoActivity {
         invalidateView();
     }
 
+    public void onCrossOutLeg(Leg leg) {
+        leg.setCrossedOut(!leg.isCrossedOut());
+        getSurvey().setSaved(false);
+        getSurveyManager().broadcastSurveyUpdated();
+        invalidateView();
+    }
+
     public void onNewCrossSection(Station station) {
         // Default: not applicable in some views
         // Override in activities that support adding cross-sections

--- a/app/src/main/java/org/hwyl/sexytopo/control/activity/SurveyEditorActivity.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/activity/SurveyEditorActivity.java
@@ -84,6 +84,9 @@ public abstract class SurveyEditorActivity extends SexyTopoActivity {
     }
 
     public void onHideOnSketchLeg(Leg leg) {
+        if (leg == null || leg.hasDestination()) {
+            return;
+        }
         leg.setHiddenOnSketch(!leg.isHiddenOnSketch());
         getSurvey().setSaved(false);
         getSurveyManager().broadcastSurveyUpdated();

--- a/app/src/main/java/org/hwyl/sexytopo/control/activity/SurveyEditorActivity.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/activity/SurveyEditorActivity.java
@@ -83,8 +83,8 @@ public abstract class SurveyEditorActivity extends SexyTopoActivity {
         invalidateView();
     }
 
-    public void onCrossOutLeg(Leg leg) {
-        leg.setCrossedOut(!leg.isCrossedOut());
+    public void onHideOnSketchLeg(Leg leg) {
+        leg.setHiddenOnSketch(!leg.isHiddenOnSketch());
         getSurvey().setSaved(false);
         getSurveyManager().broadcastSurveyUpdated();
         invalidateView();

--- a/app/src/main/java/org/hwyl/sexytopo/control/graph/ContextMenuManager.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/graph/ContextMenuManager.java
@@ -191,6 +191,14 @@ public class ContextMenuManager {
                     downgradeItem.setVisible(!isSplay);
                     downgradeItem.setEnabled(canDowngrade);
                 }
+
+                MenuItem crossOutItem = menu.findItem(R.id.action_cross_out_leg);
+                if (crossOutItem != null) {
+                    crossOutItem.setTitle(
+                            currentLeg.isCrossedOut()
+                                    ? R.string.menu_uncross_out
+                                    : R.string.menu_cross_out);
+                }
                 if (legMenuItem != null) {
                     legMenuItem.setTitle(R.string.menu_incoming_leg);
                     if (!isSplay) {
@@ -259,6 +267,10 @@ public class ContextMenuManager {
         }
         if (itemId == R.id.action_promote_to_above_leg && currentLeg != null) {
             activity.onPromoteToAboveLeg(currentLeg);
+            return true;
+        }
+        if (itemId == R.id.action_cross_out_leg && currentLeg != null) {
+            activity.onCrossOutLeg(currentLeg);
             return true;
         }
         if (itemId == R.id.action_downgrade_leg && currentLeg != null) {

--- a/app/src/main/java/org/hwyl/sexytopo/control/graph/ContextMenuManager.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/graph/ContextMenuManager.java
@@ -194,7 +194,8 @@ public class ContextMenuManager {
 
                 MenuItem hideOnSketchItem = menu.findItem(R.id.action_hide_on_sketch_leg);
                 if (hideOnSketchItem != null) {
-                    hideOnSketchItem.setChecked(currentLeg.isHiddenOnSketch());
+                    hideOnSketchItem.setEnabled(isSplay);
+                    hideOnSketchItem.setChecked(isSplay && currentLeg.isHiddenOnSketch());
                 }
                 if (legMenuItem != null) {
                     legMenuItem.setTitle(R.string.menu_incoming_leg);

--- a/app/src/main/java/org/hwyl/sexytopo/control/graph/ContextMenuManager.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/graph/ContextMenuManager.java
@@ -194,10 +194,7 @@ public class ContextMenuManager {
 
                 MenuItem crossOutItem = menu.findItem(R.id.action_cross_out_leg);
                 if (crossOutItem != null) {
-                    crossOutItem.setTitle(
-                            currentLeg.isCrossedOut()
-                                    ? R.string.menu_uncross_out
-                                    : R.string.menu_cross_out);
+                    crossOutItem.setChecked(currentLeg.isCrossedOut());
                 }
                 if (legMenuItem != null) {
                     legMenuItem.setTitle(R.string.menu_incoming_leg);

--- a/app/src/main/java/org/hwyl/sexytopo/control/graph/ContextMenuManager.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/graph/ContextMenuManager.java
@@ -192,9 +192,9 @@ public class ContextMenuManager {
                     downgradeItem.setEnabled(canDowngrade);
                 }
 
-                MenuItem crossOutItem = menu.findItem(R.id.action_cross_out_leg);
-                if (crossOutItem != null) {
-                    crossOutItem.setChecked(currentLeg.isCrossedOut());
+                MenuItem hideOnSketchItem = menu.findItem(R.id.action_hide_on_sketch_leg);
+                if (hideOnSketchItem != null) {
+                    hideOnSketchItem.setChecked(currentLeg.isHiddenOnSketch());
                 }
                 if (legMenuItem != null) {
                     legMenuItem.setTitle(R.string.menu_incoming_leg);
@@ -266,8 +266,8 @@ public class ContextMenuManager {
             activity.onPromoteToAboveLeg(currentLeg);
             return true;
         }
-        if (itemId == R.id.action_cross_out_leg && currentLeg != null) {
-            activity.onCrossOutLeg(currentLeg);
+        if (itemId == R.id.action_hide_on_sketch_leg && currentLeg != null) {
+            activity.onHideOnSketchLeg(currentLeg);
             return true;
         }
         if (itemId == R.id.action_downgrade_leg && currentLeg != null) {

--- a/app/src/main/java/org/hwyl/sexytopo/control/io/basic/SurveyJsonTranslater.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/io/basic/SurveyJsonTranslater.java
@@ -40,6 +40,7 @@ public class SurveyJsonTranslater {
     public static final String PROMOTED_FROM_TAG = "promotedFrom";
     public static final String DESTINATION_TAG = "destination";
     public static final String WAS_SHOT_BACKWARDS_TAG = "wasShotBackwards";
+    public static final String IS_CROSSED_OUT_TAG = "isCrossedOut";
     public static final String INDEX_TAG = "index";
 
     public static final String ACTIVE_STATION_TAG = "activeStation";
@@ -258,6 +259,7 @@ public class SurveyJsonTranslater {
         json.put(INCLINATION_TAG, leg.getInclination());
         json.put(DESTINATION_TAG, leg.getDestination().getName());
         json.put(WAS_SHOT_BACKWARDS_TAG, leg.wasShotBackwards());
+        json.put(IS_CROSSED_OUT_TAG, leg.isCrossedOut());
         if (index != null) {
             json.put(INDEX_TAG, index);
         }
@@ -339,6 +341,7 @@ public class SurveyJsonTranslater {
         float azimuth = (float) json.getDouble(AZIMUTH_TAG);
         float inclination = (float) json.getDouble(INCLINATION_TAG);
         boolean wasShotBackwards = json.getBoolean(WAS_SHOT_BACKWARDS_TAG);
+        boolean isCrossedOut = json.optBoolean(IS_CROSSED_OUT_TAG, false);
 
         String destinationName = json.getString(DESTINATION_TAG);
 
@@ -377,6 +380,7 @@ public class SurveyJsonTranslater {
                             wasShotBackwards);
         }
 
+        leg.setCrossedOut(isCrossedOut);
         return leg;
     }
 

--- a/app/src/main/java/org/hwyl/sexytopo/control/io/basic/SurveyJsonTranslater.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/io/basic/SurveyJsonTranslater.java
@@ -40,7 +40,7 @@ public class SurveyJsonTranslater {
     public static final String PROMOTED_FROM_TAG = "promotedFrom";
     public static final String DESTINATION_TAG = "destination";
     public static final String WAS_SHOT_BACKWARDS_TAG = "wasShotBackwards";
-    public static final String IS_CROSSED_OUT_TAG = "isCrossedOut";
+    public static final String IS_HIDDEN_ON_SKETCH_TAG = "isHiddenOnSketch";
     public static final String INDEX_TAG = "index";
 
     public static final String ACTIVE_STATION_TAG = "activeStation";
@@ -259,7 +259,7 @@ public class SurveyJsonTranslater {
         json.put(INCLINATION_TAG, leg.getInclination());
         json.put(DESTINATION_TAG, leg.getDestination().getName());
         json.put(WAS_SHOT_BACKWARDS_TAG, leg.wasShotBackwards());
-        json.put(IS_CROSSED_OUT_TAG, leg.isCrossedOut());
+        json.put(IS_HIDDEN_ON_SKETCH_TAG, leg.isHiddenOnSketch());
         if (index != null) {
             json.put(INDEX_TAG, index);
         }
@@ -341,7 +341,7 @@ public class SurveyJsonTranslater {
         float azimuth = (float) json.getDouble(AZIMUTH_TAG);
         float inclination = (float) json.getDouble(INCLINATION_TAG);
         boolean wasShotBackwards = json.getBoolean(WAS_SHOT_BACKWARDS_TAG);
-        boolean isCrossedOut = json.optBoolean(IS_CROSSED_OUT_TAG, false);
+        boolean isHiddenOnSketch = json.optBoolean(IS_HIDDEN_ON_SKETCH_TAG, false);
 
         String destinationName = json.getString(DESTINATION_TAG);
 
@@ -380,7 +380,7 @@ public class SurveyJsonTranslater {
                             wasShotBackwards);
         }
 
-        leg.setCrossedOut(isCrossedOut);
+        leg.setHiddenOnSketch(isHiddenOnSketch);
         return leg;
     }
 

--- a/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/survextherion/SurvexTherionImporter.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/survextherion/SurvexTherionImporter.java
@@ -44,28 +44,40 @@ public class SurvexTherionImporter {
                 continue;
             }
 
-            // Skip pure comment lines (but not lines with data and comments)
+            // Detect crossed-out legs: a single comment char followed by 5+ data fields.
+            // Double comment chars (;;/##) are promoted-from precursors — leave those to
+            // parseCommentedNewLinePromotedLegs.
+            boolean isCrossedOut = false;
             if (trimmed.startsWith(";") || trimmed.startsWith("#")) {
-                // Don't skip if it looks like commented new lines promoted leg
-                String[] parts = trimmed.substring(1).trim().split("\\s+");
-                if (parts.length < 5) {
-                    continue; // Just a comment, skip it
+                boolean isDouble = trimmed.length() > 1
+                        && trimmed.charAt(1) == trimmed.charAt(0);
+                if (isDouble) {
+                    continue; // Double-commented precursor line — skip here
                 }
-                // Might be commented new lines promoted leg, let it fall through
-                continue;
+                String afterComment = trimmed.substring(1).trim();
+                String[] parts = afterComment.split("\\s+");
+                if (parts.length >= 5 && looksLikeDataLine(parts)) {
+                    // Single-commented data line — a crossed-out leg
+                    isCrossedOut = true;
+                    line = afterComment; // strip the leading comment char for field parsing
+                    trimmed = afterComment;
+                } else {
+                    continue; // Plain comment, skip
+                }
             }
 
             try {
                 // Extract comment - support both ; (Survex) and # (Therion)
                 String comment = extractCommentFromLine(line);
 
-                String[] fields = line.trim().split("\\s+");
+                String[] fields = trimmed.split("\\s+");
 
                 // Check for commented new lines promoted legs in subsequent lines
                 List<Leg> commentedNewLineLegs =
                         parseCommentedNewLinePromotedLegs(lines, lineIndex, fields[0], fields[1]);
 
-                addLegToSurvey(survey, nameToStation, fields, comment, commentedNewLineLegs);
+                addLegToSurvey(survey, nameToStation, fields, comment, commentedNewLineLegs,
+                        isCrossedOut);
 
             } catch (Exception exception) {
                 throw new Exception("Error importing this line: " + line);
@@ -361,7 +373,8 @@ public class SurvexTherionImporter {
             Map<String, Station> nameToStation,
             String[] fields,
             String comment,
-            List<Leg> commentedNewLineLegs) {
+            List<Leg> commentedNewLineLegs,
+            boolean crossedOut) {
 
         String fromName = fields[0];
         String toName = fields[1];
@@ -444,6 +457,7 @@ public class SurvexTherionImporter {
             }
         }
 
+        leg.setCrossedOut(crossedOut);
         legFrom.addOnwardLeg(leg);
         survey.addLegRecord(leg);
         survey.setActiveStation(legFrom);
@@ -495,8 +509,15 @@ public class SurvexTherionImporter {
                 break;
             }
 
-            // Remove the comment character and parse
-            String content = line.substring(1).trim();
+            // Remove one or two leading comment characters.
+            // Precursors of a normal leg have one (;/# ); precursors of a crossed-out
+            // leg have two (;;/##). Strip them both the same way — we just need the data.
+            String content;
+            if (line.length() > 1 && line.charAt(1) == line.charAt(0)) {
+                content = line.substring(2).trim();
+            } else {
+                content = line.substring(1).trim();
+            }
             String[] fields = content.split("\\s+");
 
             // Check if this is a matching shot
@@ -519,6 +540,21 @@ public class SurvexTherionImporter {
         }
 
         return shots;
+    }
+
+    /**
+     * Returns true if the first five elements of parts look like a data line:
+     * fields[0] and [1] are non-numeric (station names), fields[2..4] are floats.
+     */
+    private static boolean looksLikeDataLine(String[] parts) {
+        try {
+            Float.parseFloat(parts[2]);
+            Float.parseFloat(parts[3]);
+            Float.parseFloat(parts[4]);
+            return true;
+        } catch (NumberFormatException e) {
+            return false;
+        }
     }
 
     private static String extractCommentInstructions(String comment) {

--- a/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/survextherion/SurvexTherionImporter.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/survextherion/SurvexTherionImporter.java
@@ -44,20 +44,13 @@ public class SurvexTherionImporter {
                 continue;
             }
 
-            // Detect commented lines — single comment char followed by data fields.
-            // Double comment chars (;;/##) are promoted-from precursors consumed by
-            // parseCommentedNewLinePromotedLegs; skip them here.
+            // Detect commented splay — these are hidden-on-sketch splays.
             boolean isHiddenOnSketch = false;
             if (trimmed.startsWith(";") || trimmed.startsWith("#")) {
-                boolean isDouble = trimmed.length() > 1 && trimmed.charAt(1) == trimmed.charAt(0);
-                if (isDouble) {
-                    continue; // Double-commented precursor line — skip
-                }
                 String afterComment = trimmed.substring(1).trim();
                 String[] parts = afterComment.split("\\s+");
                 if (parts.length >= 5) {
                     // Only import as hidden if it is a splay (to == "-").
-                    // Commented-out real legs are not supported and are skipped.
                     boolean isSplayLine = parts[1].equals(SexyTopoConstants.BLANK_STATION_NAME);
                     if (isSplayLine) {
                         isHiddenOnSketch = true;
@@ -536,15 +529,8 @@ public class SurvexTherionImporter {
                 break;
             }
 
-            // Remove one or two leading comment characters.
-            // Precursors of a normal leg have one (;/#); precursors of a hidden-on-sketch
-            // leg have two (;;/##). Strip them both the same way — we just need the data.
-            String content;
-            if (line.length() > 1 && line.charAt(1) == line.charAt(0)) {
-                content = line.substring(2).trim();
-            } else {
-                content = line.substring(1).trim();
-            }
+            // Precursor lines always use a single comment char.
+            String content = line.substring(1).trim();
             String[] fields = content.split("\\s+");
 
             // Check if this is a matching shot

--- a/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/survextherion/SurvexTherionImporter.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/survextherion/SurvexTherionImporter.java
@@ -44,24 +44,30 @@ public class SurvexTherionImporter {
                 continue;
             }
 
-            // Detect hidden-on-sketch legs: a single comment char followed by 5+ data fields.
-            // Double comment chars (;;/##) are promoted-from precursors — leave those to
-            // parseCommentedNewLinePromotedLegs.
+            // Detect commented lines — single comment char followed by data fields.
+            // Double comment chars (;;/##) are promoted-from precursors consumed by
+            // parseCommentedNewLinePromotedLegs; skip them here.
             boolean isHiddenOnSketch = false;
             if (trimmed.startsWith(";") || trimmed.startsWith("#")) {
                 boolean isDouble = trimmed.length() > 1 && trimmed.charAt(1) == trimmed.charAt(0);
                 if (isDouble) {
-                    continue; // Double-commented precursor line — skip here
+                    continue; // Double-commented precursor line — skip
                 }
                 String afterComment = trimmed.substring(1).trim();
                 String[] parts = afterComment.split("\\s+");
-                if (parts.length >= 5 && looksLikeDataLine(parts)) {
-                    // Single-commented data line — a hidden-on-sketch leg
-                    isHiddenOnSketch = true;
-                    line = afterComment; // strip the leading comment char for field parsing
-                    trimmed = afterComment;
+                if (parts.length >= 5) {
+                    // Only import as hidden if it is a splay (to == "-").
+                    // Commented-out real legs are not supported and are skipped.
+                    boolean isSplayLine = parts[1].equals(SexyTopoConstants.BLANK_STATION_NAME);
+                    if (isSplayLine) {
+                        isHiddenOnSketch = true;
+                        line = afterComment;
+                        trimmed = afterComment;
+                    } else {
+                        continue; // Commented-out real leg — skip
+                    }
                 } else {
-                    continue; // Plain comment, skip
+                    continue; // Plain comment — skip
                 }
             }
 
@@ -73,8 +79,8 @@ public class SurvexTherionImporter {
 
                 // Check for commented new-line promoted legs in subsequent lines.
                 // The method returns both the legs and how many lines it consumed, so
-                // we can advance lineIndex past them and avoid re-processing them as
-                // hidden-on-sketch legs in the main loop.
+                // we can advance lineIndex past them and avoid re-processing them in
+                // the main loop.
                 CommentedNewLineResult promotedResult =
                         parseCommentedNewLinePromotedLegs(lines, lineIndex, fields[0], fields[1]);
 
@@ -466,7 +472,7 @@ public class SurvexTherionImporter {
             }
         }
 
-        leg.setHiddenOnSketch(hiddenOnSketch);
+        leg.setHiddenOnSketch(isSplay && hiddenOnSketch);
         legFrom.addOnwardLeg(leg);
         survey.addLegRecord(leg);
         survey.setActiveStation(legFrom);
@@ -563,21 +569,6 @@ public class SurvexTherionImporter {
         }
 
         return new CommentedNewLineResult(shots, linesConsumed);
-    }
-
-    /**
-     * Returns true if the first five elements of parts look like a data line: fields[0] and [1] are
-     * non-numeric (station names), fields[2..4] are floats.
-     */
-    private static boolean looksLikeDataLine(String[] parts) {
-        try {
-            Float.parseFloat(parts[2]);
-            Float.parseFloat(parts[3]);
-            Float.parseFloat(parts[4]);
-            return true;
-        } catch (NumberFormatException e) {
-            return false;
-        }
     }
 
     private static String extractCommentInstructions(String comment) {

--- a/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/survextherion/SurvexTherionImporter.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/survextherion/SurvexTherionImporter.java
@@ -44,21 +44,20 @@ public class SurvexTherionImporter {
                 continue;
             }
 
-            // Detect crossed-out legs: a single comment char followed by 5+ data fields.
+            // Detect hidden-on-sketch legs: a single comment char followed by 5+ data fields.
             // Double comment chars (;;/##) are promoted-from precursors — leave those to
             // parseCommentedNewLinePromotedLegs.
-            boolean isCrossedOut = false;
+            boolean isHiddenOnSketch = false;
             if (trimmed.startsWith(";") || trimmed.startsWith("#")) {
-                boolean isDouble = trimmed.length() > 1
-                        && trimmed.charAt(1) == trimmed.charAt(0);
+                boolean isDouble = trimmed.length() > 1 && trimmed.charAt(1) == trimmed.charAt(0);
                 if (isDouble) {
                     continue; // Double-commented precursor line — skip here
                 }
                 String afterComment = trimmed.substring(1).trim();
                 String[] parts = afterComment.split("\\s+");
                 if (parts.length >= 5 && looksLikeDataLine(parts)) {
-                    // Single-commented data line — a crossed-out leg
-                    isCrossedOut = true;
+                    // Single-commented data line — a hidden-on-sketch leg
+                    isHiddenOnSketch = true;
                     line = afterComment; // strip the leading comment char for field parsing
                     trimmed = afterComment;
                 } else {
@@ -72,12 +71,22 @@ public class SurvexTherionImporter {
 
                 String[] fields = trimmed.split("\\s+");
 
-                // Check for commented new lines promoted legs in subsequent lines
-                List<Leg> commentedNewLineLegs =
+                // Check for commented new-line promoted legs in subsequent lines.
+                // The method returns both the legs and how many lines it consumed, so
+                // we can advance lineIndex past them and avoid re-processing them as
+                // hidden-on-sketch legs in the main loop.
+                CommentedNewLineResult promotedResult =
                         parseCommentedNewLinePromotedLegs(lines, lineIndex, fields[0], fields[1]);
 
-                addLegToSurvey(survey, nameToStation, fields, comment, commentedNewLineLegs,
-                        isCrossedOut);
+                addLegToSurvey(
+                        survey,
+                        nameToStation,
+                        fields,
+                        comment,
+                        promotedResult.legs,
+                        isHiddenOnSketch);
+
+                lineIndex += promotedResult.linesConsumed;
 
             } catch (Exception exception) {
                 throw new Exception("Error importing this line: " + line);
@@ -374,7 +383,7 @@ public class SurvexTherionImporter {
             String[] fields,
             String comment,
             List<Leg> commentedNewLineLegs,
-            boolean crossedOut) {
+            boolean hiddenOnSketch) {
 
         String fromName = fields[0];
         String toName = fields[1];
@@ -457,7 +466,7 @@ public class SurvexTherionImporter {
             }
         }
 
-        leg.setCrossedOut(crossedOut);
+        leg.setHiddenOnSketch(hiddenOnSketch);
         legFrom.addOnwardLeg(leg);
         survey.addLegRecord(leg);
         survey.setActiveStation(legFrom);
@@ -495,10 +504,22 @@ public class SurvexTherionImporter {
      *
      * <p>Example: 1 2 5.541 253.93 4.67 #1 2 5.542 73.95 -4.64 #1 2 5.541 73.93 -4.69
      */
-    private static List<Leg> parseCommentedNewLinePromotedLegs(
+    /** Holds the result of parsing commented new-line promoted legs. */
+    private static class CommentedNewLineResult {
+        final List<Leg> legs;
+        final int linesConsumed;
+
+        CommentedNewLineResult(List<Leg> legs, int linesConsumed) {
+            this.legs = legs;
+            this.linesConsumed = linesConsumed;
+        }
+    }
+
+    private static CommentedNewLineResult parseCommentedNewLinePromotedLegs(
             String[] lines, int startIndex, String expectedFrom, String expectedTo) {
 
         List<Leg> shots = new ArrayList<>();
+        int linesConsumed = 0;
 
         // Look at subsequent lines
         for (int i = startIndex + 1; i < lines.length; i++) {
@@ -510,7 +531,7 @@ public class SurvexTherionImporter {
             }
 
             // Remove one or two leading comment characters.
-            // Precursors of a normal leg have one (;/# ); precursors of a crossed-out
+            // Precursors of a normal leg have one (;/#); precursors of a hidden-on-sketch
             // leg have two (;;/##). Strip them both the same way — we just need the data.
             String content;
             if (line.length() > 1 && line.charAt(1) == line.charAt(0)) {
@@ -530,8 +551,10 @@ public class SurvexTherionImporter {
                     float azimuth = Float.parseFloat(fields[3]);
                     float inclination = Float.parseFloat(fields[4]);
                     shots.add(new Leg(distance, azimuth, inclination));
+                    linesConsumed++;
                 } catch (NumberFormatException e) {
                     Log.e("Failed to parse commented new line promoted leg: " + line);
+                    break;
                 }
             } else {
                 // Different leg, stop looking
@@ -539,12 +562,12 @@ public class SurvexTherionImporter {
             }
         }
 
-        return shots;
+        return new CommentedNewLineResult(shots, linesConsumed);
     }
 
     /**
-     * Returns true if the first five elements of parts look like a data line:
-     * fields[0] and [1] are non-numeric (station names), fields[2..4] are floats.
+     * Returns true if the first five elements of parts look like a data line: fields[0] and [1] are
+     * non-numeric (station names), fields[2..4] are floats.
      */
     private static boolean looksLikeDataLine(String[] parts) {
         try {

--- a/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/survextherion/SurvexTherionUtil.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/survextherion/SurvexTherionUtil.java
@@ -182,26 +182,36 @@ public class SurvexTherionUtil {
             toName = format.getSplayStationName();
         }
 
+        // Prefix the main leg line with the comment character if it is crossed out
+        char commentChar = format.getCommentChar();
+        if (leg.isCrossedOut()) {
+            builder.append(commentChar);
+        }
+
         formatField(builder, fromName);
         formatField(builder, toName);
         formatField(builder, TableCol.DISTANCE.format(leg.getDistance(), Locale.UK));
         formatField(builder, TableCol.AZIMUTH.format(leg.getAzimuth(), Locale.UK));
         formatField(builder, TableCol.INCLINATION.format(leg.getInclination(), Locale.UK));
 
-        // Handle promoted legs - put readings on subsequent lines
+        // Handle promoted legs - put readings on subsequent lines.
+        // If the parent leg is crossed out, precursors get two comment chars instead of one.
         if (leg.wasPromoted()) {
-            char commentChar = format.getCommentChar();
+            String precursorPrefix = leg.isCrossedOut()
+                    ? String.valueOf(commentChar) + commentChar
+                    : String.valueOf(commentChar);
             Leg[] precursors = leg.getPromotedFrom();
             for (Leg precursor : precursors) {
                 builder.append("\n");
-                builder.append(commentChar);
+                builder.append(precursorPrefix);
                 builder.append(fromName).append("\t");
                 builder.append(toName).append("\t");
                 builder.append(TableCol.DISTANCE.format(precursor.getDistance(), Locale.UK))
                         .append("\t");
                 builder.append(TableCol.AZIMUTH.format(precursor.getAzimuth(), Locale.UK))
                         .append("\t");
-                builder.append(TableCol.INCLINATION.format(precursor.getInclination(), Locale.UK));
+                builder.append(
+                        TableCol.INCLINATION.format(precursor.getInclination(), Locale.UK));
             }
         }
     }

--- a/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/survextherion/SurvexTherionUtil.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/survextherion/SurvexTherionUtil.java
@@ -182,7 +182,6 @@ public class SurvexTherionUtil {
             toName = format.getSplayStationName();
         }
 
-        // Prefix the main leg line with the comment character if it is hidden on sketch
         char commentChar = format.getCommentChar();
         if (leg.isHiddenOnSketch()) {
             builder.append(commentChar);
@@ -195,16 +194,12 @@ public class SurvexTherionUtil {
         formatField(builder, TableCol.INCLINATION.format(leg.getInclination(), Locale.UK));
 
         // Handle promoted legs - put readings on subsequent lines.
-        // If the parent leg is hidden on sketch, precursors get two comment chars instead of one.
+        // Precursor lines always use a single comment char.
         if (leg.wasPromoted()) {
-            String precursorPrefix =
-                    leg.isHiddenOnSketch()
-                            ? String.valueOf(commentChar) + commentChar
-                            : String.valueOf(commentChar);
             Leg[] precursors = leg.getPromotedFrom();
             for (Leg precursor : precursors) {
                 builder.append("\n");
-                builder.append(precursorPrefix);
+                builder.append(commentChar);
                 builder.append(fromName).append("\t");
                 builder.append(toName).append("\t");
                 builder.append(TableCol.DISTANCE.format(precursor.getDistance(), Locale.UK))

--- a/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/survextherion/SurvexTherionUtil.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/survextherion/SurvexTherionUtil.java
@@ -182,9 +182,9 @@ public class SurvexTherionUtil {
             toName = format.getSplayStationName();
         }
 
-        // Prefix the main leg line with the comment character if it is crossed out
+        // Prefix the main leg line with the comment character if it is hidden on sketch
         char commentChar = format.getCommentChar();
-        if (leg.isCrossedOut()) {
+        if (leg.isHiddenOnSketch()) {
             builder.append(commentChar);
         }
 
@@ -195,11 +195,12 @@ public class SurvexTherionUtil {
         formatField(builder, TableCol.INCLINATION.format(leg.getInclination(), Locale.UK));
 
         // Handle promoted legs - put readings on subsequent lines.
-        // If the parent leg is crossed out, precursors get two comment chars instead of one.
+        // If the parent leg is hidden on sketch, precursors get two comment chars instead of one.
         if (leg.wasPromoted()) {
-            String precursorPrefix = leg.isCrossedOut()
-                    ? String.valueOf(commentChar) + commentChar
-                    : String.valueOf(commentChar);
+            String precursorPrefix =
+                    leg.isHiddenOnSketch()
+                            ? String.valueOf(commentChar) + commentChar
+                            : String.valueOf(commentChar);
             Leg[] precursors = leg.getPromotedFrom();
             for (Leg precursor : precursors) {
                 builder.append("\n");
@@ -210,8 +211,7 @@ public class SurvexTherionUtil {
                         .append("\t");
                 builder.append(TableCol.AZIMUTH.format(precursor.getAzimuth(), Locale.UK))
                         .append("\t");
-                builder.append(
-                        TableCol.INCLINATION.format(precursor.getInclination(), Locale.UK));
+                builder.append(TableCol.INCLINATION.format(precursor.getInclination(), Locale.UK));
             }
         }
     }

--- a/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/therion/TherionImporter.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/therion/TherionImporter.java
@@ -110,6 +110,11 @@ public class TherionImporter extends Importer {
 
             if (trimmed.startsWith("extend")) {
                 sanitisedElevationDirectionData.add(trimmed);
+            } else if (trimmed.startsWith("#") || trimmed.startsWith(";")) {
+                // Pass through single-commented lines that look like crossed-out data legs,
+                // and double-commented precursor lines for crossed-out promoted legs.
+                // parseCentreline will decide what to do with each.
+                sanitisedCentrelineData.add(trimmed);
             } else {
                 sanitisedCentrelineData.add(trimmed);
             }

--- a/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/therion/TherionImporter.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/therion/TherionImporter.java
@@ -110,10 +110,8 @@ public class TherionImporter extends Importer {
 
             if (trimmed.startsWith("extend")) {
                 sanitisedElevationDirectionData.add(trimmed);
-            } else if (trimmed.startsWith("#") || trimmed.startsWith(";")) {
-                // Pass through single-commented lines that look like crossed-out data legs,
-                // and double-commented precursor lines for crossed-out promoted legs.
-                // parseCentreline will decide what to do with each.
+            } else if (trimmed.startsWith(String.valueOf(SurveyFormat.THERION.getCommentChar()))) {
+                // Pass through comment lines; parseCentreline will handle hidden-on-sketch splays.
                 sanitisedCentrelineData.add(trimmed);
             } else {
                 sanitisedCentrelineData.add(trimmed);

--- a/app/src/main/java/org/hwyl/sexytopo/control/table/TableRowAdapter.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/table/TableRowAdapter.java
@@ -1,6 +1,7 @@
 package org.hwyl.sexytopo.control.table;
 
 import android.content.Context;
+import android.graphics.Paint;
 import android.graphics.Typeface;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -149,6 +150,13 @@ public class TableRowAdapter extends RecyclerView.Adapter<TableRowAdapter.TableR
                 textView.setTypeface(Typeface.DEFAULT_BOLD);
             } else {
                 textView.setTypeface(Typeface.DEFAULT);
+            }
+
+            // Strikethrough for crossed-out legs
+            if (entry.getLeg().isCrossedOut()) {
+                textView.setPaintFlags(textView.getPaintFlags() | Paint.STRIKE_THRU_TEXT_FLAG);
+            } else {
+                textView.setPaintFlags(textView.getPaintFlags() & ~Paint.STRIKE_THRU_TEXT_FLAG);
             }
 
             // Set alignment based on column type

--- a/app/src/main/java/org/hwyl/sexytopo/control/table/TableRowAdapter.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/table/TableRowAdapter.java
@@ -152,8 +152,8 @@ public class TableRowAdapter extends RecyclerView.Adapter<TableRowAdapter.TableR
                 textView.setTypeface(Typeface.DEFAULT);
             }
 
-            // Strikethrough for crossed-out legs
-            if (entry.getLeg().isCrossedOut()) {
+            // Strikethrough for legs hidden on sketch
+            if (entry.getLeg().isHiddenOnSketch()) {
                 textView.setPaintFlags(textView.getPaintFlags() | Paint.STRIKE_THRU_TEXT_FLAG);
             } else {
                 textView.setPaintFlags(textView.getPaintFlags() & ~Paint.STRIKE_THRU_TEXT_FLAG);

--- a/app/src/main/java/org/hwyl/sexytopo/control/util/Space3DTransformer.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/util/Space3DTransformer.java
@@ -30,6 +30,15 @@ public class Space3DTransformer {
     }
 
     protected synchronized void update(Space<Coord3D> space, Leg leg, Coord3D start) {
+        if (leg.isCrossedOut()) {
+            // Don't add the leg to the graph, but still traverse connected stations
+            // so the rest of the survey tree remains reachable (destination plots at
+            // the same position as the originating station)
+            if (leg.hasDestination()) {
+                update(space, leg.getDestination(), start);
+            }
+            return;
+        }
         Coord3D end = transform(start, leg);
         Line<Coord3D> line = new Line<>(start, end);
         space.addLeg(leg, line);

--- a/app/src/main/java/org/hwyl/sexytopo/control/util/Space3DTransformer.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/util/Space3DTransformer.java
@@ -30,7 +30,7 @@ public class Space3DTransformer {
     }
 
     protected synchronized void update(Space<Coord3D> space, Leg leg, Coord3D start) {
-        if (leg.isCrossedOut()) {
+        if (leg.isHiddenOnSketch()) {
             // Don't add the leg to the graph, but still traverse connected stations
             // so the rest of the survey tree remains reachable (destination plots at
             // the same position as the originating station)

--- a/app/src/main/java/org/hwyl/sexytopo/control/util/Space3DTransformer.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/util/Space3DTransformer.java
@@ -30,15 +30,6 @@ public class Space3DTransformer {
     }
 
     protected synchronized void update(Space<Coord3D> space, Leg leg, Coord3D start) {
-        if (leg.isHiddenOnSketch()) {
-            // Don't add the leg to the graph, but still traverse connected stations
-            // so the rest of the survey tree remains reachable (destination plots at
-            // the same position as the originating station)
-            if (leg.hasDestination()) {
-                update(space, leg.getDestination(), start);
-            }
-            return;
-        }
         Coord3D end = transform(start, leg);
         Line<Coord3D> line = new Line<>(start, end);
         space.addLeg(leg, line);

--- a/app/src/main/java/org/hwyl/sexytopo/control/util/SurveyUpdater.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/util/SurveyUpdater.java
@@ -88,6 +88,7 @@ public class SurveyUpdater {
         Station newStation = new Station(getNextStationName(survey));
 
         Leg newLeg = Leg.toFullLeg(leg, newStation);
+        newLeg.setHiddenOnSketch(false);
 
         if (inputMode == InputMode.BACKWARD) {
             newLeg = newLeg.reverse();
@@ -147,8 +148,11 @@ public class SurveyUpdater {
                         Arrays.asList(leg.wasPromoted() ? leg.getPromotedFrom() : new Leg[] {leg}));
         allShots.add(splay);
 
-        return Leg.upgradeSplayToConnectedLeg(
-                averageLegs(allShots), leg.getDestination(), allShots.toArray(new Leg[0]));
+        Leg result =
+                Leg.upgradeSplayToConnectedLeg(
+                        averageLegs(allShots), leg.getDestination(), allShots.toArray(new Leg[0]));
+        result.setHiddenOnSketch(false);
+        return result;
     }
 
     private static synchronized String getNextStationName(Survey survey) {

--- a/app/src/main/java/org/hwyl/sexytopo/model/graph/Space.java
+++ b/app/src/main/java/org/hwyl/sexytopo/model/graph/Space.java
@@ -25,6 +25,7 @@ public class Space<T extends Coord> {
         legs.put(leg, line);
     }
 
+    @SuppressWarnings("unchecked")
     public Space<T> scale(float scale) {
 
         Space<T> scaled = new Space<>();

--- a/app/src/main/java/org/hwyl/sexytopo/model/survey/Leg.java
+++ b/app/src/main/java/org/hwyl/sexytopo/model/survey/Leg.java
@@ -19,6 +19,7 @@ public class Leg extends SurveyComponent {
     private final Station destination;
     private final Leg[] promotedFrom;
     private final boolean wasShotBackwards;
+    private boolean crossedOut = false;
 
     private static final Leg[] NO_LEGS = new Leg[] {};
 
@@ -199,6 +200,14 @@ public class Leg extends SurveyComponent {
 
     public static boolean isInclinationLegal(float inclination) {
         return MIN_INCLINATION <= inclination && inclination <= MAX_INCLINATION;
+    }
+
+    public boolean isCrossedOut() {
+        return crossedOut;
+    }
+
+    public void setCrossedOut(boolean crossedOut) {
+        this.crossedOut = crossedOut;
     }
 
     @NonNull

--- a/app/src/main/java/org/hwyl/sexytopo/model/survey/Leg.java
+++ b/app/src/main/java/org/hwyl/sexytopo/model/survey/Leg.java
@@ -19,7 +19,7 @@ public class Leg extends SurveyComponent {
     private final Station destination;
     private final Leg[] promotedFrom;
     private final boolean wasShotBackwards;
-    private boolean crossedOut = false;
+    private boolean hiddenOnSketch = false;
 
     private static final Leg[] NO_LEGS = new Leg[] {};
 
@@ -202,12 +202,12 @@ public class Leg extends SurveyComponent {
         return MIN_INCLINATION <= inclination && inclination <= MAX_INCLINATION;
     }
 
-    public boolean isCrossedOut() {
-        return crossedOut;
+    public boolean isHiddenOnSketch() {
+        return hiddenOnSketch;
     }
 
-    public void setCrossedOut(boolean crossedOut) {
-        this.crossedOut = crossedOut;
+    public void setHiddenOnSketch(boolean hiddenOnSketch) {
+        this.hiddenOnSketch = hiddenOnSketch;
     }
 
     @NonNull

--- a/app/src/main/java/org/hwyl/sexytopo/testutils/SurveyChecker.java
+++ b/app/src/main/java/org/hwyl/sexytopo/testutils/SurveyChecker.java
@@ -63,6 +63,9 @@ public class SurveyChecker {
             if (!oneLegs.get(i).toString().equals(twoLegs.get(i).toString())) {
                 return false;
             }
+            if (oneLegs.get(i).isCrossedOut() != twoLegs.get(i).isCrossedOut()) {
+                return false;
+            }
         }
 
         return true;

--- a/app/src/main/java/org/hwyl/sexytopo/testutils/SurveyChecker.java
+++ b/app/src/main/java/org/hwyl/sexytopo/testutils/SurveyChecker.java
@@ -63,7 +63,7 @@ public class SurveyChecker {
             if (!oneLegs.get(i).toString().equals(twoLegs.get(i).toString())) {
                 return false;
             }
-            if (oneLegs.get(i).isCrossedOut() != twoLegs.get(i).isCrossedOut()) {
+            if (oneLegs.get(i).isHiddenOnSketch() != twoLegs.get(i).isHiddenOnSketch()) {
                 return false;
             }
         }

--- a/app/src/main/res/menu/context_leg.xml
+++ b/app/src/main/res/menu/context_leg.xml
@@ -28,6 +28,10 @@
             android:visible="false"/>
 
         <item
+            android:id="@+id/action_cross_out_leg"
+            android:title="@string/menu_cross_out"/>
+
+        <item
             android:id="@+id/action_downgrade_leg"
             android:title="@string/menu_downgrade_leg"
             android:visible="false"/>

--- a/app/src/main/res/menu/context_leg.xml
+++ b/app/src/main/res/menu/context_leg.xml
@@ -29,7 +29,8 @@
 
         <item
             android:id="@+id/action_cross_out_leg"
-            android:title="@string/menu_cross_out"/>
+            android:title="@string/menu_hide_on_sketches"
+            android:checkable="true"/>
 
         <item
             android:id="@+id/action_downgrade_leg"

--- a/app/src/main/res/menu/context_leg.xml
+++ b/app/src/main/res/menu/context_leg.xml
@@ -28,7 +28,7 @@
             android:visible="false"/>
 
         <item
-            android:id="@+id/action_cross_out_leg"
+            android:id="@+id/action_hide_on_sketch_leg"
             android:title="@string/menu_hide_on_sketches"
             android:checkable="true"/>
 

--- a/app/src/main/res/menu/context_leg.xml
+++ b/app/src/main/res/menu/context_leg.xml
@@ -28,14 +28,14 @@
             android:visible="false"/>
 
         <item
-            android:id="@+id/action_hide_on_sketch_leg"
-            android:title="@string/menu_hide_on_sketches"
-            android:checkable="true"/>
-
-        <item
             android:id="@+id/action_downgrade_leg"
             android:title="@string/menu_downgrade_leg"
             android:visible="false"/>
+
+        <item
+            android:id="@+id/action_hide_on_sketch_leg"
+            android:title="@string/menu_hide_on_sketches"
+            android:checkable="true"/>
     </group>
 
     <!-- Delete leg separated by divider -->

--- a/app/src/main/res/values-b+fr/strings.xml
+++ b/app/src/main/res/values-b+fr/strings.xml
@@ -578,6 +578,7 @@
     <string name="menu_edit_leg">Modifier</string>
     <string name="menu_upgrade_row">Forcer une nouvelle station</string>
     <string name="menu_promote_to_above_leg">Ajouter à la visée ci-dessus</string>
+    <string name="menu_hide_on_sketches">Masquer sur les croquis</string>
     <string name="toast_splay_promoted">Radiale combinée avec la visée</string>
     <string name="toast_no_leg_above">Aucune visée valide à combiner</string>
     <string name="menu_upgrade_splay">Convertir en visée directionnelle</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -576,6 +576,7 @@
     <string name="menu_edit_leg">Bearbeiten</string>
     <string name="menu_upgrade_row">Neuen Messpunkt erzwingen</string>
     <string name="menu_promote_to_above_leg">Zur obigen Messung hinzufügen</string>
+    <string name="menu_hide_on_sketches">In Skizzen ausblenden</string>
     <string name="toast_splay_promoted">Splay mit Messung kombiniert</string>
     <string name="toast_no_leg_above">Keine gültige Messung zum Kombinieren</string>
     <string name="menu_upgrade_splay">Zu Messstrecke aufwerten</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -576,6 +576,7 @@
     <string name="menu_edit_leg">Editar</string>
     <string name="menu_upgrade_row">Forzar Nueva Estación</string>
     <string name="menu_promote_to_above_leg">Añadir al tramo superior</string>
+    <string name="menu_hide_on_sketches">Ocultar en croquis</string>
     <string name="toast_splay_promoted">Radial combinada con tramo</string>
     <string name="toast_no_leg_above">No hay tramo válido para combinar</string>
     <string name="menu_upgrade_splay">Promover a Tramo</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -576,6 +576,7 @@
     <string name="menu_edit_leg">Modifica</string>
     <string name="menu_upgrade_row">Forza Nuova Stazione</string>
     <string name="menu_promote_to_above_leg">Aggiungi al tratto sopra</string>
+    <string name="menu_hide_on_sketches">Nascondi negli schizzi</string>
     <string name="toast_splay_promoted">Splay combinato con il tratto</string>
     <string name="toast_no_leg_above">Nessun tratto valido da combinare</string>
     <string name="menu_upgrade_splay">Promuovi a Tratto</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -576,6 +576,7 @@
     <string name="menu_edit_leg">Edytuj</string>
     <string name="menu_upgrade_row">Wymuś nowe stanowisko</string>
     <string name="menu_promote_to_above_leg">Dodaj do ciągu powyżej</string>
+    <string name="menu_hide_on_sketches">Ukryj na szkicach</string>
     <string name="toast_splay_promoted">Pomiar szczegółowy połączony z ciągiem</string>
     <string name="toast_no_leg_above">Brak prawidłowego ciągu do połączenia</string>
     <string name="menu_upgrade_splay">Podnieś do ciągu</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -576,6 +576,7 @@
     <string name="menu_edit_leg">Editar</string>
     <string name="menu_upgrade_row">Forçar Nova Estação</string>
     <string name="menu_promote_to_above_leg">Adicionar ao trecho acima</string>
+    <string name="menu_hide_on_sketches">Ocultar nos esboços</string>
     <string name="toast_splay_promoted">Raio combinado com trecho</string>
     <string name="toast_no_leg_above">Nenhum trecho válido para combinar</string>
     <string name="menu_upgrade_splay">Promover a Trecho</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -609,6 +609,8 @@
     <string name="menu_edit_leg">Edit</string>
     <string name="menu_upgrade_row">Force New Station</string>
     <string name="menu_promote_to_above_leg">Add to Leg Above</string>
+    <string name="menu_cross_out">Cross Out</string>
+    <string name="menu_uncross_out">Uncross Out</string>
     <string name="toast_splay_promoted">Splay combined with leg</string>
     <string name="toast_no_leg_above">No valid leg to combine with</string>
     <string name="menu_upgrade_splay">Upgrade to Leg</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -609,8 +609,7 @@
     <string name="menu_edit_leg">Edit</string>
     <string name="menu_upgrade_row">Force New Station</string>
     <string name="menu_promote_to_above_leg">Add to Leg Above</string>
-    <string name="menu_cross_out">Cross Out</string>
-    <string name="menu_uncross_out">Uncross Out</string>
+    <string name="menu_hide_on_sketches">Hide on Sketches</string>
     <string name="toast_splay_promoted">Splay combined with leg</string>
     <string name="toast_no_leg_above">No valid leg to combine with</string>
     <string name="menu_upgrade_splay">Upgrade to Leg</string>

--- a/app/src/test/java/org/hwyl/sexytopo/control/graph/ContextMenuManagerHideOnSketchTest.java
+++ b/app/src/test/java/org/hwyl/sexytopo/control/graph/ContextMenuManagerHideOnSketchTest.java
@@ -1,0 +1,50 @@
+package org.hwyl.sexytopo.control.graph;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.hwyl.sexytopo.model.survey.Leg;
+import org.junit.Test;
+
+public class ContextMenuManagerHideOnSketchTest {
+
+    private static Leg createLeg() {
+        return new Leg(1.0f, 0.0f, 0.0f);
+    }
+
+    @Test
+    public void testLegIsNotHiddenOnSketchByDefault() {
+        Leg leg = createLeg();
+        assertFalse(leg.isHiddenOnSketch());
+    }
+
+    @Test
+    public void testSettingHiddenOnSketchToTrueReflectsInGetter() {
+        Leg leg = createLeg();
+        leg.setHiddenOnSketch(true);
+        assertTrue(leg.isHiddenOnSketch());
+    }
+
+    @Test
+    public void testSettingHiddenOnSketchToFalseReflectsInGetter() {
+        Leg leg = createLeg();
+        leg.setHiddenOnSketch(true);
+        leg.setHiddenOnSketch(false);
+        assertFalse(leg.isHiddenOnSketch());
+    }
+
+    @Test
+    public void testTogglingHiddenOnSketchFromFalseToTrue() {
+        Leg leg = createLeg();
+        leg.setHiddenOnSketch(!leg.isHiddenOnSketch());
+        assertTrue(leg.isHiddenOnSketch());
+    }
+
+    @Test
+    public void testTogglingHiddenOnSketchFromTrueToFalse() {
+        Leg leg = createLeg();
+        leg.setHiddenOnSketch(true);
+        leg.setHiddenOnSketch(!leg.isHiddenOnSketch());
+        assertFalse(leg.isHiddenOnSketch());
+    }
+}

--- a/app/src/test/java/org/hwyl/sexytopo/control/io/basic/SurveyJsonTranslaterTest.java
+++ b/app/src/test/java/org/hwyl/sexytopo/control/io/basic/SurveyJsonTranslaterTest.java
@@ -1,9 +1,11 @@
 package org.hwyl.sexytopo.control.io.basic;
 
+import org.hwyl.sexytopo.model.survey.Leg;
 import org.hwyl.sexytopo.model.survey.Survey;
 import org.hwyl.sexytopo.testutils.BasicTestSurveyCreator;
 import org.hwyl.sexytopo.testutils.ExampleSurveyCreator;
 import org.hwyl.sexytopo.testutils.SurveyChecker;
+import org.junit.Assert;
 import org.junit.Test;
 
 public class SurveyJsonTranslaterTest {
@@ -60,5 +62,52 @@ public class SurveyJsonTranslaterTest {
         SurveyJsonTranslater.populateSurvey(survey, text);
 
         SurveyChecker.areEqual(survey, newSurvey);
+    }
+
+    @Test
+    public void testCrossedOutLegIsPreservedInRoundTrip() throws Exception {
+        Survey survey = BasicTestSurveyCreator.createStraightNorth();
+        Leg legToCrossOut = survey.getAllLegs().get(0);
+        legToCrossOut.setCrossedOut(true);
+
+        String text = SurveyJsonTranslater.toText(survey, "test", 0);
+
+        Survey reloaded = new Survey();
+        SurveyJsonTranslater.populateSurvey(reloaded, text);
+
+        Leg reloadedLeg = reloaded.getAllLegs().get(0);
+        Assert.assertTrue(reloadedLeg.isCrossedOut());
+    }
+
+    @Test
+    public void testUncrossedLegIsPreservedInRoundTrip() throws Exception {
+        Survey survey = BasicTestSurveyCreator.createStraightNorth();
+        // All legs default to not crossed out
+        String text = SurveyJsonTranslater.toText(survey, "test", 0);
+
+        Survey reloaded = new Survey();
+        SurveyJsonTranslater.populateSurvey(reloaded, text);
+
+        for (Leg leg : reloaded.getAllLegs()) {
+            Assert.assertFalse(leg.isCrossedOut());
+        }
+    }
+
+    @Test
+    public void testLegMissingIsCrossedOutFieldDefaultsFalse() throws Exception {
+        // Simulates loading an old file that predates the isCrossedOut field
+        String oldJson = "{\"versionName\":\"test\",\"versionCode\":0,\"name\":\"Unsaved Survey\","
+                + "\"stations\":[{\"name\":\"0\",\"eeDirection\":\"right\",\"comment\":\"\","
+                + "\"legs\":[{\"distance\":5.0,\"azimuth\":0.0,\"inclination\":0.0,"
+                + "\"destination\":\"1\",\"wasShotBackwards\":false,\"index\":0,"
+                + "\"promotedFrom\":[]}]},"
+                + "{\"name\":\"1\",\"eeDirection\":\"right\",\"comment\":\"\",\"legs\":[]}]}";
+
+        Survey survey = new Survey();
+        SurveyJsonTranslater.populateSurvey(survey, oldJson);
+
+        for (Leg leg : survey.getAllLegs()) {
+            Assert.assertFalse(leg.isCrossedOut());
+        }
     }
 }

--- a/app/src/test/java/org/hwyl/sexytopo/control/io/basic/SurveyJsonTranslaterTest.java
+++ b/app/src/test/java/org/hwyl/sexytopo/control/io/basic/SurveyJsonTranslaterTest.java
@@ -65,10 +65,10 @@ public class SurveyJsonTranslaterTest {
     }
 
     @Test
-    public void testCrossedOutLegIsPreservedInRoundTrip() throws Exception {
+    public void testHiddenOnSketchLegIsPreservedInRoundTrip() throws Exception {
         Survey survey = BasicTestSurveyCreator.createStraightNorth();
-        Leg legToCrossOut = survey.getAllLegs().get(0);
-        legToCrossOut.setCrossedOut(true);
+        Leg legToHideOnSketch = survey.getAllLegs().get(0);
+        legToHideOnSketch.setHiddenOnSketch(true);
 
         String text = SurveyJsonTranslater.toText(survey, "test", 0);
 
@@ -76,38 +76,39 @@ public class SurveyJsonTranslaterTest {
         SurveyJsonTranslater.populateSurvey(reloaded, text);
 
         Leg reloadedLeg = reloaded.getAllLegs().get(0);
-        Assert.assertTrue(reloadedLeg.isCrossedOut());
+        Assert.assertTrue(reloadedLeg.isHiddenOnSketch());
     }
 
     @Test
-    public void testUncrossedLegIsPreservedInRoundTrip() throws Exception {
+    public void testVisibleOnSketchLegIsPreservedInRoundTrip() throws Exception {
         Survey survey = BasicTestSurveyCreator.createStraightNorth();
-        // All legs default to not crossed out
+        // All legs default to not hidden on sketch
         String text = SurveyJsonTranslater.toText(survey, "test", 0);
 
         Survey reloaded = new Survey();
         SurveyJsonTranslater.populateSurvey(reloaded, text);
 
         for (Leg leg : reloaded.getAllLegs()) {
-            Assert.assertFalse(leg.isCrossedOut());
+            Assert.assertFalse(leg.isHiddenOnSketch());
         }
     }
 
     @Test
-    public void testLegMissingIsCrossedOutFieldDefaultsFalse() throws Exception {
-        // Simulates loading an old file that predates the isCrossedOut field
-        String oldJson = "{\"versionName\":\"test\",\"versionCode\":0,\"name\":\"Unsaved Survey\","
-                + "\"stations\":[{\"name\":\"0\",\"eeDirection\":\"right\",\"comment\":\"\","
-                + "\"legs\":[{\"distance\":5.0,\"azimuth\":0.0,\"inclination\":0.0,"
-                + "\"destination\":\"1\",\"wasShotBackwards\":false,\"index\":0,"
-                + "\"promotedFrom\":[]}]},"
-                + "{\"name\":\"1\",\"eeDirection\":\"right\",\"comment\":\"\",\"legs\":[]}]}";
+    public void testLegMissingIsHiddenOnSketchFieldDefaultsFalse() throws Exception {
+        // Simulates loading an old file that predates the isHiddenOnSketch field
+        String oldJson =
+                "{\"versionName\":\"test\",\"versionCode\":0,\"name\":\"Unsaved Survey\","
+                    + "\"stations\":[{\"name\":\"0\",\"eeDirection\":\"right\",\"comment\":\"\","
+                    + "\"legs\":[{\"distance\":5.0,\"azimuth\":0.0,\"inclination\":0.0,"
+                    + "\"destination\":\"1\",\"wasShotBackwards\":false,\"index\":0,"
+                    + "\"promotedFrom\":[]}]},"
+                    + "{\"name\":\"1\",\"eeDirection\":\"right\",\"comment\":\"\",\"legs\":[]}]}";
 
         Survey survey = new Survey();
         SurveyJsonTranslater.populateSurvey(survey, oldJson);
 
         for (Leg leg : survey.getAllLegs()) {
-            Assert.assertFalse(leg.isCrossedOut());
+            Assert.assertFalse(leg.isHiddenOnSketch());
         }
     }
 }

--- a/app/src/test/java/org/hwyl/sexytopo/control/io/basic/SurveyJsonTranslaterTest.java
+++ b/app/src/test/java/org/hwyl/sexytopo/control/io/basic/SurveyJsonTranslaterTest.java
@@ -1,5 +1,6 @@
 package org.hwyl.sexytopo.control.io.basic;
 
+import java.util.List;
 import org.hwyl.sexytopo.model.survey.Leg;
 import org.hwyl.sexytopo.model.survey.Survey;
 import org.hwyl.sexytopo.testutils.BasicTestSurveyCreator;
@@ -65,50 +66,24 @@ public class SurveyJsonTranslaterTest {
     }
 
     @Test
-    public void testHiddenOnSketchLegIsPreservedInRoundTrip() throws Exception {
+    public void testHiddenOnSketchSplayIsPreservedInRoundTrip() throws Exception {
         Survey survey = BasicTestSurveyCreator.createStraightNorth();
-        Leg legToHideOnSketch = survey.getAllLegs().get(0);
-        legToHideOnSketch.setHiddenOnSketch(true);
+        // Add a hidden-on-sketch splay at the origin
+        Leg splay = new Leg(3.0f, 90.0f, 0.0f);
+        splay.setHiddenOnSketch(true);
+        survey.getOrigin().addOnwardLeg(splay);
+        survey.addLegRecord(splay);
 
         String text = SurveyJsonTranslater.toText(survey, "test", 0);
 
         Survey reloaded = new Survey();
         SurveyJsonTranslater.populateSurvey(reloaded, text);
 
-        Leg reloadedLeg = reloaded.getAllLegs().get(0);
-        Assert.assertTrue(reloadedLeg.isHiddenOnSketch());
-    }
-
-    @Test
-    public void testVisibleOnSketchLegIsPreservedInRoundTrip() throws Exception {
-        Survey survey = BasicTestSurveyCreator.createStraightNorth();
-        // All legs default to not hidden on sketch
-        String text = SurveyJsonTranslater.toText(survey, "test", 0);
-
-        Survey reloaded = new Survey();
-        SurveyJsonTranslater.populateSurvey(reloaded, text);
-
-        for (Leg leg : reloaded.getAllLegs()) {
-            Assert.assertFalse(leg.isHiddenOnSketch());
-        }
-    }
-
-    @Test
-    public void testLegMissingIsHiddenOnSketchFieldDefaultsFalse() throws Exception {
-        // Simulates loading an old file that predates the isHiddenOnSketch field
-        String oldJson =
-                "{\"versionName\":\"test\",\"versionCode\":0,\"name\":\"Unsaved Survey\","
-                    + "\"stations\":[{\"name\":\"0\",\"eeDirection\":\"right\",\"comment\":\"\","
-                    + "\"legs\":[{\"distance\":5.0,\"azimuth\":0.0,\"inclination\":0.0,"
-                    + "\"destination\":\"1\",\"wasShotBackwards\":false,\"index\":0,"
-                    + "\"promotedFrom\":[]}]},"
-                    + "{\"name\":\"1\",\"eeDirection\":\"right\",\"comment\":\"\",\"legs\":[]}]}";
-
-        Survey survey = new Survey();
-        SurveyJsonTranslater.populateSurvey(survey, oldJson);
-
-        for (Leg leg : survey.getAllLegs()) {
-            Assert.assertFalse(leg.isHiddenOnSketch());
-        }
+        List<Leg> reloadedSplays =
+                reloaded.getAllLegsInChronoOrder().stream()
+                        .filter(l -> !l.hasDestination())
+                        .collect(java.util.stream.Collectors.toList());
+        Assert.assertEquals(1, reloadedSplays.size());
+        Assert.assertTrue(reloadedSplays.get(0).isHiddenOnSketch());
     }
 }

--- a/app/src/test/java/org/hwyl/sexytopo/control/io/thirdparty/survex/SurvexExporterTest.java
+++ b/app/src/test/java/org/hwyl/sexytopo/control/io/thirdparty/survex/SurvexExporterTest.java
@@ -2,6 +2,8 @@ package org.hwyl.sexytopo.control.io.thirdparty.survex;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
+import org.hwyl.sexytopo.model.survey.Leg;
 import org.hwyl.sexytopo.model.survey.Station;
 import org.hwyl.sexytopo.model.survey.Survey;
 import org.hwyl.sexytopo.model.survey.Trip;
@@ -76,6 +78,57 @@ public class SurvexExporterTest {
         Trip trip = createTripWithTeam(entry("Fido", Trip.Role.DOG));
         String result = SurvexExporter.formatTeamLines(trip);
         Assert.assertTrue(result.contains("assistant"));
+    }
+
+    @Test
+    public void testCrossedOutLegIsCommentedOut() {
+        SurvexExporter exporter = new SurvexExporter();
+        Survey survey = BasicTestSurveyCreator.createStraightNorth();
+        survey.getAllLegs().get(0).setCrossedOut(true);
+        String content = exporter.getContent(survey);
+        Assert.assertTrue(content.contains(";0\t1\t5.000\t0.00\t0.00"));
+    }
+
+    @Test
+    public void testUncrossedLegIsNotCommentedOut() {
+        SurvexExporter exporter = new SurvexExporter();
+        Survey survey = BasicTestSurveyCreator.createStraightNorth();
+        String content = exporter.getContent(survey);
+        // Data lines must not start with the comment char (allow for leading whitespace or tabs)
+        for (String line : content.split("\n")) {
+            String trimmed = line.trim();
+            if (trimmed.startsWith("0\t") || trimmed.startsWith("1\t")
+                    || trimmed.startsWith("2\t") || trimmed.startsWith("3\t")) {
+                Assert.assertFalse("Data line should not be commented: " + line,
+                        line.trim().startsWith(";"));
+            }
+        }
+    }
+
+    @Test
+    public void testCrossedOutSplayIsCommentedOut() {
+        SurvexExporter exporter = new SurvexExporter();
+        Survey survey = BasicTestSurveyCreator.create5MEast();
+        List<Leg> legs = survey.getAllLegs();
+        Leg splay = legs.get(legs.size() - 1);
+        splay.setCrossedOut(true);
+        String content = exporter.getContent(survey);
+        Assert.assertTrue(content.contains(";"));
+    }
+
+    @Test
+    public void testCrossedOutPromotedLegHasDoublySemicolonPrecursors() {
+        SurvexExporter exporter = new SurvexExporter();
+        Survey survey = BasicTestSurveyCreator.createStraightNorthThroughRepeats();
+        for (Leg leg : survey.getAllLegs()) {
+            if (leg.wasPromoted()) {
+                leg.setCrossedOut(true);
+                break;
+            }
+        }
+        String content = exporter.getContent(survey);
+        Assert.assertTrue("Crossed-out promoted leg should have ;; precursor lines",
+                content.contains(";;"));
     }
 
     private static Trip.TeamEntry entry(String name, Trip.Role... roles) {

--- a/app/src/test/java/org/hwyl/sexytopo/control/io/thirdparty/survex/SurvexExporterTest.java
+++ b/app/src/test/java/org/hwyl/sexytopo/control/io/thirdparty/survex/SurvexExporterTest.java
@@ -81,12 +81,12 @@ public class SurvexExporterTest {
     }
 
     @Test
-    public void testCrossedOutLegIsCommentedOut() {
+    public void testHiddenOnSketchLegIsCommentedOut() {
         SurvexExporter exporter = new SurvexExporter();
         Survey survey = BasicTestSurveyCreator.createStraightNorth();
-        survey.getAllLegs().get(0).setCrossedOut(true);
+        survey.getAllLegs().get(0).setHiddenOnSketch(true);
         String content = exporter.getContent(survey);
-        Assert.assertTrue(content.contains(";0\t1\t5.000\t0.00\t0.00"));
+        Assert.assertTrue(content.contains(";1\t2\t5.000\t0.00\t0.00"));
     }
 
     @Test
@@ -97,37 +97,40 @@ public class SurvexExporterTest {
         // Data lines must not start with the comment char (allow for leading whitespace or tabs)
         for (String line : content.split("\n")) {
             String trimmed = line.trim();
-            if (trimmed.startsWith("0\t") || trimmed.startsWith("1\t")
-                    || trimmed.startsWith("2\t") || trimmed.startsWith("3\t")) {
-                Assert.assertFalse("Data line should not be commented: " + line,
-                        line.trim().startsWith(";"));
+            if (trimmed.startsWith("0\t")
+                    || trimmed.startsWith("1\t")
+                    || trimmed.startsWith("2\t")
+                    || trimmed.startsWith("3\t")) {
+                Assert.assertFalse(
+                        "Data line should not be commented: " + line, line.trim().startsWith(";"));
             }
         }
     }
 
     @Test
-    public void testCrossedOutSplayIsCommentedOut() {
+    public void testHiddenOnSketchSplayIsCommentedOut() {
         SurvexExporter exporter = new SurvexExporter();
         Survey survey = BasicTestSurveyCreator.create5MEast();
         List<Leg> legs = survey.getAllLegs();
         Leg splay = legs.get(legs.size() - 1);
-        splay.setCrossedOut(true);
+        splay.setHiddenOnSketch(true);
         String content = exporter.getContent(survey);
         Assert.assertTrue(content.contains(";"));
     }
 
     @Test
-    public void testCrossedOutPromotedLegHasDoublySemicolonPrecursors() {
+    public void testHiddenOnSketchPromotedLegHasDoublySemicolonPrecursors() {
         SurvexExporter exporter = new SurvexExporter();
         Survey survey = BasicTestSurveyCreator.createStraightNorthThroughRepeats();
         for (Leg leg : survey.getAllLegs()) {
             if (leg.wasPromoted()) {
-                leg.setCrossedOut(true);
+                leg.setHiddenOnSketch(true);
                 break;
             }
         }
         String content = exporter.getContent(survey);
-        Assert.assertTrue("Crossed-out promoted leg should have ;; precursor lines",
+        Assert.assertTrue(
+                "Hidden-on-sketch promoted leg should have ;; precursor lines",
                 content.contains(";;"));
     }
 

--- a/app/src/test/java/org/hwyl/sexytopo/control/io/thirdparty/survex/SurvexExporterTest.java
+++ b/app/src/test/java/org/hwyl/sexytopo/control/io/thirdparty/survex/SurvexExporterTest.java
@@ -81,34 +81,7 @@ public class SurvexExporterTest {
     }
 
     @Test
-    public void testHiddenOnSketchLegIsCommentedOut() {
-        SurvexExporter exporter = new SurvexExporter();
-        Survey survey = BasicTestSurveyCreator.createStraightNorth();
-        survey.getAllLegs().get(0).setHiddenOnSketch(true);
-        String content = exporter.getContent(survey);
-        Assert.assertTrue(content.contains(";1\t2\t5.000\t0.00\t0.00"));
-    }
-
-    @Test
-    public void testUncrossedLegIsNotCommentedOut() {
-        SurvexExporter exporter = new SurvexExporter();
-        Survey survey = BasicTestSurveyCreator.createStraightNorth();
-        String content = exporter.getContent(survey);
-        // Data lines must not start with the comment char (allow for leading whitespace or tabs)
-        for (String line : content.split("\n")) {
-            String trimmed = line.trim();
-            if (trimmed.startsWith("0\t")
-                    || trimmed.startsWith("1\t")
-                    || trimmed.startsWith("2\t")
-                    || trimmed.startsWith("3\t")) {
-                Assert.assertFalse(
-                        "Data line should not be commented: " + line, line.trim().startsWith(";"));
-            }
-        }
-    }
-
-    @Test
-    public void testHiddenOnSketchSplayIsCommentedOut() {
+    public void testHiddenOnSketchSplayIsExported() {
         SurvexExporter exporter = new SurvexExporter();
         Survey survey = BasicTestSurveyCreator.create5MEast();
         List<Leg> legs = survey.getAllLegs();
@@ -116,22 +89,6 @@ public class SurvexExporterTest {
         splay.setHiddenOnSketch(true);
         String content = exporter.getContent(survey);
         Assert.assertTrue(content.contains(";"));
-    }
-
-    @Test
-    public void testHiddenOnSketchPromotedLegHasDoublySemicolonPrecursors() {
-        SurvexExporter exporter = new SurvexExporter();
-        Survey survey = BasicTestSurveyCreator.createStraightNorthThroughRepeats();
-        for (Leg leg : survey.getAllLegs()) {
-            if (leg.wasPromoted()) {
-                leg.setHiddenOnSketch(true);
-                break;
-            }
-        }
-        String content = exporter.getContent(survey);
-        Assert.assertTrue(
-                "Hidden-on-sketch promoted leg should have ;; precursor lines",
-                content.contains(";;"));
     }
 
     private static Trip.TeamEntry entry(String name, Trip.Role... roles) {

--- a/app/src/test/java/org/hwyl/sexytopo/control/io/thirdparty/survex/SurvexImporterTest.java
+++ b/app/src/test/java/org/hwyl/sexytopo/control/io/thirdparty/survex/SurvexImporterTest.java
@@ -36,4 +36,54 @@ public class SurvexImporterTest {
         Station created = survey.getStationByName("2");
         Assert.assertEquals("testComment", created.getComment());
     }
+
+    @Test
+    public void testCrossedOutSplayIsImported() throws Exception {
+        final String testContent = ";0\t-\t5.0\t90.0\t0.0";
+        Survey survey = new Survey();
+        SurvexTherionImporter.parseCentreline(testContent, survey);
+        Assert.assertEquals(1, survey.getAllLegs().size());
+        Assert.assertTrue(survey.getAllLegs().get(0).isCrossedOut());
+    }
+
+    @Test
+    public void testCrossedOutLegIsImported() throws Exception {
+        final String testContent = ";0\t1\t5.0\t0.0\t0.0";
+        Survey survey = new Survey();
+        SurvexTherionImporter.parseCentreline(testContent, survey);
+        Assert.assertEquals(1, survey.getAllLegs().size());
+        Leg leg = survey.getAllLegs().get(0);
+        Assert.assertTrue(leg.isCrossedOut());
+        Assert.assertNotNull(survey.getStationByName("1"));
+    }
+
+    @Test
+    public void testNormalLegIsNotCrossedOut() throws Exception {
+        final String testContent = "0\t1\t5.0\t0.0\t0.0";
+        Survey survey = new Survey();
+        SurvexTherionImporter.parseCentreline(testContent, survey);
+        Assert.assertFalse(survey.getAllLegs().get(0).isCrossedOut());
+    }
+
+    @Test
+    public void testPlainCommentLineIsSkipped() throws Exception {
+        final String testContent = "; this is just a comment";
+        Survey survey = new Survey();
+        SurvexTherionImporter.parseCentreline(testContent, survey);
+        Assert.assertEquals(0, survey.getAllLegs().size());
+    }
+
+    @Test
+    public void testCrossedOutPromotedLegPreservesPromotedFrom() throws Exception {
+        final String testContent =
+                ";0\t1\t5.541\t253.93\t4.67\n"
+                + ";;0\t1\t5.542\t73.95\t-4.64\n"
+                + ";;0\t1\t5.541\t73.93\t-4.69";
+        Survey survey = new Survey();
+        SurvexTherionImporter.parseCentreline(testContent, survey);
+        Assert.assertEquals(1, survey.getAllLegs().size());
+        Leg leg = survey.getAllLegs().get(0);
+        Assert.assertTrue(leg.isCrossedOut());
+        Assert.assertEquals(2, leg.getPromotedFrom().length);
+    }
 }

--- a/app/src/test/java/org/hwyl/sexytopo/control/io/thirdparty/survex/SurvexImporterTest.java
+++ b/app/src/test/java/org/hwyl/sexytopo/control/io/thirdparty/survex/SurvexImporterTest.java
@@ -47,26 +47,17 @@ public class SurvexImporterTest {
         List<Leg> allLegs = survey.getAllLegsInChronoOrder();
         Assert.assertEquals(2, allLegs.size());
         Leg splay = allLegs.get(1);
+        Assert.assertFalse(splay.hasDestination());
         Assert.assertTrue(splay.isHiddenOnSketch());
     }
 
     @Test
-    public void testHiddenOnSketchLegIsImported() throws Exception {
-        final String testContent = ";0\t1\t5.0\t0.0\t0.0";
+    public void testCommentedRealLegIsSkipped() throws Exception {
+        // Commented-out real legs are not imported (hidden-on-sketch is splay-only)
+        final String testContent = "0\t1\t5.0\t0.0\t0.0\n;1\t2\t3.0\t90.0\t0.0";
         Survey survey = new Survey();
         SurvexTherionImporter.parseCentreline(testContent, survey);
-        Assert.assertEquals(1, survey.getAllLegs().size());
-        Leg leg = survey.getAllLegs().get(0);
-        Assert.assertTrue(leg.isHiddenOnSketch());
-        Assert.assertNotNull(survey.getStationByName("1"));
-    }
-
-    @Test
-    public void testNormalLegIsNotHiddenOnSketch() throws Exception {
-        final String testContent = "0\t1\t5.0\t0.0\t0.0";
-        Survey survey = new Survey();
-        SurvexTherionImporter.parseCentreline(testContent, survey);
-        Assert.assertFalse(survey.getAllLegs().get(0).isHiddenOnSketch());
+        Assert.assertEquals(1, survey.getAllLegsInChronoOrder().size());
     }
 
     @Test
@@ -75,19 +66,5 @@ public class SurvexImporterTest {
         Survey survey = new Survey();
         SurvexTherionImporter.parseCentreline(testContent, survey);
         Assert.assertEquals(0, survey.getAllLegs().size());
-    }
-
-    @Test
-    public void testHiddenOnSketchPromotedLegPreservesPromotedFrom() throws Exception {
-        final String testContent =
-                ";0\t1\t5.541\t253.93\t4.67\n"
-                        + ";;0\t1\t5.542\t73.95\t-4.64\n"
-                        + ";;0\t1\t5.541\t73.93\t-4.69";
-        Survey survey = new Survey();
-        SurvexTherionImporter.parseCentreline(testContent, survey);
-        Assert.assertEquals(1, survey.getAllLegs().size());
-        Leg leg = survey.getAllLegs().get(0);
-        Assert.assertTrue(leg.isHiddenOnSketch());
-        Assert.assertEquals(2, leg.getPromotedFrom().length);
     }
 }

--- a/app/src/test/java/org/hwyl/sexytopo/control/io/thirdparty/survex/SurvexImporterTest.java
+++ b/app/src/test/java/org/hwyl/sexytopo/control/io/thirdparty/survex/SurvexImporterTest.java
@@ -1,5 +1,6 @@
 package org.hwyl.sexytopo.control.io.thirdparty.survex;
 
+import java.util.List;
 import org.hwyl.sexytopo.control.io.thirdparty.survextherion.SurvexTherionImporter;
 import org.hwyl.sexytopo.model.survey.Leg;
 import org.hwyl.sexytopo.model.survey.Station;
@@ -38,31 +39,34 @@ public class SurvexImporterTest {
     }
 
     @Test
-    public void testCrossedOutSplayIsImported() throws Exception {
-        final String testContent = ";0\t-\t5.0\t90.0\t0.0";
+    public void testHiddenOnSketchSplayIsImported() throws Exception {
+        // A non-splay leg must come first to establish the survey origin; the splay follows
+        final String testContent = "0\t1\t5.0\t0.0\t0.0\n;1\t-\t2.0\t90.0\t0.0";
         Survey survey = new Survey();
         SurvexTherionImporter.parseCentreline(testContent, survey);
-        Assert.assertEquals(1, survey.getAllLegs().size());
-        Assert.assertTrue(survey.getAllLegs().get(0).isCrossedOut());
+        List<Leg> allLegs = survey.getAllLegsInChronoOrder();
+        Assert.assertEquals(2, allLegs.size());
+        Leg splay = allLegs.get(1);
+        Assert.assertTrue(splay.isHiddenOnSketch());
     }
 
     @Test
-    public void testCrossedOutLegIsImported() throws Exception {
+    public void testHiddenOnSketchLegIsImported() throws Exception {
         final String testContent = ";0\t1\t5.0\t0.0\t0.0";
         Survey survey = new Survey();
         SurvexTherionImporter.parseCentreline(testContent, survey);
         Assert.assertEquals(1, survey.getAllLegs().size());
         Leg leg = survey.getAllLegs().get(0);
-        Assert.assertTrue(leg.isCrossedOut());
+        Assert.assertTrue(leg.isHiddenOnSketch());
         Assert.assertNotNull(survey.getStationByName("1"));
     }
 
     @Test
-    public void testNormalLegIsNotCrossedOut() throws Exception {
+    public void testNormalLegIsNotHiddenOnSketch() throws Exception {
         final String testContent = "0\t1\t5.0\t0.0\t0.0";
         Survey survey = new Survey();
         SurvexTherionImporter.parseCentreline(testContent, survey);
-        Assert.assertFalse(survey.getAllLegs().get(0).isCrossedOut());
+        Assert.assertFalse(survey.getAllLegs().get(0).isHiddenOnSketch());
     }
 
     @Test
@@ -74,16 +78,16 @@ public class SurvexImporterTest {
     }
 
     @Test
-    public void testCrossedOutPromotedLegPreservesPromotedFrom() throws Exception {
+    public void testHiddenOnSketchPromotedLegPreservesPromotedFrom() throws Exception {
         final String testContent =
                 ";0\t1\t5.541\t253.93\t4.67\n"
-                + ";;0\t1\t5.542\t73.95\t-4.64\n"
-                + ";;0\t1\t5.541\t73.93\t-4.69";
+                        + ";;0\t1\t5.542\t73.95\t-4.64\n"
+                        + ";;0\t1\t5.541\t73.93\t-4.69";
         Survey survey = new Survey();
         SurvexTherionImporter.parseCentreline(testContent, survey);
         Assert.assertEquals(1, survey.getAllLegs().size());
         Leg leg = survey.getAllLegs().get(0);
-        Assert.assertTrue(leg.isCrossedOut());
+        Assert.assertTrue(leg.isHiddenOnSketch());
         Assert.assertEquals(2, leg.getPromotedFrom().length);
     }
 }

--- a/app/src/test/java/org/hwyl/sexytopo/control/io/thirdparty/therion/TherionImporterTest.java
+++ b/app/src/test/java/org/hwyl/sexytopo/control/io/thirdparty/therion/TherionImporterTest.java
@@ -649,4 +649,30 @@ public class TherionImporterTest {
         Direction stationFiveDirection = stationFive.getExtendedElevationDirection();
         Assert.assertEquals(Direction.RIGHT, stationFiveDirection);
     }
+
+    @Test
+    public void testCrossedOutLegSurvivesUpdateCentreline() throws Exception {
+        List<String> lines = Arrays.asList(
+                "centreline",
+                "data normal from to tape compass clino",
+                "#0\t1\t5.0\t0.0\t0.0",
+                "endcentreline");
+        Survey survey = new Survey();
+        TherionImporter.updateCentreline(lines, survey);
+        Assert.assertEquals(1, survey.getAllLegs().size());
+        Assert.assertTrue(survey.getAllLegs().get(0).isCrossedOut());
+    }
+
+    @Test
+    public void testCrossedOutSplaySurvivesUpdateCentreline() throws Exception {
+        List<String> lines = Arrays.asList(
+                "centreline",
+                "data normal from to tape compass clino",
+                "#0\t-\t5.0\t90.0\t0.0",
+                "endcentreline");
+        Survey survey = new Survey();
+        TherionImporter.updateCentreline(lines, survey);
+        Assert.assertEquals(1, survey.getAllLegs().size());
+        Assert.assertTrue(survey.getAllLegs().get(0).isCrossedOut());
+    }
 }

--- a/app/src/test/java/org/hwyl/sexytopo/control/io/thirdparty/therion/TherionImporterTest.java
+++ b/app/src/test/java/org/hwyl/sexytopo/control/io/thirdparty/therion/TherionImporterTest.java
@@ -651,20 +651,6 @@ public class TherionImporterTest {
     }
 
     @Test
-    public void testHiddenOnSketchLegSurvivesUpdateCentreline() throws Exception {
-        List<String> lines =
-                Arrays.asList(
-                        "centreline",
-                        "data normal from to tape compass clino",
-                        "#0\t1\t5.0\t0.0\t0.0",
-                        "endcentreline");
-        Survey survey = new Survey();
-        TherionImporter.updateCentreline(lines, survey);
-        Assert.assertEquals(1, survey.getAllLegs().size());
-        Assert.assertTrue(survey.getAllLegs().get(0).isHiddenOnSketch());
-    }
-
-    @Test
     public void testHiddenOnSketchSplaySurvivesUpdateCentreline() throws Exception {
         // A non-splay leg must come first to establish the survey origin; the splay follows
         List<String> lines =
@@ -679,6 +665,7 @@ public class TherionImporterTest {
         List<Leg> allLegs = survey.getAllLegsInChronoOrder();
         Assert.assertEquals(2, allLegs.size());
         Leg splay = allLegs.get(1);
+        Assert.assertFalse(splay.hasDestination());
         Assert.assertTrue(splay.isHiddenOnSketch());
     }
 }

--- a/app/src/test/java/org/hwyl/sexytopo/control/io/thirdparty/therion/TherionImporterTest.java
+++ b/app/src/test/java/org/hwyl/sexytopo/control/io/thirdparty/therion/TherionImporterTest.java
@@ -651,28 +651,34 @@ public class TherionImporterTest {
     }
 
     @Test
-    public void testCrossedOutLegSurvivesUpdateCentreline() throws Exception {
-        List<String> lines = Arrays.asList(
-                "centreline",
-                "data normal from to tape compass clino",
-                "#0\t1\t5.0\t0.0\t0.0",
-                "endcentreline");
+    public void testHiddenOnSketchLegSurvivesUpdateCentreline() throws Exception {
+        List<String> lines =
+                Arrays.asList(
+                        "centreline",
+                        "data normal from to tape compass clino",
+                        "#0\t1\t5.0\t0.0\t0.0",
+                        "endcentreline");
         Survey survey = new Survey();
         TherionImporter.updateCentreline(lines, survey);
         Assert.assertEquals(1, survey.getAllLegs().size());
-        Assert.assertTrue(survey.getAllLegs().get(0).isCrossedOut());
+        Assert.assertTrue(survey.getAllLegs().get(0).isHiddenOnSketch());
     }
 
     @Test
-    public void testCrossedOutSplaySurvivesUpdateCentreline() throws Exception {
-        List<String> lines = Arrays.asList(
-                "centreline",
-                "data normal from to tape compass clino",
-                "#0\t-\t5.0\t90.0\t0.0",
-                "endcentreline");
+    public void testHiddenOnSketchSplaySurvivesUpdateCentreline() throws Exception {
+        // A non-splay leg must come first to establish the survey origin; the splay follows
+        List<String> lines =
+                Arrays.asList(
+                        "centreline",
+                        "data normal from to tape compass clino",
+                        "0\t1\t5.0\t0.0\t0.0",
+                        "#1\t-\t5.0\t90.0\t0.0",
+                        "endcentreline");
         Survey survey = new Survey();
         TherionImporter.updateCentreline(lines, survey);
-        Assert.assertEquals(1, survey.getAllLegs().size());
-        Assert.assertTrue(survey.getAllLegs().get(0).isCrossedOut());
+        List<Leg> allLegs = survey.getAllLegsInChronoOrder();
+        Assert.assertEquals(2, allLegs.size());
+        Leg splay = allLegs.get(1);
+        Assert.assertTrue(splay.isHiddenOnSketch());
     }
 }

--- a/app/src/test/java/org/hwyl/sexytopo/model/survey/LegTest.java
+++ b/app/src/test/java/org/hwyl/sexytopo/model/survey/LegTest.java
@@ -238,4 +238,32 @@ public class LegTest {
         Assert.assertFalse(Leg.isInclinationLegal(-90.1f));
         Assert.assertFalse(Leg.isInclinationLegal(90.1f));
     }
+
+    @Test
+    public void testIsCrossedOutDefaultsFalse() {
+        Leg leg = new Leg(5.0f, 45.0f, 30.0f);
+        Assert.assertFalse(leg.isCrossedOut());
+    }
+
+    @Test
+    public void testSetCrossedOutTrue() {
+        Leg leg = new Leg(5.0f, 45.0f, 30.0f);
+        leg.setCrossedOut(true);
+        Assert.assertTrue(leg.isCrossedOut());
+    }
+
+    @Test
+    public void testSetCrossedOutCanBeToggled() {
+        Leg leg = new Leg(5.0f, 45.0f, 30.0f);
+        leg.setCrossedOut(true);
+        leg.setCrossedOut(false);
+        Assert.assertFalse(leg.isCrossedOut());
+    }
+
+    @Test
+    public void testCrossedOutDefaultsFalseForLegWithDestination() {
+        Station destination = new Station("A1");
+        Leg leg = new Leg(5.0f, 45.0f, 30.0f, destination, new Leg[] {});
+        Assert.assertFalse(leg.isCrossedOut());
+    }
 }

--- a/app/src/test/java/org/hwyl/sexytopo/model/survey/LegTest.java
+++ b/app/src/test/java/org/hwyl/sexytopo/model/survey/LegTest.java
@@ -240,30 +240,16 @@ public class LegTest {
     }
 
     @Test
-    public void testIsHiddenOnSketchDefaultsFalse() {
-        Leg leg = new Leg(5.0f, 45.0f, 30.0f);
-        Assert.assertFalse(leg.isHiddenOnSketch());
-    }
-
-    @Test
-    public void testSetHiddenOnSketchTrue() {
-        Leg leg = new Leg(5.0f, 45.0f, 30.0f);
-        leg.setHiddenOnSketch(true);
-        Assert.assertTrue(leg.isHiddenOnSketch());
-    }
-
-    @Test
-    public void testSetHiddenOnSketchCanBeToggled() {
-        Leg leg = new Leg(5.0f, 45.0f, 30.0f);
-        leg.setHiddenOnSketch(true);
-        leg.setHiddenOnSketch(false);
-        Assert.assertFalse(leg.isHiddenOnSketch());
-    }
-
-    @Test
-    public void testHiddenOnSketchDefaultsFalseForLegWithDestination() {
-        Station destination = new Station("A1");
-        Leg leg = new Leg(5.0f, 45.0f, 30.0f, destination, new Leg[] {});
-        Assert.assertFalse(leg.isHiddenOnSketch());
+    public void testUpgradeSplayToLegClearsHiddenOnSketch() {
+        Survey survey = new Survey();
+        Leg splay = new Leg(5.0f, 45.0f, 30.0f);
+        splay.setHiddenOnSketch(true);
+        survey.getOrigin().addOnwardLeg(splay);
+        survey.addLegRecord(splay);
+        org.hwyl.sexytopo.control.util.SurveyUpdater.upgradeSplay(
+                survey, splay, org.hwyl.sexytopo.control.util.InputMode.FORWARD);
+        Leg upgradedLeg = survey.getAllLegs().get(0);
+        Assert.assertTrue(upgradedLeg.hasDestination());
+        Assert.assertFalse(upgradedLeg.isHiddenOnSketch());
     }
 }

--- a/app/src/test/java/org/hwyl/sexytopo/model/survey/LegTest.java
+++ b/app/src/test/java/org/hwyl/sexytopo/model/survey/LegTest.java
@@ -240,30 +240,30 @@ public class LegTest {
     }
 
     @Test
-    public void testIsCrossedOutDefaultsFalse() {
+    public void testIsHiddenOnSketchDefaultsFalse() {
         Leg leg = new Leg(5.0f, 45.0f, 30.0f);
-        Assert.assertFalse(leg.isCrossedOut());
+        Assert.assertFalse(leg.isHiddenOnSketch());
     }
 
     @Test
-    public void testSetCrossedOutTrue() {
+    public void testSetHiddenOnSketchTrue() {
         Leg leg = new Leg(5.0f, 45.0f, 30.0f);
-        leg.setCrossedOut(true);
-        Assert.assertTrue(leg.isCrossedOut());
+        leg.setHiddenOnSketch(true);
+        Assert.assertTrue(leg.isHiddenOnSketch());
     }
 
     @Test
-    public void testSetCrossedOutCanBeToggled() {
+    public void testSetHiddenOnSketchCanBeToggled() {
         Leg leg = new Leg(5.0f, 45.0f, 30.0f);
-        leg.setCrossedOut(true);
-        leg.setCrossedOut(false);
-        Assert.assertFalse(leg.isCrossedOut());
+        leg.setHiddenOnSketch(true);
+        leg.setHiddenOnSketch(false);
+        Assert.assertFalse(leg.isHiddenOnSketch());
     }
 
     @Test
-    public void testCrossedOutDefaultsFalseForLegWithDestination() {
+    public void testHiddenOnSketchDefaultsFalseForLegWithDestination() {
         Station destination = new Station("A1");
         Leg leg = new Leg(5.0f, 45.0f, 30.0f, destination, new Leg[] {});
-        Assert.assertFalse(leg.isCrossedOut());
+        Assert.assertFalse(leg.isHiddenOnSketch());
     }
 }


### PR DESCRIPTION
Crossed out readings are not displayed on the plan and elevation

The reason I'm playing with this. At the start of each trip I take two forward and one backwards shot to check the calibration. I usually do this before I go underground, so these are not a part of the survey, but an important part of the survey data that needs to be included in the file.

I'm not convinced that this is the best method, however it may be a very adaptable method. 
For example it could be used to help with poor mans lidar surveys such as been suggested in #248

closes #46
