### PR TITLE
Vertical elevation leg

### DIFF
--- a/app/src/main/assets/guide/index.html
+++ b/app/src/main/assets/guide/index.html
@@ -254,10 +254,11 @@
 </ul>
 
 <h3>Elevation Direction</h3>
-<p>In elevation view, controls which direction to draw the passage:</p>
+<p>In elevation view, controls which direction to draw the leg:</p>
 <ul>
-	<li><strong>Draw Left</strong> draws passage extending to the left</li>
-	<li><strong>Draw Right</strong> draws passage extending to the right</li>
+	<li><strong>Draw Left</strong> draws leg extending to the left</li>
+	<li><strong>Draw Right</strong> draws leg extending to the right</li>
+	<li><strong>Draw Vertical</strong> ony uses the height change of the leg</li>
 </ul>
 
 <h3>Navigate</h3>

--- a/app/src/main/java/org/hwyl/sexytopo/control/activity/SurveyEditorActivity.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/activity/SurveyEditorActivity.java
@@ -72,6 +72,15 @@ public abstract class SurveyEditorActivity extends SexyTopoActivity {
         }
     }
 
+    public void onSetDirectionVertical(Station station) {
+        if (station.getExtendedElevationDirection() != Direction.VERTICAL) {
+            // Only affect this one station's incoming leg — do NOT propagate to the subtree
+            station.setExtendedElevationDirection(Direction.VERTICAL);
+            getSurveyManager().broadcastSurveyUpdated();
+            invalidateView();
+        }
+    }
+
     public void onReverse(Leg leg) {
         Station station = leg.getDestination();
         if (station == null) {

--- a/app/src/main/java/org/hwyl/sexytopo/control/graph/ContextMenuManager.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/graph/ContextMenuManager.java
@@ -60,6 +60,7 @@ public class ContextMenuManager {
         menuActions.put(R.id.action_jump_to_elevation, activity::onJumpToElevation);
         menuActions.put(R.id.action_direction_left, activity::onSetDirectionLeft);
         menuActions.put(R.id.action_direction_right, activity::onSetDirectionRight);
+        menuActions.put(R.id.action_direction_vertical, activity::onSetDirectionVertical);
         menuActions.put(R.id.action_new_cross_section, activity::onNewCrossSection);
         menuActions.put(R.id.action_start_new_survey, activity::onStartNewSurvey);
         menuActions.put(R.id.action_link_survey, activity::onLinkSurvey);
@@ -221,10 +222,14 @@ public class ContextMenuManager {
         // Configure direction radio buttons
         MenuItem leftItem = menu.findItem(R.id.action_direction_left);
         MenuItem rightItem = menu.findItem(R.id.action_direction_right);
+        MenuItem verticalItem = menu.findItem(R.id.action_direction_vertical);
         if (leftItem != null && rightItem != null) {
             Direction currentDirection = station.getExtendedElevationDirection();
             leftItem.setChecked(currentDirection == Direction.LEFT);
             rightItem.setChecked(currentDirection == Direction.RIGHT);
+            if (verticalItem != null) {
+                verticalItem.setChecked(currentDirection == Direction.VERTICAL);
+            }
         }
 
         viewContext.configureViewSpecificItems(menu);

--- a/app/src/main/java/org/hwyl/sexytopo/control/graph/GraphView.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/graph/GraphView.java
@@ -88,7 +88,6 @@ public class GraphView extends View {
     public static final int FADED_ALPHA = 0xff / 5;
     private static final int STATION_STROKE_WIDTH_DP = 2;
     private static final int DASHED_LINE_INTERVAL_DP = 4;
-    private static final int VERTICAL_LEG_DASH_INTERVAL_DP = 8;
     private static final int CROSS_SECTION_CONNECTOR_WIDTH_DP = 2;
     private static final int CROSS_SECTION_INDICATOR_WIDTH_DP = 2;
 
@@ -96,7 +95,6 @@ public class GraphView extends View {
     private static final int LEGEND_TICK_SIZE_DP = 5;
     private float legendTickSizePx;
     private float dashedLineIntervalPx;
-    private float verticalLegDashIntervalPx;
 
     private static final float DELETE_DETAILS_WITHIN_N_DP = 5.0f;
     private static final float SELECTION_SENSITIVITY_DP = 25.0f;
@@ -294,7 +292,6 @@ public class GraphView extends View {
         stationCrossDiameterPx = dpToPixels(GeneralPreferences.getStationCrossDiameterDp());
         legendTickSizePx = dpToPixels(LEGEND_TICK_SIZE_DP);
         dashedLineIntervalPx = dpToPixels(DASHED_LINE_INTERVAL_DP);
-        verticalLegDashIntervalPx = dpToPixels(VERTICAL_LEG_DASH_INTERVAL_DP);
         deleteDetailsWithinPx = dpToPixels(DELETE_DETAILS_WITHIN_N_DP);
         selectionSensitivityPx = dpToPixels(SELECTION_SENSITIVITY_DP);
         snapToLineSensitivityPx = dpToPixels(SNAP_TO_LINE_SENSITIVITY_DP);
@@ -1041,7 +1038,7 @@ public class GraphView extends View {
             if (projectionType == Projection2D.EXTENDED_ELEVATION
                     && leg.hasDestination()
                     && leg.getDestination().getExtendedElevationDirection() == Direction.VERTICAL) {
-                drawDashedLine(canvas, start, end, verticalLegDashIntervalPx, paint);
+                drawDashedLine(canvas, start, end, dashedLineIntervalPx, paint);
             } else if (projectionType.isLegInPlane(leg)) {
                 canvas.drawLine(start.x, start.y, end.x, end.y, paint);
             } else {

--- a/app/src/main/java/org/hwyl/sexytopo/control/graph/GraphView.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/graph/GraphView.java
@@ -42,6 +42,7 @@ import org.hwyl.sexytopo.control.util.SketchPreferences;
 import org.hwyl.sexytopo.control.util.Space2DUtils;
 import org.hwyl.sexytopo.control.util.TextTools;
 import org.hwyl.sexytopo.model.graph.Coord2D;
+import org.hwyl.sexytopo.model.graph.Direction;
 import org.hwyl.sexytopo.model.graph.Line;
 import org.hwyl.sexytopo.model.graph.Projection2D;
 import org.hwyl.sexytopo.model.graph.Space;
@@ -87,6 +88,7 @@ public class GraphView extends View {
     public static final int FADED_ALPHA = 0xff / 5;
     private static final int STATION_STROKE_WIDTH_DP = 2;
     private static final int DASHED_LINE_INTERVAL_DP = 4;
+    private static final int VERTICAL_LEG_DASH_INTERVAL_DP = 8;
     private static final int CROSS_SECTION_CONNECTOR_WIDTH_DP = 2;
     private static final int CROSS_SECTION_INDICATOR_WIDTH_DP = 2;
 
@@ -94,6 +96,7 @@ public class GraphView extends View {
     private static final int LEGEND_TICK_SIZE_DP = 5;
     private float legendTickSizePx;
     private float dashedLineIntervalPx;
+    private float verticalLegDashIntervalPx;
 
     private static final float DELETE_DETAILS_WITHIN_N_DP = 5.0f;
     private static final float SELECTION_SENSITIVITY_DP = 25.0f;
@@ -291,6 +294,7 @@ public class GraphView extends View {
         stationCrossDiameterPx = dpToPixels(GeneralPreferences.getStationCrossDiameterDp());
         legendTickSizePx = dpToPixels(LEGEND_TICK_SIZE_DP);
         dashedLineIntervalPx = dpToPixels(DASHED_LINE_INTERVAL_DP);
+        verticalLegDashIntervalPx = dpToPixels(VERTICAL_LEG_DASH_INTERVAL_DP);
         deleteDetailsWithinPx = dpToPixels(DELETE_DETAILS_WITHIN_N_DP);
         selectionSensitivityPx = dpToPixels(SELECTION_SENSITIVITY_DP);
         snapToLineSensitivityPx = dpToPixels(SNAP_TO_LINE_SENSITIVITY_DP);
@@ -1034,7 +1038,11 @@ public class GraphView extends View {
                 paint = fade ? fadedLegPaint : legPaint;
             }
 
-            if (projectionType.isLegInPlane(leg)) {
+            if (projectionType == Projection2D.EXTENDED_ELEVATION
+                    && leg.hasDestination()
+                    && leg.getDestination().getExtendedElevationDirection() == Direction.VERTICAL) {
+                drawDashedLine(canvas, start, end, verticalLegDashIntervalPx, paint);
+            } else if (projectionType.isLegInPlane(leg)) {
                 canvas.drawLine(start.x, start.y, end.x, end.y, paint);
             } else {
                 drawDashedLine(canvas, start, end, dashedLineIntervalPx, paint);

--- a/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/survextherion/SurvexTherionUtil.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/survextherion/SurvexTherionUtil.java
@@ -219,28 +219,49 @@ public class SurvexTherionUtil {
     public static String getExtendedElevationExtensions(Survey survey, SurveyFormat format) {
         StringBuilder builder = new StringBuilder();
         String marker = format.getCommandChar();
-        generateExtendCommandsFromStation(builder, survey.getOrigin(), null, marker);
+        generateExtendCommandsFromStation(builder, survey.getOrigin(), null, null, marker);
         return builder.toString();
     }
 
     private static void generateExtendCommandsFromStation(
-            StringBuilder builder, Station station, Direction lastDirection, String marker) {
+            StringBuilder builder,
+            Station station,
+            Station fromStation,
+            Direction lastDirection,
+            String marker) {
 
         Direction currentDirection = station.getExtendedElevationDirection();
-        if (lastDirection == null) {
-            builder.append(getExtendCommand(station, "start", marker));
-        } else if (currentDirection != lastDirection) {
-            builder.append(
-                    getExtendCommand(station, currentDirection.name().toLowerCase(), marker));
-        }
 
-        for (Leg leg : station.getConnectedOnwardLegs()) {
-            generateExtendCommandsFromStation(
-                    builder, leg.getDestination(), station.getExtendedElevationDirection(), marker);
+        if (currentDirection == Direction.VERTICAL) {
+            // VERTICAL is leg-scoped: emit a two-station "extend vertical <from> <to>" command.
+            // The direction seen by child stations is not changed — pass lastDirection forward
+            // unchanged so the survey continues in the same left/right direction after the
+            // vertical leg.
+            builder.append(getExtendCommand(fromStation, station, "vertical", marker));
+            for (Leg leg : station.getConnectedOnwardLegs()) {
+                generateExtendCommandsFromStation(
+                        builder, leg.getDestination(), station, lastDirection, marker);
+            }
+        } else {
+            if (lastDirection == null) {
+                builder.append(getExtendCommand(station, "start", marker));
+            } else if (currentDirection != lastDirection) {
+                builder.append(
+                        getExtendCommand(station, currentDirection.name().toLowerCase(), marker));
+            }
+            for (Leg leg : station.getConnectedOnwardLegs()) {
+                generateExtendCommandsFromStation(
+                        builder, leg.getDestination(), station, currentDirection, marker);
+            }
         }
     }
 
     private static String getExtendCommand(Station station, String direction, String marker) {
         return marker + "extend " + direction + " " + station.getName() + "\n";
+    }
+
+    private static String getExtendCommand(
+            Station from, Station to, String direction, String marker) {
+        return marker + "extend " + direction + " " + from.getName() + " " + to.getName() + "\n";
     }
 }

--- a/app/src/main/java/org/hwyl/sexytopo/control/util/Space3DTransformerForElevation.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/util/Space3DTransformerForElevation.java
@@ -26,8 +26,26 @@ public class Space3DTransformerForElevation extends Space3DTransformer {
 
     protected void updateLeg(Space<Coord3D> space, Leg leg, Coord3D start) {
 
+        Direction direction = leg.getDestination().getExtendedElevationDirection();
+
+        if (direction == Direction.VERTICAL) {
+            // Render only the true vertical component of this leg: keep x and y identical to the
+            // start (zero horizontal displacement on screen) and shift z by r*sin(inclination),
+            // which is the actual height change. This correctly preserves the station's altitude
+            // without inflating it the way forcing inclination to ±90° would.
+            float dz = leg.getDistance()
+                    * (float) Math.sin(Math.toRadians(leg.getInclination()));
+            Coord3D end = new Coord3D(start.x, start.y, start.z + dz);
+            space.addLeg(leg, new Line<>(start, end));
+            if (leg.hasDestination()) {
+                // delta=0: subsequent legs are not rotated by this vertical leg's azimuth
+                update(space, leg.getDestination(), end, 0);
+            }
+            return;
+        }
+
         Leg adjustedLeg;
-        if (leg.getDestination().getExtendedElevationDirection() == Direction.LEFT) {
+        if (direction == Direction.LEFT) {
             adjustedLeg = leg.adjustAzimuth(180);
         } else {
             adjustedLeg = leg.adjustAzimuth(0);

--- a/app/src/main/java/org/hwyl/sexytopo/control/util/Space3DTransformerForElevation.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/util/Space3DTransformerForElevation.java
@@ -25,39 +25,48 @@ public class Space3DTransformerForElevation extends Space3DTransformer {
     }
 
     protected void updateLeg(Space<Coord3D> space, Leg leg, Coord3D start) {
-
         Direction direction = leg.getDestination().getExtendedElevationDirection();
 
-        if (direction == Direction.VERTICAL) {
-            // Render only the true vertical component of this leg: keep x and y identical to the
-            // start (zero horizontal displacement on screen) and shift z by r*sin(inclination),
-            // which is the actual height change. This correctly preserves the station's altitude
-            // without inflating it the way forcing inclination to ±90° would.
-            float dz = leg.getDistance()
-                    * (float) Math.sin(Math.toRadians(leg.getInclination()));
-            Coord3D end = new Coord3D(start.x, start.y, start.z + dz);
-            space.addLeg(leg, new Line<>(start, end));
-            if (leg.hasDestination()) {
-                // delta=0: subsequent legs are not rotated by this vertical leg's azimuth
-                update(space, leg.getDestination(), end, 0);
-            }
-            return;
-        }
+        Coord3D end = computeEnd(start, leg, direction);
+        space.addLeg(leg, new Line<>(start, end));
 
-        Leg adjustedLeg;
-        if (direction == Direction.LEFT) {
-            adjustedLeg = leg.adjustAzimuth(180);
-        } else {
-            adjustedLeg = leg.adjustAzimuth(0);
-        }
-
-        float delta = adjustedLeg.getAzimuth() - leg.getAzimuth();
-
-        Coord3D end = Space3DUtils.toCartesian(start, adjustedLeg);
-        Line<Coord3D> line = new Line<>(start, end);
-        space.addLeg(leg, line);
         if (leg.hasDestination()) {
+            float delta = computeDelta(leg, direction);
             update(space, leg.getDestination(), end, delta);
+        }
+    }
+
+    /**
+     * Computes the end coordinate of a leg in the extended elevation projection. Vertical legs
+     * preserve x/y and shift only z by the true height change. Left/right legs are projected via
+     * toCartesian using their adjusted azimuth.
+     */
+    private static Coord3D computeEnd(Coord3D start, Leg leg, Direction direction) {
+        if (direction == Direction.VERTICAL) {
+            return Space3DUtils.toCartesianVertical(start, leg);
+        }
+        Leg adjustedLeg = adjustLegForDirection(leg, direction);
+        return Space3DUtils.toCartesian(start, adjustedLeg);
+    }
+
+    /**
+     * Computes the azimuth delta to pass to child stations. Vertical legs pass delta=0 so
+     * subsequent legs are not rotated by this leg's azimuth. Left/right legs pass the difference
+     * introduced by the direction adjustment.
+     */
+    private static float computeDelta(Leg leg, Direction direction) {
+        if (direction == Direction.VERTICAL) {
+            return 0;
+        }
+        Leg adjustedLeg = adjustLegForDirection(leg, direction);
+        return adjustedLeg.getAzimuth() - leg.getAzimuth();
+    }
+
+    private static Leg adjustLegForDirection(Leg leg, Direction direction) {
+        if (direction == Direction.LEFT) {
+            return leg.adjustAzimuth(180);
+        } else {
+            return leg.adjustAzimuth(0);
         }
     }
 

--- a/app/src/main/java/org/hwyl/sexytopo/control/util/Space3DUtils.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/util/Space3DUtils.java
@@ -20,4 +20,14 @@ public class Space3DUtils {
 
         return new Coord3D(x, y, z);
     }
+
+    /**
+     * Converts a leg to its endpoint treating it as purely vertical: x and y are unchanged from the
+     * start, and z shifts by r*sin(inclination). This preserves the true altitude change without
+     * any horizontal displacement on screen.
+     */
+    public static Coord3D toCartesianVertical(Coord3D start, Leg leg) {
+        float dz = leg.getDistance() * (float) Math.sin(Math.toRadians(leg.getInclination()));
+        return new Coord3D(start.x, start.y, start.z + dz);
+    }
 }

--- a/app/src/main/java/org/hwyl/sexytopo/control/util/SurveyUpdater.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/util/SurveyUpdater.java
@@ -180,7 +180,8 @@ public class SurveyUpdater {
         if (areLegsAboutTheSame(lastNLegs)) {
 
             Station newStation = new Station(getNextStationName(survey));
-            newStation.setExtendedElevationDirection(resolveInheritedDirection(survey, activeStation));
+            newStation.setExtendedElevationDirection(
+                    resolveInheritedDirection(survey, activeStation));
 
             Leg newLeg = averageLegs(lastNLegs);
             newLeg =
@@ -236,7 +237,8 @@ public class SurveyUpdater {
 
         if (areLegsBacksights(fore, back)) {
             Station newStation = new Station(getNextStationName(survey));
-            newStation.setExtendedElevationDirection(resolveInheritedDirection(survey, activeStation));
+            newStation.setExtendedElevationDirection(
+                    resolveInheritedDirection(survey, activeStation));
 
             Leg newLeg = averageBacksights(fore, back);
             newLeg = Leg.toFullLeg(newLeg, newStation);
@@ -492,6 +494,8 @@ public class SurveyUpdater {
         Direction grandparentDirection = grandparent.getExtendedElevationDirection();
         // If the grandparent is also VERTICAL, keep climbing until we find a real direction
         // or exhaust the chain — but for simplicity one level is sufficient for typical caves.
-        return (grandparentDirection == Direction.VERTICAL) ? Direction.RIGHT : grandparentDirection;
+        return (grandparentDirection == Direction.VERTICAL)
+                ? Direction.RIGHT
+                : grandparentDirection;
     }
 }

--- a/app/src/main/java/org/hwyl/sexytopo/control/util/SurveyUpdater.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/util/SurveyUpdater.java
@@ -474,28 +474,20 @@ public class SurveyUpdater {
      *
      * <p>If the active (parent) station has direction VERTICAL, that means the leg into it was a
      * one-off vertical rendering. The new station should instead continue in the direction of the
-     * grandparent station (Option A), so that the survey resumes its prior horizontal direction
-     * after the vertical leg. If no grandparent exists (active is origin), fall back to RIGHT.
+     * nearest non-vertical ancestor, so that the survey resumes its prior horizontal direction
+     * after any number of consecutive vertical legs. If no non-vertical ancestor exists, fall back
+     * to RIGHT.
      */
     private static Direction resolveInheritedDirection(Survey survey, Station activeStation) {
         Direction activeDirection = activeStation.getExtendedElevationDirection();
         if (activeDirection != Direction.VERTICAL) {
             return activeDirection;
         }
-        // Walk up one level to find the grandparent station's direction
         Leg referringLeg = survey.getReferringLeg(activeStation);
         if (referringLeg == null) {
             return Direction.RIGHT; // origin station — nothing above it
         }
-        Station grandparent = survey.getOriginatingStation(referringLeg);
-        if (grandparent == null) {
-            return Direction.RIGHT;
-        }
-        Direction grandparentDirection = grandparent.getExtendedElevationDirection();
-        // If the grandparent is also VERTICAL, keep climbing until we find a real direction
-        // or exhaust the chain — but for simplicity one level is sufficient for typical caves.
-        return (grandparentDirection == Direction.VERTICAL)
-                ? Direction.RIGHT
-                : grandparentDirection;
+        Station parent = survey.getOriginatingStation(referringLeg);
+        return resolveInheritedDirection(survey, parent);
     }
 }

--- a/app/src/main/java/org/hwyl/sexytopo/control/util/SurveyUpdater.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/util/SurveyUpdater.java
@@ -180,7 +180,7 @@ public class SurveyUpdater {
         if (areLegsAboutTheSame(lastNLegs)) {
 
             Station newStation = new Station(getNextStationName(survey));
-            newStation.setExtendedElevationDirection(activeStation.getExtendedElevationDirection());
+            newStation.setExtendedElevationDirection(resolveInheritedDirection(survey, activeStation));
 
             Leg newLeg = averageLegs(lastNLegs);
             newLeg =
@@ -236,7 +236,7 @@ public class SurveyUpdater {
 
         if (areLegsBacksights(fore, back)) {
             Station newStation = new Station(getNextStationName(survey));
-            newStation.setExtendedElevationDirection(activeStation.getExtendedElevationDirection());
+            newStation.setExtendedElevationDirection(resolveInheritedDirection(survey, activeStation));
 
             Leg newLeg = averageBacksights(fore, back);
             newLeg = Leg.toFullLeg(newLeg, newStation);
@@ -465,5 +465,33 @@ public class SurveyUpdater {
             Station destination = leg.getDestination();
             setDirectionOfSubtree(destination, direction);
         }
+    }
+
+    /**
+     * Resolves the direction that a newly-created station should inherit from its parent.
+     *
+     * <p>If the active (parent) station has direction VERTICAL, that means the leg into it was a
+     * one-off vertical rendering. The new station should instead continue in the direction of the
+     * grandparent station (Option A), so that the survey resumes its prior horizontal direction
+     * after the vertical leg. If no grandparent exists (active is origin), fall back to RIGHT.
+     */
+    private static Direction resolveInheritedDirection(Survey survey, Station activeStation) {
+        Direction activeDirection = activeStation.getExtendedElevationDirection();
+        if (activeDirection != Direction.VERTICAL) {
+            return activeDirection;
+        }
+        // Walk up one level to find the grandparent station's direction
+        Leg referringLeg = survey.getReferringLeg(activeStation);
+        if (referringLeg == null) {
+            return Direction.RIGHT; // origin station — nothing above it
+        }
+        Station grandparent = survey.getOriginatingStation(referringLeg);
+        if (grandparent == null) {
+            return Direction.RIGHT;
+        }
+        Direction grandparentDirection = grandparent.getExtendedElevationDirection();
+        // If the grandparent is also VERTICAL, keep climbing until we find a real direction
+        // or exhaust the chain — but for simplicity one level is sufficient for typical caves.
+        return (grandparentDirection == Direction.VERTICAL) ? Direction.RIGHT : grandparentDirection;
     }
 }

--- a/app/src/main/java/org/hwyl/sexytopo/model/graph/Direction.java
+++ b/app/src/main/java/org/hwyl/sexytopo/model/graph/Direction.java
@@ -2,9 +2,12 @@ package org.hwyl.sexytopo.model.graph;
 
 public enum Direction {
     LEFT,
-    RIGHT;
+    RIGHT,
+    VERTICAL;
 
     public Direction opposite() {
-        return (this == LEFT) ? RIGHT : LEFT;
+        if (this == LEFT) return RIGHT;
+        if (this == RIGHT) return LEFT;
+        return VERTICAL;
     }
 }

--- a/app/src/main/java/org/hwyl/sexytopo/model/survey/Leg.java
+++ b/app/src/main/java/org/hwyl/sexytopo/model/survey/Leg.java
@@ -140,11 +140,7 @@ public class Leg extends SurveyComponent {
     public Leg adjustAzimuthAndInclination(float newAzimuth, float newInclination) {
         if (hasDestination()) {
             return new Leg(
-                    getDistance(),
-                    newAzimuth,
-                    newInclination,
-                    getDestination(),
-                    getPromotedFrom());
+                    getDistance(), newAzimuth, newInclination, getDestination(), getPromotedFrom());
         } else {
             return new Leg(getDistance(), newAzimuth, newInclination);
         }

--- a/app/src/main/java/org/hwyl/sexytopo/model/survey/Leg.java
+++ b/app/src/main/java/org/hwyl/sexytopo/model/survey/Leg.java
@@ -137,6 +137,19 @@ public class Leg extends SurveyComponent {
         }
     }
 
+    public Leg adjustAzimuthAndInclination(float newAzimuth, float newInclination) {
+        if (hasDestination()) {
+            return new Leg(
+                    getDistance(),
+                    newAzimuth,
+                    newInclination,
+                    getDestination(),
+                    getPromotedFrom());
+        } else {
+            return new Leg(getDistance(), newAzimuth, newInclination);
+        }
+    }
+
     public Leg asBacksight(Station destination) {
         float backAzimuth = Space2DUtils.adjustAngle(getAzimuth(), 180.0f);
         Leg leg =

--- a/app/src/main/java/org/hwyl/sexytopo/model/survey/Leg.java
+++ b/app/src/main/java/org/hwyl/sexytopo/model/survey/Leg.java
@@ -137,15 +137,6 @@ public class Leg extends SurveyComponent {
         }
     }
 
-    public Leg adjustAzimuthAndInclination(float newAzimuth, float newInclination) {
-        if (hasDestination()) {
-            return new Leg(
-                    getDistance(), newAzimuth, newInclination, getDestination(), getPromotedFrom());
-        } else {
-            return new Leg(getDistance(), newAzimuth, newInclination);
-        }
-    }
-
     public Leg asBacksight(Station destination) {
         float backAzimuth = Space2DUtils.adjustAngle(getAzimuth(), 180.0f);
         Leg leg =

--- a/app/src/main/res/menu/context_station.xml
+++ b/app/src/main/res/menu/context_station.xml
@@ -83,6 +83,11 @@
                         android:id="@+id/action_direction_right"
                         android:title="@string/menu_draw_right"
                         android:checkable="true"/>
+
+                    <item
+                        android:id="@+id/action_direction_vertical"
+                        android:title="@string/menu_draw_vertical"
+                        android:checkable="true"/>
                 </group>
             </menu>
         </item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -618,6 +618,7 @@
     <string name="menu_elevation">Elevation</string>
     <string name="menu_draw_left">Draw Left</string>
     <string name="menu_draw_right">Draw Right</string>
+    <string name="menu_draw_vertical">Draw Vertical</string>
     <string name="menu_move_row">Move to Different Station</string>
     <string name="menu_jump_to">Jump</string>
     <string name="menu_jump_to_station_in_plan">&#10132; Plan</string>

--- a/app/src/test/java/org/hwyl/sexytopo/control/util/Space3DTransformerForElevationTest.java
+++ b/app/src/test/java/org/hwyl/sexytopo/control/util/Space3DTransformerForElevationTest.java
@@ -1,0 +1,127 @@
+package org.hwyl.sexytopo.control.util;
+
+import org.hwyl.sexytopo.model.graph.Coord3D;
+import org.hwyl.sexytopo.model.graph.Direction;
+import org.hwyl.sexytopo.model.graph.Space;
+import org.hwyl.sexytopo.model.survey.Leg;
+import org.hwyl.sexytopo.model.survey.Survey;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class Space3DTransformerForElevationTest {
+
+    private static final double DELTA = 0.0001;
+    private static final Space3DTransformerForElevation TRANSFORMER =
+            new Space3DTransformerForElevation();
+
+    // --- RIGHT direction ---
+
+    @Test
+    public void testRightLegProjectsToPositiveY() {
+        Survey survey = new Survey();
+        SurveyUpdater.updateWithNewStation(survey, new Leg(5, 90, 0));
+        setDirectionOnStation(survey, "2", Direction.RIGHT);
+
+        Space<Coord3D> space = TRANSFORMER.transformTo3D(survey);
+        Coord3D station2 = space.getStationMap().get(survey.getStationByName("2"));
+
+        Assert.assertTrue("Right leg should produce positive y", station2.y > 0);
+    }
+
+    @Test
+    public void testRightLegZeroesXComponent() {
+        Survey survey = new Survey();
+        SurveyUpdater.updateWithNewStation(survey, new Leg(5, 90, 0));
+        setDirectionOnStation(survey, "2", Direction.RIGHT);
+
+        Space<Coord3D> space = TRANSFORMER.transformTo3D(survey);
+        Coord3D station2 = space.getStationMap().get(survey.getStationByName("2"));
+
+        Assert.assertEquals(0, station2.x, DELTA);
+    }
+
+    // --- LEFT direction ---
+
+    @Test
+    public void testLeftLegProjectsToNegativeY() {
+        Survey survey = new Survey();
+        SurveyUpdater.updateWithNewStation(survey, new Leg(5, 90, 0));
+        setDirectionOnStation(survey, "2", Direction.LEFT);
+
+        Space<Coord3D> space = TRANSFORMER.transformTo3D(survey);
+        Coord3D station2 = space.getStationMap().get(survey.getStationByName("2"));
+
+        Assert.assertTrue("Left leg should produce negative y", station2.y < 0);
+    }
+
+    @Test
+    public void testLeftLegZeroesXComponent() {
+        Survey survey = new Survey();
+        SurveyUpdater.updateWithNewStation(survey, new Leg(5, 90, 0));
+        setDirectionOnStation(survey, "2", Direction.LEFT);
+
+        Space<Coord3D> space = TRANSFORMER.transformTo3D(survey);
+        Coord3D station2 = space.getStationMap().get(survey.getStationByName("2"));
+
+        Assert.assertEquals(0, station2.x, DELTA);
+    }
+
+    // --- VERTICAL direction ---
+
+    @Test
+    public void testVerticalLegPreservesXY() {
+        Survey survey = new Survey();
+        SurveyUpdater.updateWithNewStation(survey, new Leg(5, 45, 60));
+        setDirectionOnStation(survey, "2", Direction.VERTICAL);
+
+        Space<Coord3D> space = TRANSFORMER.transformTo3D(survey);
+        Coord3D station2 = space.getStationMap().get(survey.getStationByName("2"));
+
+        Assert.assertEquals(0, station2.x, DELTA);
+        Assert.assertEquals(0, station2.y, DELTA);
+    }
+
+    @Test
+    public void testVerticalLegCorrectZ() {
+        // 10m leg at 30° inclination: z = 10 * sin(30°) = 5
+        Survey survey = new Survey();
+        SurveyUpdater.updateWithNewStation(survey, new Leg(10, 45, 30));
+        setDirectionOnStation(survey, "2", Direction.VERTICAL);
+
+        Space<Coord3D> space = TRANSFORMER.transformTo3D(survey);
+        Coord3D station2 = space.getStationMap().get(survey.getStationByName("2"));
+
+        Assert.assertEquals(5.0, station2.z, DELTA);
+    }
+
+    // --- Delta / subsequent leg rotation ---
+
+    @Test
+    public void testSubsequentLegAfterVerticalNotRotated() {
+        // Station 2 is vertical; station 3 should be plotted relative to station 2
+        // with zero rotation contributed by the vertical leg.
+        // Second leg azimuth=90 with RIGHT direction -> adjustAzimuth(0) -> azimuth=0 -> positive y
+        Survey survey = new Survey();
+        SurveyUpdater.updateWithNewStation(survey, new Leg(5, 90, 90));
+        SurveyUpdater.updateWithNewStation(survey, new Leg(5, 90, 0));
+
+        setDirectionOnStation(survey, "2", Direction.VERTICAL);
+        setDirectionOnStation(survey, "3", Direction.RIGHT);
+
+        Space<Coord3D> space = TRANSFORMER.transformTo3D(survey);
+        Coord3D station2 = space.getStationMap().get(survey.getStationByName("2"));
+        Coord3D station3 = space.getStationMap().get(survey.getStationByName("3"));
+
+        // Station 3 should be offset in y from station 2 with no x or z change
+        Assert.assertTrue(
+                "Station 3 should be positively offset in y from station 2 after a vertical leg",
+                station3.y > station2.y);
+        Assert.assertEquals(station2.x, station3.x, DELTA);
+    }
+
+    // --- Helpers ---
+
+    private void setDirectionOnStation(Survey survey, String name, Direction direction) {
+        survey.getStationByName(name).setExtendedElevationDirection(direction);
+    }
+}

--- a/app/src/test/java/org/hwyl/sexytopo/control/util/Space3DUtilsTest.java
+++ b/app/src/test/java/org/hwyl/sexytopo/control/util/Space3DUtilsTest.java
@@ -69,6 +69,37 @@ public class Space3DUtilsTest {
         assertEquals(Coord3D.ORIGIN, result);
     }
 
+    @Test
+    public void testVerticalLegStraightUp() {
+        Leg up1MLeg = new Leg(1, 0, 90);
+        Coord3D result = Space3DUtils.toCartesianVertical(Coord3D.ORIGIN, up1MLeg);
+        assertEquals(new Coord3D(0, 0, 1), result);
+    }
+
+    @Test
+    public void testVerticalLegStraightDown() {
+        Leg down1MLeg = new Leg(1, 0, -90);
+        Coord3D result = Space3DUtils.toCartesianVertical(Coord3D.ORIGIN, down1MLeg);
+        assertEquals(new Coord3D(0, 0, -1), result);
+    }
+
+    @Test
+    public void testVerticalLegInclinedPreservesXY() {
+        Leg inclinedLeg = new Leg(10, 45, 30);
+        Coord3D result = Space3DUtils.toCartesianVertical(Coord3D.ORIGIN, inclinedLeg);
+        // x and y must remain zero regardless of azimuth
+        Assert.assertEquals(0, result.x, 0.0001);
+        Assert.assertEquals(0, result.y, 0.0001);
+    }
+
+    @Test
+    public void testVerticalLegInclinedCorrectZ() {
+        Leg inclinedLeg = new Leg(10, 45, 30);
+        Coord3D result = Space3DUtils.toCartesianVertical(Coord3D.ORIGIN, inclinedLeg);
+        // z = 10 * sin(30°) = 5
+        Assert.assertEquals(5.0, result.z, 0.0001);
+    }
+
     private void assertEquals(Coord3D zero, Coord3D one) {
 
         double x0 = zero.x;

--- a/app/src/test/java/org/hwyl/sexytopo/control/util/SurveyUpdaterInheritedDirectionTest.java
+++ b/app/src/test/java/org/hwyl/sexytopo/control/util/SurveyUpdaterInheritedDirectionTest.java
@@ -9,111 +9,121 @@ import org.junit.Test;
 
 public class SurveyUpdaterInheritedDirectionTest {
 
-    private static final Leg DUMMY_LEG = new Leg(5, 0, 0);
+    // Three identical splays are required to trigger createNewStationIfTripleShot,
+    // which is the only path that calls resolveInheritedDirection.
+    private static final Leg SPLAY = new Leg(5, 0, 0);
 
     /**
-     * Builds a linear survey with the given number of legs and returns it.
-     * Station names will be "1" (origin), "2", "3", ...
+     * Adds a new station via three matching splays, which triggers the triple-shot path and causes
+     * resolveInheritedDirection to be called. Returns the newly-created station.
      */
-    private Survey buildLinearSurvey(int legCount) {
-        Survey survey = new Survey();
-        for (int i = 0; i < legCount; i++) {
-            SurveyUpdater.updateWithNewStation(survey, DUMMY_LEG);
-        }
-        return survey;
+    private Station addStationViaTripleShot(Survey survey) {
+        Station before = survey.getActiveStation();
+        SurveyUpdater.update(survey, SPLAY);
+        SurveyUpdater.update(survey, SPLAY);
+        SurveyUpdater.update(survey, SPLAY);
+        Station after = survey.getActiveStation();
+        Assert.assertNotSame("Triple shot should have created a new station", before, after);
+        return after;
     }
 
     // --- Non-vertical parent ---
 
     @Test
     public void testNonVerticalParentInheritsOwnDirection() {
-        Survey survey = buildLinearSurvey(1);
-        survey.getStationByName("2").setExtendedElevationDirection(Direction.LEFT);
+        Survey survey = new Survey();
+        survey.getOrigin().setExtendedElevationDirection(Direction.LEFT);
 
-        SurveyUpdater.updateWithNewStation(survey, DUMMY_LEG);
+        Station newStation = addStationViaTripleShot(survey);
 
-        Station newStation = survey.getStationByName("3");
         Assert.assertEquals(Direction.LEFT, newStation.getExtendedElevationDirection());
     }
 
     @Test
     public void testRightParentInheritsRight() {
-        Survey survey = buildLinearSurvey(1);
-        survey.getStationByName("2").setExtendedElevationDirection(Direction.RIGHT);
+        Survey survey = new Survey();
+        survey.getOrigin().setExtendedElevationDirection(Direction.RIGHT);
 
-        SurveyUpdater.updateWithNewStation(survey, DUMMY_LEG);
+        Station newStation = addStationViaTripleShot(survey);
 
-        Station newStation = survey.getStationByName("3");
         Assert.assertEquals(Direction.RIGHT, newStation.getExtendedElevationDirection());
     }
 
     // --- Single vertical parent ---
 
     @Test
-    public void testVerticalParentInheritsFromGrandparent() {
-        // Origin("1") = RIGHT, station "2" = VERTICAL → new station "3" should inherit RIGHT
-        Survey survey = buildLinearSurvey(1);
-        survey.getStationByName("2").setExtendedElevationDirection(Direction.VERTICAL);
+    public void testVerticalParentInheritsRightFromGrandparent() {
+        // Origin = RIGHT, then add station via triple-shot, mark it VERTICAL,
+        // then add another station — should inherit RIGHT from origin.
+        Survey survey = new Survey();
+        survey.getOrigin().setExtendedElevationDirection(Direction.RIGHT);
 
-        SurveyUpdater.updateWithNewStation(survey, DUMMY_LEG);
+        Station firstStation = addStationViaTripleShot(survey);
+        firstStation.setExtendedElevationDirection(Direction.VERTICAL);
 
-        Station newStation = survey.getStationByName("3");
-        Assert.assertEquals(Direction.RIGHT, newStation.getExtendedElevationDirection());
+        Station secondStation = addStationViaTripleShot(survey);
+
+        Assert.assertEquals(Direction.RIGHT, secondStation.getExtendedElevationDirection());
     }
 
     @Test
     public void testVerticalParentInheritsLeftFromGrandparent() {
-        // Origin("1") = LEFT, station "2" = VERTICAL → new station "3" should inherit LEFT
-        Survey survey = buildLinearSurvey(1);
+        // Origin = LEFT, then add station via triple-shot, mark it VERTICAL,
+        // then add another station — should inherit LEFT from origin.
+        Survey survey = new Survey();
         survey.getOrigin().setExtendedElevationDirection(Direction.LEFT);
-        survey.getStationByName("2").setExtendedElevationDirection(Direction.VERTICAL);
 
-        SurveyUpdater.updateWithNewStation(survey, DUMMY_LEG);
+        Station firstStation = addStationViaTripleShot(survey);
+        firstStation.setExtendedElevationDirection(Direction.VERTICAL);
 
-        Station newStation = survey.getStationByName("3");
-        Assert.assertEquals(Direction.LEFT, newStation.getExtendedElevationDirection());
+        Station secondStation = addStationViaTripleShot(survey);
+
+        Assert.assertEquals(Direction.LEFT, secondStation.getExtendedElevationDirection());
     }
 
     // --- Multiple consecutive vertical parents (the case the old code got wrong) ---
 
     @Test
-    public void testTwoConsecutiveVerticalsInheritsFromGreatGrandparent() {
-        // "1"=RIGHT, "2"=VERTICAL, "3"=VERTICAL → new station "4" should climb to "1" and get RIGHT
-        Survey survey = buildLinearSurvey(2);
-        survey.getStationByName("2").setExtendedElevationDirection(Direction.VERTICAL);
-        survey.getStationByName("3").setExtendedElevationDirection(Direction.VERTICAL);
+    public void testTwoConsecutiveVerticalsInheritsRightFromGreatGrandparent() {
+        Survey survey = new Survey();
+        survey.getOrigin().setExtendedElevationDirection(Direction.RIGHT);
 
-        SurveyUpdater.updateWithNewStation(survey, DUMMY_LEG);
+        Station firstStation = addStationViaTripleShot(survey);
+        firstStation.setExtendedElevationDirection(Direction.VERTICAL);
 
-        Station newStation = survey.getStationByName("4");
-        Assert.assertEquals(Direction.RIGHT, newStation.getExtendedElevationDirection());
+        Station secondStation = addStationViaTripleShot(survey);
+        secondStation.setExtendedElevationDirection(Direction.VERTICAL);
+
+        Station thirdStation = addStationViaTripleShot(survey);
+
+        Assert.assertEquals(Direction.RIGHT, thirdStation.getExtendedElevationDirection());
     }
 
     @Test
     public void testTwoConsecutiveVerticalsInheritsLeftFromGreatGrandparent() {
-        // "1"=LEFT, "2"=VERTICAL, "3"=VERTICAL → new station "4" should climb to "1" and get LEFT
-        Survey survey = buildLinearSurvey(2);
+        Survey survey = new Survey();
         survey.getOrigin().setExtendedElevationDirection(Direction.LEFT);
-        survey.getStationByName("2").setExtendedElevationDirection(Direction.VERTICAL);
-        survey.getStationByName("3").setExtendedElevationDirection(Direction.VERTICAL);
 
-        SurveyUpdater.updateWithNewStation(survey, DUMMY_LEG);
+        Station firstStation = addStationViaTripleShot(survey);
+        firstStation.setExtendedElevationDirection(Direction.VERTICAL);
 
-        Station newStation = survey.getStationByName("4");
-        Assert.assertEquals(Direction.LEFT, newStation.getExtendedElevationDirection());
+        Station secondStation = addStationViaTripleShot(survey);
+        secondStation.setExtendedElevationDirection(Direction.VERTICAL);
+
+        Station thirdStation = addStationViaTripleShot(survey);
+
+        Assert.assertEquals(Direction.LEFT, thirdStation.getExtendedElevationDirection());
     }
 
     // --- Vertical at origin (edge case) ---
 
     @Test
     public void testVerticalOriginFallsBackToRight() {
-        // Origin itself is VERTICAL — no ancestor to inherit from, should fall back to RIGHT
         Survey survey = new Survey();
         survey.getOrigin().setExtendedElevationDirection(Direction.VERTICAL);
 
-        SurveyUpdater.updateWithNewStation(survey, DUMMY_LEG);
+        Station newStation = addStationViaTripleShot(survey);
 
-        Station newStation = survey.getStationByName("2");
         Assert.assertEquals(Direction.RIGHT, newStation.getExtendedElevationDirection());
     }
 }

--- a/app/src/test/java/org/hwyl/sexytopo/control/util/SurveyUpdaterInheritedDirectionTest.java
+++ b/app/src/test/java/org/hwyl/sexytopo/control/util/SurveyUpdaterInheritedDirectionTest.java
@@ -1,0 +1,119 @@
+package org.hwyl.sexytopo.control.util;
+
+import org.hwyl.sexytopo.model.graph.Direction;
+import org.hwyl.sexytopo.model.survey.Leg;
+import org.hwyl.sexytopo.model.survey.Station;
+import org.hwyl.sexytopo.model.survey.Survey;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SurveyUpdaterInheritedDirectionTest {
+
+    private static final Leg DUMMY_LEG = new Leg(5, 0, 0);
+
+    /**
+     * Builds a linear survey with the given number of legs and returns it.
+     * Station names will be "1" (origin), "2", "3", ...
+     */
+    private Survey buildLinearSurvey(int legCount) {
+        Survey survey = new Survey();
+        for (int i = 0; i < legCount; i++) {
+            SurveyUpdater.updateWithNewStation(survey, DUMMY_LEG);
+        }
+        return survey;
+    }
+
+    // --- Non-vertical parent ---
+
+    @Test
+    public void testNonVerticalParentInheritsOwnDirection() {
+        Survey survey = buildLinearSurvey(1);
+        survey.getStationByName("2").setExtendedElevationDirection(Direction.LEFT);
+
+        SurveyUpdater.updateWithNewStation(survey, DUMMY_LEG);
+
+        Station newStation = survey.getStationByName("3");
+        Assert.assertEquals(Direction.LEFT, newStation.getExtendedElevationDirection());
+    }
+
+    @Test
+    public void testRightParentInheritsRight() {
+        Survey survey = buildLinearSurvey(1);
+        survey.getStationByName("2").setExtendedElevationDirection(Direction.RIGHT);
+
+        SurveyUpdater.updateWithNewStation(survey, DUMMY_LEG);
+
+        Station newStation = survey.getStationByName("3");
+        Assert.assertEquals(Direction.RIGHT, newStation.getExtendedElevationDirection());
+    }
+
+    // --- Single vertical parent ---
+
+    @Test
+    public void testVerticalParentInheritsFromGrandparent() {
+        // Origin("1") = RIGHT, station "2" = VERTICAL → new station "3" should inherit RIGHT
+        Survey survey = buildLinearSurvey(1);
+        survey.getStationByName("2").setExtendedElevationDirection(Direction.VERTICAL);
+
+        SurveyUpdater.updateWithNewStation(survey, DUMMY_LEG);
+
+        Station newStation = survey.getStationByName("3");
+        Assert.assertEquals(Direction.RIGHT, newStation.getExtendedElevationDirection());
+    }
+
+    @Test
+    public void testVerticalParentInheritsLeftFromGrandparent() {
+        // Origin("1") = LEFT, station "2" = VERTICAL → new station "3" should inherit LEFT
+        Survey survey = buildLinearSurvey(1);
+        survey.getOrigin().setExtendedElevationDirection(Direction.LEFT);
+        survey.getStationByName("2").setExtendedElevationDirection(Direction.VERTICAL);
+
+        SurveyUpdater.updateWithNewStation(survey, DUMMY_LEG);
+
+        Station newStation = survey.getStationByName("3");
+        Assert.assertEquals(Direction.LEFT, newStation.getExtendedElevationDirection());
+    }
+
+    // --- Multiple consecutive vertical parents (the case the old code got wrong) ---
+
+    @Test
+    public void testTwoConsecutiveVerticalsInheritsFromGreatGrandparent() {
+        // "1"=RIGHT, "2"=VERTICAL, "3"=VERTICAL → new station "4" should climb to "1" and get RIGHT
+        Survey survey = buildLinearSurvey(2);
+        survey.getStationByName("2").setExtendedElevationDirection(Direction.VERTICAL);
+        survey.getStationByName("3").setExtendedElevationDirection(Direction.VERTICAL);
+
+        SurveyUpdater.updateWithNewStation(survey, DUMMY_LEG);
+
+        Station newStation = survey.getStationByName("4");
+        Assert.assertEquals(Direction.RIGHT, newStation.getExtendedElevationDirection());
+    }
+
+    @Test
+    public void testTwoConsecutiveVerticalsInheritsLeftFromGreatGrandparent() {
+        // "1"=LEFT, "2"=VERTICAL, "3"=VERTICAL → new station "4" should climb to "1" and get LEFT
+        Survey survey = buildLinearSurvey(2);
+        survey.getOrigin().setExtendedElevationDirection(Direction.LEFT);
+        survey.getStationByName("2").setExtendedElevationDirection(Direction.VERTICAL);
+        survey.getStationByName("3").setExtendedElevationDirection(Direction.VERTICAL);
+
+        SurveyUpdater.updateWithNewStation(survey, DUMMY_LEG);
+
+        Station newStation = survey.getStationByName("4");
+        Assert.assertEquals(Direction.LEFT, newStation.getExtendedElevationDirection());
+    }
+
+    // --- Vertical at origin (edge case) ---
+
+    @Test
+    public void testVerticalOriginFallsBackToRight() {
+        // Origin itself is VERTICAL — no ancestor to inherit from, should fall back to RIGHT
+        Survey survey = new Survey();
+        survey.getOrigin().setExtendedElevationDirection(Direction.VERTICAL);
+
+        SurveyUpdater.updateWithNewStation(survey, DUMMY_LEG);
+
+        Station newStation = survey.getStationByName("2");
+        Assert.assertEquals(Direction.RIGHT, newStation.getExtendedElevationDirection());
+    }
+}


### PR DESCRIPTION
For some situations it is better to ignore the left or right part of the extended elevation and only use the height change. As an example, this happens when a leg goes across a passage.
Added the ability to make a leg only use the vertical height change.
This is supported by Therion, but it appears not by Survex. However, the extend export for Survex is currently wrong and does not work.

In commit 7f6b133 I thought that the forced to vertical legs should be shown some how, I've tried making them dashed. Not sure this is the right solution but I do feel they should be differentiated somehow