### PR TITLE
Inclination checks

### DIFF
--- a/app/src/main/java/org/hwyl/sexytopo/control/table/EditLegForm.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/table/EditLegForm.java
@@ -19,6 +19,29 @@ public class EditLegForm extends Form {
     private static final int SPINNER_FORWARD = 0;
     private static final int SPINNER_BACKWARD = 1;
 
+    /**
+     * A TextWatcher that, in addition to triggering validation, enables range-error display
+     * as soon as the watched field contains any non-empty text. This lets out-of-range errors
+     * appear immediately while the user is typing, without showing a "cannot be blank" error
+     * on an untouched field.
+     */
+    private static class RangeValidationTrigger extends TextViewValidationTrigger {
+        private final android.widget.EditText field;
+
+        RangeValidationTrigger(Form form, android.widget.EditText field) {
+            super(form);
+            this.field = field;
+        }
+
+        @Override
+        public void afterTextChanged(android.text.Editable editable) {
+            if (field.getText().length() > 0) {
+                form.enableRangeErrors();
+            }
+            super.afterTextChanged(editable);
+        }
+    }
+
     private final Context context;
     private final Survey survey;
     private String defaultToName;
@@ -126,10 +149,10 @@ public class EditLegForm extends Form {
             this.toStationField.addTextChangedListener(new TextViewValidationTrigger(this));
         }
         this.distanceField.addTextChangedListener(new TextViewValidationTrigger(this));
-        this.azimuthField.addTextChangedListener(new TextViewValidationTrigger(this));
-        this.inclinationField.addTextChangedListener(new TextViewValidationTrigger(this));
+        this.azimuthField.addTextChangedListener(new RangeValidationTrigger(this, this.azimuthField));
+        this.inclinationField.addTextChangedListener(new RangeValidationTrigger(this, this.inclinationField));
 
-        // Enable error display once user first interacts with any field
+        // Enable error display once the user leaves a field for the first time.
         android.view.View.OnFocusChangeListener enableErrorsOnTouch =
                 (v, hasFocus) -> {
                     if (!hasFocus) {
@@ -344,14 +367,14 @@ public class EditLegForm extends Form {
             } else {
                 float azimuth = Float.parseFloat(azimuthText);
                 if (!Leg.isAzimuthLegal(azimuth)) {
-                    setError(
+                    setRangeError(
                             this.azimuthLayout,
                             context.getString(
                                     R.string.validation_error_azimuth_range,
                                     Leg.MIN_AZIMUTH,
                                     Leg.MAX_AZIMUTH));
                 } else {
-                    setError(this.azimuthLayout, (Integer) null);
+                    setRangeError(this.azimuthLayout, (Integer) null);
                 }
             }
         } catch (NumberFormatException e) {
@@ -371,14 +394,14 @@ public class EditLegForm extends Form {
             } else {
                 float inclination = Float.parseFloat(inclinationText);
                 if (!Leg.isInclinationLegal(inclination)) {
-                    setError(
+                    setRangeError(
                             this.inclinationLayout,
                             context.getString(
                                     R.string.validation_error_inclination_range,
                                     Leg.MIN_INCLINATION,
                                     Leg.MAX_INCLINATION));
                 } else {
-                    setError(this.inclinationLayout, (Integer) null);
+                    setRangeError(this.inclinationLayout, (Integer) null);
                 }
             }
         } catch (NumberFormatException e) {

--- a/app/src/main/java/org/hwyl/sexytopo/control/table/EditLegForm.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/table/EditLegForm.java
@@ -439,8 +439,8 @@ public class EditLegForm extends Form {
         // RangeValidationTrigger does for the decimal azimuth field.
         enableRangeErrors();
         boolean dmsValid =
-                validateMinsSecsField(azimuthMinutesLayout, azimuthMinutesField)
-                        & validateMinsSecsField(azimuthSecondsLayout, azimuthSecondsField);
+                validateMinutesField(azimuthMinutesLayout, azimuthMinutesField)
+                        & validateSecondsField(azimuthSecondsLayout, azimuthSecondsField);
         if (!dmsValid) return;
 
         // Compute decimal equivalent and range-check it, showing error on degrees layout
@@ -504,8 +504,8 @@ public class EditLegForm extends Form {
         // RangeValidationTrigger does for the decimal inclination field.
         enableRangeErrors();
         boolean dmsValid =
-                validateMinsSecsField(inclinationMinutesLayout, inclinationMinutesField)
-                        & validateMinsSecsField(inclinationSecondsLayout, inclinationSecondsField);
+                validateMinutesField(inclinationMinutesLayout, inclinationMinutesField)
+                        & validateSecondsField(inclinationSecondsLayout, inclinationSecondsField);
         if (!dmsValid) return;
 
         // Compute decimal equivalent and range-check it, showing error on degrees layout.
@@ -527,19 +527,16 @@ public class EditLegForm extends Form {
     }
 
     /**
-     * Validates a minutes or seconds field. Blank is accepted (treated as zero). If non-blank, the
-     * value must be a whole number in the range 0-59. Sets an error on the layout and marks the
-     * form invalid if not. Returns true if the field is valid (or blank), false otherwise. Uses
-     * bitwise & rather than && in callers so both fields are always evaluated and both errors shown
-     * at once rather than stopping at the first failure.
+     * Validates a minutes field. Blank is accepted (treated as zero). If non-blank, the value must
+     * be a whole number in the range 0–59. Sets an error on the layout and marks the form invalid
+     * if not. Returns true if the field is valid (or blank), false otherwise.
      */
-    private boolean validateMinsSecsField(TextInputLayout layout, EditText field) {
+    private boolean validateMinutesField(TextInputLayout layout, EditText field) {
         String text = field.getText().toString();
         if (text.isEmpty()) {
             setError(layout, (Integer) null);
             return true;
         }
-        // Must be a whole number (no decimal point)
         if (text.contains(".")) {
             setError(layout, context.getString(R.string.validation_error_must_be_whole_number));
             return false;
@@ -554,6 +551,32 @@ public class EditLegForm extends Form {
             return true;
         } catch (NumberFormatException e) {
             setError(layout, context.getString(R.string.validation_error_must_be_whole_number));
+            return false;
+        }
+    }
+
+    /**
+     * Validates a seconds field. Blank is accepted (treated as zero). If non-blank, the value must
+     * be a non-negative number less than 60; decimal values (e.g. {@code 30.5}) are permitted. Sets
+     * an error on the layout and marks the form invalid if not. Returns true if the field is valid
+     * (or blank), false otherwise.
+     */
+    private boolean validateSecondsField(TextInputLayout layout, EditText field) {
+        String text = field.getText().toString();
+        if (text.isEmpty()) {
+            setError(layout, (Integer) null);
+            return true;
+        }
+        try {
+            float value = Float.parseFloat(text);
+            if (value < 0 || value >= 60) {
+                setError(layout, context.getString(R.string.validation_error_secs_range));
+                return false;
+            }
+            setError(layout, (Integer) null);
+            return true;
+        } catch (NumberFormatException e) {
+            setError(layout, context.getString(R.string.validation_error_must_be_number));
             return false;
         }
     }

--- a/app/src/main/java/org/hwyl/sexytopo/control/table/EditLegForm.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/table/EditLegForm.java
@@ -396,10 +396,7 @@ public class EditLegForm extends Form {
                 if (!Leg.isInclinationLegal(inclination)) {
                     setRangeError(
                             this.inclinationLayout,
-                            context.getString(
-                                    R.string.validation_error_inclination_range,
-                                    Leg.MIN_INCLINATION,
-                                    Leg.MAX_INCLINATION));
+                            context.getString(R.string.validation_error_inclination_range));
                 } else {
                     setRangeError(this.inclinationLayout, (Integer) null);
                 }

--- a/app/src/main/java/org/hwyl/sexytopo/control/table/EditLegForm.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/table/EditLegForm.java
@@ -204,6 +204,15 @@ public class EditLegForm extends Form {
         this.distanceField.setOnFocusChangeListener(enableErrorsOnTouch);
         this.azimuthField.setOnFocusChangeListener(enableErrorsOnTouch);
         this.inclinationField.setOnFocusChangeListener(enableErrorsOnTouch);
+
+        if (GeneralPreferences.isDegMinsSecsModeOn()) {
+            this.azimuthMinutesField.setOnFocusChangeListener(enableErrorsOnTouch);
+            this.azimuthSecondsField.setOnFocusChangeListener(enableErrorsOnTouch);
+        }
+        if (GeneralPreferences.isIncDegMinsSecsModeOn()) {
+            this.inclinationMinutesField.setOnFocusChangeListener(enableErrorsOnTouch);
+            this.inclinationSecondsField.setOnFocusChangeListener(enableErrorsOnTouch);
+        }
     }
 
     private void initialiseInputMode(View dialogView) {
@@ -438,27 +447,42 @@ public class EditLegForm extends Form {
         // Degrees has content - enable range error display, mirroring what
         // RangeValidationTrigger does for the decimal azimuth field.
         enableRangeErrors();
-        boolean dmsValid =
-                validateMinutesField(azimuthMinutesLayout, azimuthMinutesField)
+        boolean ignored =
+                validateAzimuthDegreesField()
+                        & validateMinutesField(azimuthMinutesLayout, azimuthMinutesField)
                         & validateSecondsField(azimuthSecondsLayout, azimuthSecondsField);
-        if (!dmsValid) return;
+    }
 
-        // Compute decimal equivalent and range-check it, showing error on degrees layout
+    /**
+     * Validates the azimuth degrees field independently. The value must be a whole number in [0,
+     * 359]. Sets a range error on {@code azimuthDegreesLayout} and marks the form invalid if out of
+     * range. Returns true if valid, false otherwise.
+     */
+    private boolean validateAzimuthDegreesField() {
+        String text = azimuthDegreesField.getText().toString();
+        if (text.contains(".")) {
+            setError(
+                    azimuthDegreesLayout,
+                    context.getString(R.string.validation_error_must_be_whole_number));
+            return false;
+        }
         try {
-            float azimuth = getAzimuth();
-            if (!Leg.isAzimuthLegal(azimuth)) {
+            int degrees = Integer.parseInt(text);
+            if (degrees < Leg.MIN_AZIMUTH || degrees >= Leg.MAX_AZIMUTH) {
                 setRangeError(
-                        this.azimuthDegreesLayout,
+                        azimuthDegreesLayout,
                         context.getString(
                                 R.string.validation_error_azimuth_range,
                                 Leg.MIN_AZIMUTH,
                                 Leg.MAX_AZIMUTH));
-            } else {
-                setRangeError(this.azimuthDegreesLayout, (Integer) null);
+                return false;
             }
+            setRangeError(azimuthDegreesLayout, (Integer) null);
+            return true;
         } catch (NumberFormatException e) {
-            // Degrees field contains a partial value (e.g. just "-"), not yet parseable
+            // Partial input such as a lone "-"; not yet parseable, suppress error display
             this.valid = false;
+            return false;
         }
     }
 
@@ -503,26 +527,98 @@ public class EditLegForm extends Form {
         // Degrees has content - enable range error display, mirroring what
         // RangeValidationTrigger does for the decimal inclination field.
         enableRangeErrors();
-        boolean dmsValid =
-                validateMinutesField(inclinationMinutesLayout, inclinationMinutesField)
-                        & validateSecondsField(inclinationSecondsLayout, inclinationSecondsField);
-        if (!dmsValid) return;
+        boolean ignored =
+                validateInclinationDegreesField()
+                        & validateInclinationMinutesField()
+                        & validateInclinationSecondsField();
+    }
 
-        // Compute decimal equivalent and range-check it, showing error on degrees layout.
-        // Wrap in try/catch to handle partial input such as a lone "-" which is not yet
-        // parseable as a float but is a valid intermediate state while typing a negative value.
+    /**
+     * Validates the inclination degrees field independently. The value must be a whole number in
+     * [−90, 90] or [270, 360] (theodolite range). Sets a range error on {@code
+     * inclinationDegreesLayout} and marks the form invalid if out of range. Returns true if valid,
+     * false otherwise.
+     */
+    private boolean validateInclinationDegreesField() {
+        String text = inclinationDegreesField.getText().toString();
+        if (text.contains(".")) {
+            setError(
+                    inclinationDegreesLayout,
+                    context.getString(R.string.validation_error_must_be_whole_number));
+            return false;
+        }
         try {
-            float inclination = getInclination();
-            if (!Leg.isInclinationLegal(inclination)) {
+            int degrees = Integer.parseInt(text);
+            boolean inNormalRange =
+                    degrees >= Leg.MIN_INCLINATION && degrees <= Leg.MAX_INCLINATION;
+            boolean inTheodoliteRange =
+                    degrees >= Leg.MIN_THEODOLITE_INC && degrees <= Leg.MAX_THEODOLITE_INC;
+            if (!inNormalRange && !inTheodoliteRange) {
                 setRangeError(
-                        this.inclinationDegreesLayout,
+                        inclinationDegreesLayout,
                         context.getString(R.string.validation_error_inclination_range));
-            } else {
-                setRangeError(this.inclinationDegreesLayout, (Integer) null);
+                return false;
             }
+            setRangeError(inclinationDegreesLayout, (Integer) null);
+            return true;
         } catch (NumberFormatException e) {
-            // Degrees field contains a partial value (e.g. just "-"), not yet parseable
+            // Partial input such as a lone "-"; not yet parseable, suppress error display
             this.valid = false;
+            return false;
+        }
+    }
+
+    /**
+     * Validates the inclination minutes field. Applies the standard 0–59 whole-number check, plus
+     * an additional constraint: if the degrees field contains ±90, minutes must be 0 or blank since
+     * as a minute or second value would take it out of range.
+     */
+    private boolean validateInclinationMinutesField() {
+        if (isAtInclinationBoundary() && !isZeroOrBlank(inclinationMinutesField)) {
+            setError(
+                    inclinationMinutesLayout,
+                    context.getString(R.string.validation_error_must_be_zero_for_90));
+            return false;
+        }
+        return validateMinutesField(inclinationMinutesLayout, inclinationMinutesField);
+    }
+
+    /**
+     * Validates the inclination seconds field. Applies the standard 0–59.99 check, plus an
+     * additional constraint: if the degrees field contains ±90, seconds must be 0 or blank.
+     */
+    private boolean validateInclinationSecondsField() {
+        if (isAtInclinationBoundary() && !isZeroOrBlank(inclinationSecondsField)) {
+            setError(
+                    inclinationSecondsLayout,
+                    context.getString(R.string.validation_error_must_be_zero_for_90));
+            return false;
+        }
+        return validateSecondsField(inclinationSecondsLayout, inclinationSecondsField);
+    }
+
+    /**
+     * Returns true if the inclination degrees field contains exactly 90 or −90, indicating that the
+     * reading is at the vertical boundary and minutes/seconds must be zero.
+     */
+    private boolean isAtInclinationBoundary() {
+        String text = inclinationDegreesField.getText().toString();
+        return text.equals("90") || text.equals("-90");
+    }
+
+    /**
+     * Returns true if the given field is blank or contains a value that is numerically zero (e.g.
+     * "0", "0.0", "00"). Used to enforce the ±90° boundary constraint.
+     */
+    private boolean isZeroOrBlank(EditText field) {
+        String text = field.getText().toString();
+        if (text.isEmpty()) {
+            return true;
+        }
+        try {
+            return Float.parseFloat(text) == 0.0f;
+        } catch (NumberFormatException e) {
+            return false;
         }
     }
 

--- a/app/src/main/java/org/hwyl/sexytopo/control/table/EditLegForm.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/table/EditLegForm.java
@@ -10,6 +10,7 @@ import com.google.android.material.textfield.TextInputLayout;
 import org.hwyl.sexytopo.R;
 import org.hwyl.sexytopo.SexyTopoConstants;
 import org.hwyl.sexytopo.control.util.InputMode;
+import org.hwyl.sexytopo.control.util.GeneralPreferences;
 import org.hwyl.sexytopo.control.util.SurveyTools;
 import org.hwyl.sexytopo.model.survey.Leg;
 import org.hwyl.sexytopo.model.survey.Station;
@@ -67,6 +68,14 @@ public class EditLegForm extends Form {
     private TextInputLayout azimuthLayout;
     private TextInputLayout inclinationLayout;
 
+    // TextInputLayout wrappers for DMS minutes/seconds fields, used to show range errors
+    private TextInputLayout azimuthMinutesLayout;
+    private TextInputLayout azimuthSecondsLayout;
+    private TextInputLayout inclinationMinutesLayout;
+    private TextInputLayout inclinationSecondsLayout;
+    private TextInputLayout azimuthDegreesLayout;
+    private TextInputLayout inclinationDegreesLayout;
+
     private EditText distanceField;
     private EditText azimuthField;
     private EditText inclinationField;
@@ -75,6 +84,9 @@ public class EditLegForm extends Form {
     private EditText azimuthDegreesField;
     private EditText azimuthMinutesField;
     private EditText azimuthSecondsField;
+    private EditText inclinationDegreesField;
+    private EditText inclinationMinutesField;
+    private EditText inclinationSecondsField;
 
     private Spinner inputModeSpinner;
     private InputMode inputMode = InputMode.FORWARD;
@@ -130,6 +142,12 @@ public class EditLegForm extends Form {
         this.distanceLayout = dialogView.findViewById(R.id.distanceLayout);
         this.azimuthLayout = dialogView.findViewById(R.id.azimuth_standard);
         this.inclinationLayout = dialogView.findViewById(R.id.inclinationLayout);
+        this.azimuthMinutesLayout = dialogView.findViewById(R.id.editAzimuthMinutesLayout);
+        this.azimuthSecondsLayout = dialogView.findViewById(R.id.editAzimuthSecondsLayout);
+        this.inclinationMinutesLayout = dialogView.findViewById(R.id.editInclinationMinutesLayout);
+        this.inclinationSecondsLayout = dialogView.findViewById(R.id.editInclinationSecondsLayout);
+        this.azimuthDegreesLayout = dialogView.findViewById(R.id.editAzimuthDegreesLayout);
+        this.inclinationDegreesLayout = dialogView.findViewById(R.id.editInclinationDegreesLayout);
 
         this.fromStationField = dialogView.findViewById(R.id.editFromStation);
         this.fromCommentField = dialogView.findViewById(R.id.editFromComment);
@@ -141,6 +159,9 @@ public class EditLegForm extends Form {
         this.azimuthDegreesField = dialogView.findViewById(R.id.editAzimuthDegrees);
         this.azimuthMinutesField = dialogView.findViewById(R.id.editAzimuthMinutes);
         this.azimuthSecondsField = dialogView.findViewById(R.id.editAzimuthSeconds);
+        this.inclinationDegreesField = dialogView.findViewById(R.id.editInclinationDegrees);
+        this.inclinationMinutesField = dialogView.findViewById(R.id.editInclinationMinutes);
+        this.inclinationSecondsField = dialogView.findViewById(R.id.editInclinationSeconds);
         this.inputModeSpinner = dialogView.findViewById(R.id.inputModeSpinner);
 
         // Set up validation listeners
@@ -151,6 +172,17 @@ public class EditLegForm extends Form {
         this.distanceField.addTextChangedListener(new TextViewValidationTrigger(this));
         this.azimuthField.addTextChangedListener(new RangeValidationTrigger(this, this.azimuthField));
         this.inclinationField.addTextChangedListener(new RangeValidationTrigger(this, this.inclinationField));
+
+        if (GeneralPreferences.isDegMinsSecsModeOn()) {
+            this.azimuthDegreesField.addTextChangedListener(new TextViewValidationTrigger(this));
+            this.azimuthMinutesField.addTextChangedListener(new TextViewValidationTrigger(this));
+            this.azimuthSecondsField.addTextChangedListener(new TextViewValidationTrigger(this));
+        }
+        if (GeneralPreferences.isIncDegMinsSecsModeOn()) {
+            this.inclinationDegreesField.addTextChangedListener(new TextViewValidationTrigger(this));
+            this.inclinationMinutesField.addTextChangedListener(new TextViewValidationTrigger(this));
+            this.inclinationSecondsField.addTextChangedListener(new TextViewValidationTrigger(this));
+        }
 
         // Enable error display once the user leaves a field for the first time.
         android.view.View.OnFocusChangeListener enableErrorsOnTouch =
@@ -358,6 +390,14 @@ public class EditLegForm extends Form {
     }
 
     private void validateAzimuth() {
+        if (GeneralPreferences.isDegMinsSecsModeOn()) {
+            validateAzimuthDms();
+        } else {
+            validateAzimuthDecimal();
+        }
+    }
+
+    private void validateAzimuthDecimal() {
         String azimuthText = this.azimuthField.getText().toString();
         try {
             if (azimuthText.isEmpty()) {
@@ -384,7 +424,47 @@ public class EditLegForm extends Form {
         }
     }
 
+    private void validateAzimuthDms() {
+        // Degrees is required; missing minutes/seconds are treated as zero.
+        if (azimuthDegreesField.getText().toString().isEmpty()) {
+            this.valid = false;
+            return;
+        }
+        // Degrees has content - enable range error display, mirroring what
+        // RangeValidationTrigger does for the decimal azimuth field.
+        enableRangeErrors();
+        boolean dmsValid = validateMinsSecsField(azimuthMinutesLayout, azimuthMinutesField)
+                & validateMinsSecsField(azimuthSecondsLayout, azimuthSecondsField);
+        if (!dmsValid) return;
+
+        // Compute decimal equivalent and range-check it, showing error on degrees layout
+        try {
+            float azimuth = getAzimuth();
+            if (!Leg.isAzimuthLegal(azimuth)) {
+                setRangeError(
+                        this.azimuthDegreesLayout,
+                        context.getString(
+                                R.string.validation_error_azimuth_range,
+                                Leg.MIN_AZIMUTH,
+                                Leg.MAX_AZIMUTH));
+            } else {
+                setRangeError(this.azimuthDegreesLayout, (Integer) null);
+            }
+        } catch (NumberFormatException e) {
+            // Degrees field contains a partial value (e.g. just "-"), not yet parseable
+            this.valid = false;
+        }
+    }
+
     private void validateInclination() {
+        if (GeneralPreferences.isIncDegMinsSecsModeOn()) {
+            validateInclinationDms();
+        } else {
+            validateInclinationDecimal();
+        }
+    }
+
+    private void validateInclinationDecimal() {
         String inclinationText = this.inclinationField.getText().toString();
         try {
             if (inclinationText.isEmpty()) {
@@ -405,6 +485,70 @@ public class EditLegForm extends Form {
             setError(
                     this.inclinationLayout,
                     context.getString(R.string.validation_error_must_be_number));
+        }
+    }
+
+    private void validateInclinationDms() {
+        // Degrees is required; missing minutes/seconds are treated as zero.
+        if (inclinationDegreesField.getText().toString().isEmpty()) {
+            this.valid = false;
+            return;
+        }
+        // Degrees has content - enable range error display, mirroring what
+        // RangeValidationTrigger does for the decimal inclination field.
+        enableRangeErrors();
+        boolean dmsValid = validateMinsSecsField(inclinationMinutesLayout, inclinationMinutesField)
+                & validateMinsSecsField(inclinationSecondsLayout, inclinationSecondsField);
+        if (!dmsValid) return;
+
+        // Compute decimal equivalent and range-check it, showing error on degrees layout.
+        // Wrap in try/catch to handle partial input such as a lone "-" which is not yet
+        // parseable as a float but is a valid intermediate state while typing a negative value.
+        try {
+            float inclination = getInclination();
+            if (!Leg.isInclinationLegal(inclination)) {
+                setRangeError(
+                        this.inclinationDegreesLayout,
+                        context.getString(R.string.validation_error_inclination_range));
+            } else {
+                setRangeError(this.inclinationDegreesLayout, (Integer) null);
+            }
+        } catch (NumberFormatException e) {
+            // Degrees field contains a partial value (e.g. just "-"), not yet parseable
+            this.valid = false;
+        }
+    }
+
+    /**
+     * Validates a minutes or seconds field. Blank is accepted (treated as zero).
+     * If non-blank, the value must be a whole number in the range 0-59.
+     * Sets an error on the layout and marks the form invalid if not.
+     * Returns true if the field is valid (or blank), false otherwise.
+     * Uses bitwise & rather than && in callers so both fields are always evaluated
+     * and both errors shown at once rather than stopping at the first failure.
+     */
+    private boolean validateMinsSecsField(TextInputLayout layout, EditText field) {
+        String text = field.getText().toString();
+        if (text.isEmpty()) {
+            setError(layout, (Integer) null);
+            return true;
+        }
+        // Must be a whole number (no decimal point)
+        if (text.contains(".")) {
+            setError(layout, context.getString(R.string.validation_error_must_be_whole_number));
+            return false;
+        }
+        try {
+            int value = Integer.parseInt(text);
+            if (value < 0 || value > 59) {
+                setError(layout, context.getString(R.string.validation_error_mins_secs_range));
+                return false;
+            }
+            setError(layout, (Integer) null);
+            return true;
+        } catch (NumberFormatException e) {
+            setError(layout, context.getString(R.string.validation_error_must_be_whole_number));
+            return false;
         }
     }
 
@@ -468,15 +612,32 @@ public class EditLegForm extends Form {
     }
 
     private float getInclination() {
-        return Float.parseFloat(this.inclinationField.getText().toString());
+        // Check if we're using deg/min/sec mode by checking if those fields have values
+        if (inclinationDegreesField != null && inclinationDegreesField.getText().length() > 0) {
+            float degrees = Float.parseFloat(inclinationDegreesField.getText().toString());
+            String minsText = inclinationMinutesField.getText().toString();
+            String secsText = inclinationSecondsField.getText().toString();
+            float minutes = minsText.isEmpty() ? 0.0f : Float.parseFloat(minsText);
+            float seconds = secsText.isEmpty() ? 0.0f : Float.parseFloat(secsText);
+            // The sign of the degrees component determines the direction of the inclination.
+            // Minutes and seconds are always positive and added in the same direction.
+            float sign = degrees < 0 ? -1.0f : 1.0f;
+            return degrees + sign * (minutes * (1.0f / 60.0f)
+                    + seconds * (1.0f / 60.0f) * (1.0f / 60.0f));
+        } else {
+            // Standard decimal mode
+            return Float.parseFloat(this.inclinationField.getText().toString());
+        }
     }
 
     private float getAzimuth() {
         // Check if we're using deg/min/sec mode by checking if those fields have values
         if (azimuthDegreesField != null && azimuthDegreesField.getText().length() > 0) {
             float degrees = Float.parseFloat(azimuthDegreesField.getText().toString());
-            float minutes = Float.parseFloat(azimuthMinutesField.getText().toString());
-            float seconds = Float.parseFloat(azimuthSecondsField.getText().toString());
+            String minsText = azimuthMinutesField.getText().toString();
+            String secsText = azimuthSecondsField.getText().toString();
+            float minutes = minsText.isEmpty() ? 0.0f : Float.parseFloat(minsText);
+            float seconds = secsText.isEmpty() ? 0.0f : Float.parseFloat(secsText);
             return degrees
                     + (minutes * (1.0f / 60.0f))
                     + (seconds * (1.0f / 60.0f) * (1.0f / 60.0f));

--- a/app/src/main/java/org/hwyl/sexytopo/control/table/EditLegForm.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/table/EditLegForm.java
@@ -9,8 +9,8 @@ import android.widget.Spinner;
 import com.google.android.material.textfield.TextInputLayout;
 import org.hwyl.sexytopo.R;
 import org.hwyl.sexytopo.SexyTopoConstants;
-import org.hwyl.sexytopo.control.util.InputMode;
 import org.hwyl.sexytopo.control.util.GeneralPreferences;
+import org.hwyl.sexytopo.control.util.InputMode;
 import org.hwyl.sexytopo.control.util.SurveyTools;
 import org.hwyl.sexytopo.model.survey.Leg;
 import org.hwyl.sexytopo.model.survey.Station;
@@ -21,10 +21,10 @@ public class EditLegForm extends Form {
     private static final int SPINNER_BACKWARD = 1;
 
     /**
-     * A TextWatcher that, in addition to triggering validation, enables range-error display
-     * as soon as the watched field contains any non-empty text. This lets out-of-range errors
-     * appear immediately while the user is typing, without showing a "cannot be blank" error
-     * on an untouched field.
+     * A TextWatcher that, in addition to triggering validation, enables range-error display as soon
+     * as the watched field contains any non-empty text. This lets out-of-range errors appear
+     * immediately while the user is typing, without showing a "cannot be blank" error on an
+     * untouched field.
      */
     private static class RangeValidationTrigger extends TextViewValidationTrigger {
         private final android.widget.EditText field;
@@ -170,8 +170,10 @@ public class EditLegForm extends Form {
             this.toStationField.addTextChangedListener(new TextViewValidationTrigger(this));
         }
         this.distanceField.addTextChangedListener(new TextViewValidationTrigger(this));
-        this.azimuthField.addTextChangedListener(new RangeValidationTrigger(this, this.azimuthField));
-        this.inclinationField.addTextChangedListener(new RangeValidationTrigger(this, this.inclinationField));
+        this.azimuthField.addTextChangedListener(
+                new RangeValidationTrigger(this, this.azimuthField));
+        this.inclinationField.addTextChangedListener(
+                new RangeValidationTrigger(this, this.inclinationField));
 
         if (GeneralPreferences.isDegMinsSecsModeOn()) {
             this.azimuthDegreesField.addTextChangedListener(new TextViewValidationTrigger(this));
@@ -179,9 +181,12 @@ public class EditLegForm extends Form {
             this.azimuthSecondsField.addTextChangedListener(new TextViewValidationTrigger(this));
         }
         if (GeneralPreferences.isIncDegMinsSecsModeOn()) {
-            this.inclinationDegreesField.addTextChangedListener(new TextViewValidationTrigger(this));
-            this.inclinationMinutesField.addTextChangedListener(new TextViewValidationTrigger(this));
-            this.inclinationSecondsField.addTextChangedListener(new TextViewValidationTrigger(this));
+            this.inclinationDegreesField.addTextChangedListener(
+                    new TextViewValidationTrigger(this));
+            this.inclinationMinutesField.addTextChangedListener(
+                    new TextViewValidationTrigger(this));
+            this.inclinationSecondsField.addTextChangedListener(
+                    new TextViewValidationTrigger(this));
         }
 
         // Enable error display once the user leaves a field for the first time.
@@ -433,8 +438,9 @@ public class EditLegForm extends Form {
         // Degrees has content - enable range error display, mirroring what
         // RangeValidationTrigger does for the decimal azimuth field.
         enableRangeErrors();
-        boolean dmsValid = validateMinsSecsField(azimuthMinutesLayout, azimuthMinutesField)
-                & validateMinsSecsField(azimuthSecondsLayout, azimuthSecondsField);
+        boolean dmsValid =
+                validateMinsSecsField(azimuthMinutesLayout, azimuthMinutesField)
+                        & validateMinsSecsField(azimuthSecondsLayout, azimuthSecondsField);
         if (!dmsValid) return;
 
         // Compute decimal equivalent and range-check it, showing error on degrees layout
@@ -497,8 +503,9 @@ public class EditLegForm extends Form {
         // Degrees has content - enable range error display, mirroring what
         // RangeValidationTrigger does for the decimal inclination field.
         enableRangeErrors();
-        boolean dmsValid = validateMinsSecsField(inclinationMinutesLayout, inclinationMinutesField)
-                & validateMinsSecsField(inclinationSecondsLayout, inclinationSecondsField);
+        boolean dmsValid =
+                validateMinsSecsField(inclinationMinutesLayout, inclinationMinutesField)
+                        & validateMinsSecsField(inclinationSecondsLayout, inclinationSecondsField);
         if (!dmsValid) return;
 
         // Compute decimal equivalent and range-check it, showing error on degrees layout.
@@ -520,12 +527,11 @@ public class EditLegForm extends Form {
     }
 
     /**
-     * Validates a minutes or seconds field. Blank is accepted (treated as zero).
-     * If non-blank, the value must be a whole number in the range 0-59.
-     * Sets an error on the layout and marks the form invalid if not.
-     * Returns true if the field is valid (or blank), false otherwise.
-     * Uses bitwise & rather than && in callers so both fields are always evaluated
-     * and both errors shown at once rather than stopping at the first failure.
+     * Validates a minutes or seconds field. Blank is accepted (treated as zero). If non-blank, the
+     * value must be a whole number in the range 0-59. Sets an error on the layout and marks the
+     * form invalid if not. Returns true if the field is valid (or blank), false otherwise. Uses
+     * bitwise & rather than && in callers so both fields are always evaluated and both errors shown
+     * at once rather than stopping at the first failure.
      */
     private boolean validateMinsSecsField(TextInputLayout layout, EditText field) {
         String text = field.getText().toString();
@@ -622,8 +628,8 @@ public class EditLegForm extends Form {
             // The sign of the degrees component determines the direction of the inclination.
             // Minutes and seconds are always positive and added in the same direction.
             float sign = degrees < 0 ? -1.0f : 1.0f;
-            return degrees + sign * (minutes * (1.0f / 60.0f)
-                    + seconds * (1.0f / 60.0f) * (1.0f / 60.0f));
+            return degrees
+                    + sign * (minutes * (1.0f / 60.0f) + seconds * (1.0f / 60.0f) * (1.0f / 60.0f));
         } else {
             // Standard decimal mode
             return Float.parseFloat(this.inclinationField.getText().toString());

--- a/app/src/main/java/org/hwyl/sexytopo/control/table/Form.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/table/Form.java
@@ -34,7 +34,7 @@ public abstract class Form {
         void onDidValidate(Boolean valid);
     }
 
-    private boolean valid;
+    protected boolean valid;
     private boolean showErrors;
     private boolean showRangeErrors;
     @Nullable private OnDidValidateCallback onDidValidateCallback;

--- a/app/src/main/java/org/hwyl/sexytopo/control/table/Form.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/table/Form.java
@@ -11,7 +11,7 @@ public abstract class Form {
     private final Context context;
 
     static class TextViewValidationTrigger implements TextWatcher {
-        private final Form form;
+        final Form form;
 
         TextViewValidationTrigger(Form form) {
             this.form = form;
@@ -36,17 +36,23 @@ public abstract class Form {
 
     private boolean valid;
     private boolean showErrors;
+    private boolean showRangeErrors;
     @Nullable private OnDidValidateCallback onDidValidateCallback;
 
     Form(Context context) {
         this.context = context;
         this.valid = true;
         this.showErrors = false;
+        this.showRangeErrors = false;
         this.onDidValidateCallback = null;
     }
 
     public void enableErrors() {
         this.showErrors = true;
+    }
+
+    public void enableRangeErrors() {
+        this.showRangeErrors = true;
     }
 
     public void setOnDidValidateCallback(@Nullable OnDidValidateCallback callback) {
@@ -88,5 +94,15 @@ public abstract class Form {
     protected void setError(TextInputLayout layout, Integer error) {
         CharSequence message = error == null ? null : context.getString(error);
         this.setError(layout, message);
+    }
+
+    protected void setRangeError(TextInputLayout layout, CharSequence error) {
+        this.valid = this.valid & (error == null);
+        layout.setError(showRangeErrors ? error : null);
+    }
+
+    protected void setRangeError(TextInputLayout layout, Integer error) {
+        CharSequence message = error == null ? null : context.getString(error);
+        this.setRangeError(layout, message);
     }
 }

--- a/app/src/main/java/org/hwyl/sexytopo/control/table/LegDialogs.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/table/LegDialogs.java
@@ -242,25 +242,30 @@ public class LegDialogs {
                 .setText(Float.toString(editData.getDistance()));
 
         if (usingDegMinsSecs) {
-            float azimuth = editData.getAzimuth();
-            int degrees = (int) azimuth;
-            float remainder = azimuth - degrees;
-            int minutes = (int) (remainder * 60);
-            float seconds = ((remainder * 60) - minutes) * 60;
-
+            float[] azimuthDms = Leg.decomposeToDms(editData.getAzimuth());
             ((TextView) (dialog.findViewById(R.id.editAzimuthDegrees)))
-                    .setText(Integer.toString(degrees));
+                    .setText(Integer.toString((int) azimuthDms[0]));
             ((TextView) (dialog.findViewById(R.id.editAzimuthMinutes)))
-                    .setText(Integer.toString(minutes));
+                    .setText(Integer.toString((int) azimuthDms[1]));
             ((TextView) (dialog.findViewById(R.id.editAzimuthSeconds)))
-                    .setText(Float.toString(seconds));
+                    .setText(Float.toString(azimuthDms[2]));
         } else {
             ((TextView) (dialog.findViewById(R.id.editAzimuth)))
                     .setText(Float.toString(editData.getAzimuth()));
         }
 
-        ((TextView) (dialog.findViewById(R.id.editInclination)))
-                .setText(Float.toString(editData.getInclination()));
+        if (GeneralPreferences.isIncDegMinsSecsModeOn()) {
+            float[] inclinationDms = Leg.decomposeToDms(editData.getInclination());
+            ((TextView) (dialog.findViewById(R.id.editInclinationDegrees)))
+                    .setText(Integer.toString((int) inclinationDms[0]));
+            ((TextView) (dialog.findViewById(R.id.editInclinationMinutes)))
+                    .setText(Integer.toString((int) inclinationDms[1]));
+            ((TextView) (dialog.findViewById(R.id.editInclinationSeconds)))
+                    .setText(Float.toString(inclinationDms[2]));
+        } else {
+            ((TextView) (dialog.findViewById(R.id.editInclination)))
+                    .setText(Float.toString(editData.getInclination()));
+        }
 
         DialogUtils.enableValidationOnButton(
                 dialog,

--- a/app/src/main/java/org/hwyl/sexytopo/control/table/LegDialogs.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/table/LegDialogs.java
@@ -69,7 +69,12 @@ public class LegDialogs {
         boolean usingDegMinsSecs = GeneralPreferences.isDegMinsSecsModeOn();
         if (usingDegMinsSecs) {
             dialogView.findViewById(R.id.azimuth_standard).setVisibility(View.GONE);
-            dialogView.findViewById(R.id.azimuth_deg_mins_secs).setVisibility(View.VISIBLE);
+            dialogView.findViewById(R.id.azimuth_dms_container).setVisibility(View.VISIBLE);
+        }
+
+        if (GeneralPreferences.isIncDegMinsSecsModeOn()) {
+            dialogView.findViewById(R.id.inclinationLayout).setVisibility(View.GONE);
+            dialogView.findViewById(R.id.inclination_dms_container).setVisibility(View.VISIBLE);
         }
 
         // Hide TO field for splays
@@ -202,7 +207,12 @@ public class LegDialogs {
 
         if (usingDegMinsSecs) {
             dialogView.findViewById(R.id.azimuth_standard).setVisibility(View.GONE);
-            dialogView.findViewById(R.id.azimuth_deg_mins_secs).setVisibility(View.VISIBLE);
+            dialogView.findViewById(R.id.azimuth_dms_container).setVisibility(View.VISIBLE);
+        }
+
+        if (GeneralPreferences.isIncDegMinsSecsModeOn()) {
+            dialogView.findViewById(R.id.inclinationLayout).setVisibility(View.GONE);
+            dialogView.findViewById(R.id.inclination_dms_container).setVisibility(View.VISIBLE);
         }
 
         // Hide to station field for splays

--- a/app/src/main/java/org/hwyl/sexytopo/control/util/GeneralPreferences.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/util/GeneralPreferences.java
@@ -158,6 +158,10 @@ public class GeneralPreferences {
         return getBoolean("pref_deg_mins_secs", false);
     }
 
+    public static boolean isIncDegMinsSecsModeOn() {
+        return getBoolean("pref_inc_deg_mins_secs", false);
+    }
+
     // ********** Surveying ***********
 
     public static float getMaxDistanceDelta() {

--- a/app/src/main/java/org/hwyl/sexytopo/model/graph/Projection2D.java
+++ b/app/src/main/java/org/hwyl/sexytopo/model/graph/Projection2D.java
@@ -22,7 +22,9 @@ public enum Projection2D {
         }
 
         public boolean isLegInPlane(Leg leg) {
-            return -45 < leg.getInclination() && leg.getInclination() < 45;
+            float inc = leg.getInclination();
+            return (-45 < inc && inc < 45)
+                    || (Leg.MIN_THEODOLITE_INC + 45 <= inc && inc <= Leg.MAX_THEODOLITE_INC);
         }
     },
     ELEVATION_NS("Elevation NS", "elev_ns") {

--- a/app/src/main/java/org/hwyl/sexytopo/model/survey/Leg.java
+++ b/app/src/main/java/org/hwyl/sexytopo/model/survey/Leg.java
@@ -12,6 +12,8 @@ public class Leg extends SurveyComponent {
     public static final int MAX_AZIMUTH = 360;
     public static final int MIN_INCLINATION = -90;
     public static final int MAX_INCLINATION = 90;
+    public static final int MIN_THEODOLITE_INC = 270;
+    public static final int MAX_THEODOLITE_INC = 360;
 
     private final float distance; // in metres
     private final float azimuth;
@@ -198,7 +200,8 @@ public class Leg extends SurveyComponent {
     }
 
     public static boolean isInclinationLegal(float inclination) {
-        return MIN_INCLINATION <= inclination && inclination <= MAX_INCLINATION;
+        return (MIN_INCLINATION <= inclination && inclination <= MAX_INCLINATION)
+                || (MIN_THEODOLITE_INC <= inclination && inclination <= MAX_THEODOLITE_INC);
     }
 
     @NonNull

--- a/app/src/main/java/org/hwyl/sexytopo/model/survey/Leg.java
+++ b/app/src/main/java/org/hwyl/sexytopo/model/survey/Leg.java
@@ -204,6 +204,24 @@ public class Leg extends SurveyComponent {
                 || (MIN_THEODOLITE_INC <= inclination && inclination <= MAX_THEODOLITE_INC);
     }
 
+    /**
+     * Decomposes a decimal-degrees value into degrees, minutes, and seconds.
+     *
+     * <p>The sign of the original value is preserved on the degrees component only. Minutes and
+     * seconds are always positive
+     *
+     * @param decimalDegrees the value to decompose
+     * @return a three-element array {@code [degrees, minutes, seconds]} where {@code degrees}
+     *     carries the sign and {@code minutes}/{@code seconds} are non-negative
+     */
+    public static float[] decomposeToDms(float decimalDegrees) {
+        int degrees = (int) decimalDegrees;
+        float remainder = Math.abs(decimalDegrees - degrees);
+        int minutes = (int) (remainder * 60);
+        float seconds = ((remainder * 60) - minutes) * 60;
+        return new float[] {degrees, minutes, seconds};
+    }
+
     @NonNull
     public String toString() {
         return "(D"

--- a/app/src/main/res/layout/leg_edit_dialog.xml
+++ b/app/src/main/res/layout/leg_edit_dialog.xml
@@ -39,18 +39,32 @@
     </com.google.android.material.textfield.TextInputLayout>
 
     <LinearLayout
-        android:id="@+id/azimuth_deg_mins_secs"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="8dp"
-        android:orientation="horizontal"
-        android:visibility="gone">
+        android:orientation="vertical"
+        android:visibility="gone"
+        android:id="@+id/azimuth_dms_container">
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/manual_edit_azimuth_deg_mins_secs"
+            android:layout_marginBottom="4dp"
+            android:textSize="14sp"/>
+        <LinearLayout
+            android:id="@+id/azimuth_deg_mins_secs"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:baselineAligned="false">
         <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/editAzimuthDegreesLayout"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
             android:layout_marginEnd="4dp"
             android:hint="@string/deg"
+            app:errorEnabled="true"
             style="@style/Widget.Material3.TextInputLayout.OutlinedBox">
             <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/editAzimuthDegrees"
@@ -62,9 +76,11 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
+            android:id="@+id/editAzimuthMinutesLayout"
             android:layout_marginStart="4dp"
             android:layout_marginEnd="4dp"
             android:hint="@string/min"
+            app:errorEnabled="true"
             style="@style/Widget.Material3.TextInputLayout.OutlinedBox">
             <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/editAzimuthMinutes"
@@ -76,8 +92,10 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
+            android:id="@+id/editAzimuthSecondsLayout"
             android:layout_marginStart="4dp"
             android:hint="@string/sec"
+            app:errorEnabled="true"
             style="@style/Widget.Material3.TextInputLayout.OutlinedBox">
             <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/editAzimuthSeconds"
@@ -85,6 +103,7 @@
                 android:layout_height="wrap_content"
                 android:inputType="number"/>
         </com.google.android.material.textfield.TextInputLayout>
+        </LinearLayout>
     </LinearLayout>
 
     <com.google.android.material.textfield.TextInputLayout
@@ -101,5 +120,73 @@
             android:layout_height="wrap_content"
             android:inputType="numberDecimal|numberSigned"/>
     </com.google.android.material.textfield.TextInputLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:orientation="vertical"
+        android:visibility="gone"
+        android:id="@+id/inclination_dms_container">
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/manual_edit_inclination_deg_mins_secs"
+            android:layout_marginBottom="4dp"
+            android:textSize="14sp"/>
+        <LinearLayout
+            android:id="@+id/inclination_deg_mins_secs"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:baselineAligned="false">
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/editInclinationDegreesLayout"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:layout_marginEnd="4dp"
+            android:hint="@string/deg"
+            app:errorEnabled="true"
+            style="@style/Widget.Material3.TextInputLayout.OutlinedBox">
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/editInclinationDegrees"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="numberSigned"/>
+        </com.google.android.material.textfield.TextInputLayout>
+        <com.google.android.material.textfield.TextInputLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:id="@+id/editInclinationMinutesLayout"
+            android:layout_marginStart="4dp"
+            android:layout_marginEnd="4dp"
+            android:hint="@string/min"
+            app:errorEnabled="true"
+            style="@style/Widget.Material3.TextInputLayout.OutlinedBox">
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/editInclinationMinutes"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="number"/>
+        </com.google.android.material.textfield.TextInputLayout>
+        <com.google.android.material.textfield.TextInputLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:id="@+id/editInclinationSecondsLayout"
+            android:layout_marginStart="4dp"
+            android:hint="@string/sec"
+            app:errorEnabled="true"
+            style="@style/Widget.Material3.TextInputLayout.OutlinedBox">
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/editInclinationSeconds"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="number"/>
+        </com.google.android.material.textfield.TextInputLayout>
+        </LinearLayout>
+    </LinearLayout>
 
 </LinearLayout>

--- a/app/src/main/res/layout/leg_edit_dialog.xml
+++ b/app/src/main/res/layout/leg_edit_dialog.xml
@@ -101,7 +101,7 @@
                 android:id="@+id/editAzimuthSeconds"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:inputType="number"/>
+                android:inputType="numberDecimal"/>
         </com.google.android.material.textfield.TextInputLayout>
         </LinearLayout>
     </LinearLayout>
@@ -184,7 +184,7 @@
                 android:id="@+id/editInclinationSeconds"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:inputType="number"/>
+                android:inputType="numberDecimal"/>
         </com.google.android.material.textfield.TextInputLayout>
         </LinearLayout>
     </LinearLayout>

--- a/app/src/main/res/layout/leg_edit_dialog_unified.xml
+++ b/app/src/main/res/layout/leg_edit_dialog_unified.xml
@@ -208,7 +208,7 @@
                     android:id="@+id/editAzimuthSeconds"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:inputType="number"/>
+                    android:inputType="numberDecimal"/>
             </com.google.android.material.textfield.TextInputLayout>
             </LinearLayout>
         </LinearLayout>
@@ -291,7 +291,7 @@
                     android:id="@+id/editInclinationSeconds"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:inputType="number"/>
+                    android:inputType="numberDecimal"/>
             </com.google.android.material.textfield.TextInputLayout>
             </LinearLayout>
         </LinearLayout>

--- a/app/src/main/res/layout/leg_edit_dialog_unified.xml
+++ b/app/src/main/res/layout/leg_edit_dialog_unified.xml
@@ -17,6 +17,7 @@
             android:layout_marginBottom="12dp"
             android:orientation="horizontal"
             android:gravity="center_vertical"
+            android:baselineAligned="false"
             android:visibility="gone">
             <TextView
                 android:layout_width="wrap_content"
@@ -35,6 +36,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="horizontal"
+            android:baselineAligned="false"
             android:layout_marginTop="8dp">
 
             <com.google.android.material.textfield.TextInputLayout
@@ -75,6 +77,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="horizontal"
+            android:baselineAligned="false"
             android:layout_marginTop="8dp">
 
             <com.google.android.material.textfield.TextInputLayout
@@ -143,18 +146,32 @@
         </com.google.android.material.textfield.TextInputLayout>
 
         <LinearLayout
-            android:id="@+id/azimuth_deg_mins_secs"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="8dp"
-            android:orientation="horizontal"
-            android:visibility="gone">
+            android:orientation="vertical"
+            android:visibility="gone"
+            android:id="@+id/azimuth_dms_container">
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/manual_edit_azimuth_deg_mins_secs"
+                android:layout_marginBottom="4dp"
+                android:textSize="14sp"/>
+            <LinearLayout
+                android:id="@+id/azimuth_deg_mins_secs"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:baselineAligned="false">
             <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/editAzimuthDegreesLayout"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
                 android:layout_marginEnd="4dp"
                 android:hint="@string/deg"
+                app:errorEnabled="true"
                 style="@style/Widget.Material3.TextInputLayout.OutlinedBox">
                 <com.google.android.material.textfield.TextInputEditText
                     android:id="@+id/editAzimuthDegrees"
@@ -166,9 +183,11 @@
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
+                android:id="@+id/editAzimuthMinutesLayout"
                 android:layout_marginStart="4dp"
                 android:layout_marginEnd="4dp"
                 android:hint="@string/min"
+                app:errorEnabled="true"
                 style="@style/Widget.Material3.TextInputLayout.OutlinedBox">
                 <com.google.android.material.textfield.TextInputEditText
                     android:id="@+id/editAzimuthMinutes"
@@ -180,8 +199,10 @@
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
+                android:id="@+id/editAzimuthSecondsLayout"
                 android:layout_marginStart="4dp"
                 android:hint="@string/sec"
+                app:errorEnabled="true"
                 style="@style/Widget.Material3.TextInputLayout.OutlinedBox">
                 <com.google.android.material.textfield.TextInputEditText
                     android:id="@+id/editAzimuthSeconds"
@@ -189,6 +210,7 @@
                     android:layout_height="wrap_content"
                     android:inputType="number"/>
             </com.google.android.material.textfield.TextInputLayout>
+            </LinearLayout>
         </LinearLayout>
 
         <com.google.android.material.textfield.TextInputLayout
@@ -205,6 +227,74 @@
                 android:layout_height="wrap_content"
                 android:inputType="numberDecimal|numberSigned"/>
         </com.google.android.material.textfield.TextInputLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:orientation="vertical"
+            android:visibility="gone"
+            android:id="@+id/inclination_dms_container">
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/manual_edit_inclination_deg_mins_secs"
+                android:layout_marginBottom="4dp"
+                android:textSize="14sp"/>
+            <LinearLayout
+                android:id="@+id/inclination_deg_mins_secs"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:baselineAligned="false">
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/editInclinationDegreesLayout"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:layout_marginEnd="4dp"
+                android:hint="@string/deg"
+                app:errorEnabled="true"
+                style="@style/Widget.Material3.TextInputLayout.OutlinedBox">
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/editInclinationDegrees"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:inputType="numberSigned"/>
+            </com.google.android.material.textfield.TextInputLayout>
+            <com.google.android.material.textfield.TextInputLayout
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:id="@+id/editInclinationMinutesLayout"
+                android:layout_marginStart="4dp"
+                android:layout_marginEnd="4dp"
+                android:hint="@string/min"
+                app:errorEnabled="true"
+                style="@style/Widget.Material3.TextInputLayout.OutlinedBox">
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/editInclinationMinutes"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:inputType="number"/>
+            </com.google.android.material.textfield.TextInputLayout>
+            <com.google.android.material.textfield.TextInputLayout
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:id="@+id/editInclinationSecondsLayout"
+                android:layout_marginStart="4dp"
+                android:hint="@string/sec"
+                app:errorEnabled="true"
+                style="@style/Widget.Material3.TextInputLayout.OutlinedBox">
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/editInclinationSeconds"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:inputType="number"/>
+            </com.google.android.material.textfield.TextInputLayout>
+            </LinearLayout>
+        </LinearLayout>
 
     </LinearLayout>
 </ScrollView>

--- a/app/src/main/res/layout/leg_edit_dialog_unified_with_lruds.xml
+++ b/app/src/main/res/layout/leg_edit_dialog_unified_with_lruds.xml
@@ -17,6 +17,7 @@
             android:layout_marginBottom="12dp"
             android:orientation="horizontal"
             android:gravity="center_vertical"
+            android:baselineAligned="false"
             android:visibility="gone">
             <TextView
                 android:layout_width="wrap_content"
@@ -35,6 +36,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="horizontal"
+            android:baselineAligned="false"
             android:layout_marginTop="8dp">
 
             <com.google.android.material.textfield.TextInputLayout
@@ -74,6 +76,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="horizontal"
+            android:baselineAligned="false"
             android:layout_marginTop="8dp">
 
             <com.google.android.material.textfield.TextInputLayout
@@ -142,18 +145,32 @@
         </com.google.android.material.textfield.TextInputLayout>
 
         <LinearLayout
-            android:id="@+id/azimuth_deg_mins_secs"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="8dp"
-            android:orientation="horizontal"
-            android:visibility="gone">
+            android:orientation="vertical"
+            android:visibility="gone"
+            android:id="@+id/azimuth_dms_container">
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/manual_edit_azimuth_deg_mins_secs"
+                android:layout_marginBottom="4dp"
+                android:textSize="14sp"/>
+            <LinearLayout
+                android:id="@+id/azimuth_deg_mins_secs"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:baselineAligned="false">
             <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/editAzimuthDegreesLayout"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
                 android:layout_marginEnd="4dp"
                 android:hint="@string/deg"
+                app:errorEnabled="true"
                 style="@style/Widget.Material3.TextInputLayout.OutlinedBox">
                 <com.google.android.material.textfield.TextInputEditText
                     android:id="@+id/editAzimuthDegrees"
@@ -165,9 +182,11 @@
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
+                android:id="@+id/editAzimuthMinutesLayout"
                 android:layout_marginStart="4dp"
                 android:layout_marginEnd="4dp"
                 android:hint="@string/min"
+                app:errorEnabled="true"
                 style="@style/Widget.Material3.TextInputLayout.OutlinedBox">
                 <com.google.android.material.textfield.TextInputEditText
                     android:id="@+id/editAzimuthMinutes"
@@ -179,8 +198,10 @@
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
+                android:id="@+id/editAzimuthSecondsLayout"
                 android:layout_marginStart="4dp"
                 android:hint="@string/sec"
+                app:errorEnabled="true"
                 style="@style/Widget.Material3.TextInputLayout.OutlinedBox">
                 <com.google.android.material.textfield.TextInputEditText
                     android:id="@+id/editAzimuthSeconds"
@@ -188,6 +209,7 @@
                     android:layout_height="wrap_content"
                     android:inputType="number"/>
             </com.google.android.material.textfield.TextInputLayout>
+            </LinearLayout>
         </LinearLayout>
 
         <com.google.android.material.textfield.TextInputLayout
@@ -204,6 +226,74 @@
                 android:layout_height="wrap_content"
                 android:inputType="numberDecimal|numberSigned"/>
         </com.google.android.material.textfield.TextInputLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:orientation="vertical"
+            android:visibility="gone"
+            android:id="@+id/inclination_dms_container">
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/manual_edit_inclination_deg_mins_secs"
+                android:layout_marginBottom="4dp"
+                android:textSize="14sp"/>
+            <LinearLayout
+                android:id="@+id/inclination_deg_mins_secs"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:baselineAligned="false">
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/editInclinationDegreesLayout"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:layout_marginEnd="4dp"
+                android:hint="@string/deg"
+                app:errorEnabled="true"
+                style="@style/Widget.Material3.TextInputLayout.OutlinedBox">
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/editInclinationDegrees"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:inputType="numberSigned"/>
+            </com.google.android.material.textfield.TextInputLayout>
+            <com.google.android.material.textfield.TextInputLayout
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:id="@+id/editInclinationMinutesLayout"
+                android:layout_marginStart="4dp"
+                android:layout_marginEnd="4dp"
+                android:hint="@string/min"
+                app:errorEnabled="true"
+                style="@style/Widget.Material3.TextInputLayout.OutlinedBox">
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/editInclinationMinutes"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:inputType="number"/>
+            </com.google.android.material.textfield.TextInputLayout>
+            <com.google.android.material.textfield.TextInputLayout
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:id="@+id/editInclinationSecondsLayout"
+                android:layout_marginStart="4dp"
+                android:hint="@string/sec"
+                app:errorEnabled="true"
+                style="@style/Widget.Material3.TextInputLayout.OutlinedBox">
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/editInclinationSeconds"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:inputType="number"/>
+            </com.google.android.material.textfield.TextInputLayout>
+            </LinearLayout>
+        </LinearLayout>
 
         <com.google.android.material.textfield.TextInputLayout
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/leg_edit_dialog_unified_with_lruds.xml
+++ b/app/src/main/res/layout/leg_edit_dialog_unified_with_lruds.xml
@@ -207,7 +207,7 @@
                     android:id="@+id/editAzimuthSeconds"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:inputType="number"/>
+                    android:inputType="numberDecimal"/>
             </com.google.android.material.textfield.TextInputLayout>
             </LinearLayout>
         </LinearLayout>
@@ -290,7 +290,7 @@
                     android:id="@+id/editInclinationSeconds"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:inputType="number"/>
+                    android:inputType="numberDecimal"/>
             </com.google.android.material.textfield.TextInputLayout>
             </LinearLayout>
         </LinearLayout>

--- a/app/src/main/res/values-b+fr/strings.xml
+++ b/app/src/main/res/values-b+fr/strings.xml
@@ -541,6 +541,7 @@
     <string name="validation_error_must_be_whole_number">Doit être un nombre entier</string>
     <string name="validation_error_mins_secs_range">Doit être compris entre 0 et 59</string>
     <string name="validation_error_secs_range">Doit être compris entre 0 et moins de 60</string>
+    <string name="validation_error_must_be_zero_for_90">Doit être 0 pour ±90°</string>
 
     <!-- Input mode for leg editing -->
     <string-array name="leg_edit_input_mode_options">

--- a/app/src/main/res/values-b+fr/strings.xml
+++ b/app/src/main/res/values-b+fr/strings.xml
@@ -540,6 +540,7 @@
     <string name="validation_error_inclination_range">Doit être entre -90 et 90 ou entre 270 et 360</string>
     <string name="validation_error_must_be_whole_number">Doit être un nombre entier</string>
     <string name="validation_error_mins_secs_range">Doit être compris entre 0 et 59</string>
+    <string name="validation_error_secs_range">Doit être compris entre 0 et moins de 60</string>
 
     <!-- Input mode for leg editing -->
     <string-array name="leg_edit_input_mode_options">

--- a/app/src/main/res/values-b+fr/strings.xml
+++ b/app/src/main/res/values-b+fr/strings.xml
@@ -534,7 +534,7 @@
     <string name="validation_error_must_be_number">Doit être un nombre</string>
     <string name="validation_error_distance_minimum">Doit être >= %1$d</string>
     <string name="validation_error_azimuth_range">Doit être entre %1$d et %2$d</string>
-    <string name="validation_error_inclination_range">Doit être entre %1$d et %2$d</string>
+    <string name="validation_error_inclination_range">Doit être entre -90 et 90 ou entre 270 et 360</string>
 
     <!-- Input mode for leg editing -->
     <string-array name="leg_edit_input_mode_options">

--- a/app/src/main/res/values-b+fr/strings.xml
+++ b/app/src/main/res/values-b+fr/strings.xml
@@ -532,9 +532,9 @@
     <string name="validation_error_same_as_from_station">Ne peut pas être identique à la station d\'origine</string>
     <string name="validation_error_station_name_not_unique">Le nom de la station doit être unique</string>
     <string name="validation_error_must_be_number">Doit être un nombre</string>
-    <string name="validation_error_distance_minimum">Doit être >= %1$f</string>
-    <string name="validation_error_azimuth_range">Doit être entre %1$f et %2$f</string>
-    <string name="validation_error_inclination_range">Doit être entre %1$f et %2$f</string>
+    <string name="validation_error_distance_minimum">Doit être >= %1$d</string>
+    <string name="validation_error_azimuth_range">Doit être entre %1$d et %2$d</string>
+    <string name="validation_error_inclination_range">Doit être entre %1$d et %2$d</string>
 
     <!-- Input mode for leg editing -->
     <string-array name="leg_edit_input_mode_options">

--- a/app/src/main/res/values-b+fr/strings.xml
+++ b/app/src/main/res/values-b+fr/strings.xml
@@ -463,6 +463,9 @@
     </string-array>
     <string name="settings_key_deg_mins_secs_title">Azimut en degrés/minutes/secondes</string>
     <string name="settings_key_deg_mins_secs_summary">Entrer les valeurs d\'azimut en degrés/minutes/secondes (au lieu du mode décimal par défaut)</string>
+    <string name="manual_edit_inclination_deg_mins_secs">Inclinaison (&#176; \' \")</string>
+    <string name="settings_key_inc_deg_mins_secs_title">Inclinaison en degrés/minutes/secondes</string>
+    <string name="settings_key_inc_deg_mins_secs_summary">Entrer les valeurs d\'inclinaison en degrés/minutes/secondes (au lieu du mode décimal par défaut)</string>
     <string name="settings_export_title">Exporter</string>
     <string name="settings_export_summary">Formats d\'export et options de dossier</string>
     <string name="settings_export_svg_background_title">Arrière-plan SVG</string>
@@ -535,6 +538,8 @@
     <string name="validation_error_distance_minimum">Doit être >= %1$d</string>
     <string name="validation_error_azimuth_range">Doit être entre %1$d et %2$d</string>
     <string name="validation_error_inclination_range">Doit être entre -90 et 90 ou entre 270 et 360</string>
+    <string name="validation_error_must_be_whole_number">Doit être un nombre entier</string>
+    <string name="validation_error_mins_secs_range">Doit être compris entre 0 et 59</string>
 
     <!-- Input mode for leg editing -->
     <string-array name="leg_edit_input_mode_options">

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -463,6 +463,9 @@
     </string-array>
     <string name="settings_key_deg_mins_secs_title">Azimut in Grad/Minuten/Sekunden</string>
     <string name="settings_key_deg_mins_secs_summary">Azimutwerte in Grad/Minuten/Sekunden eingeben (im Gegensatz zur Standardeinstellung in Dezimalwerten)</string>
+    <string name="manual_edit_inclination_deg_mins_secs">Neigung (° \' \")</string>
+    <string name="settings_key_inc_deg_mins_secs_title">Neigung in Grad/Minuten/Sekunden</string>
+    <string name="settings_key_inc_deg_mins_secs_summary">Neigungswerte in Grad/Minuten/Sekunden eingeben (im Gegensatz zur Standardeinstellung in Dezimalwerten)</string>
     <string name="settings_export_title">Exportieren</string>
     <string name="settings_export_summary">Exportformate und Ordneroptionen</string>
     <string name="settings_export_svg_background_title">SVG-Hintergrund</string>
@@ -535,6 +538,8 @@
     <string name="validation_error_distance_minimum">Muss >= %1$d sein</string>
     <string name="validation_error_azimuth_range">Muss zwischen %1$d und %2$d liegen</string>
     <string name="validation_error_inclination_range">Muss zwischen -90 und 90 oder zwischen 270 und 360 liegen</string>
+    <string name="validation_error_must_be_whole_number">Muss eine ganze Zahl sein</string>
+    <string name="validation_error_mins_secs_range">Muss zwischen 0 und 59 liegen</string>
 
     <!-- Input mode for leg editing -->
     <string-array name="leg_edit_input_mode_options">

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -532,9 +532,9 @@
     <string name="validation_error_same_as_from_station">Kann nicht derselbe wie der Ursprungsmesspunkt sein</string>
     <string name="validation_error_station_name_not_unique">Messpunktname muss eindeutig sein</string>
     <string name="validation_error_must_be_number">Muss eine Zahl sein</string>
-    <string name="validation_error_distance_minimum">Muss >= %1$f sein</string>
-    <string name="validation_error_azimuth_range">Muss zwischen %1$f und %2$f liegen</string>
-    <string name="validation_error_inclination_range">Muss zwischen %1$f und %2$f liegen</string>
+    <string name="validation_error_distance_minimum">Muss >= %1$d sein</string>
+    <string name="validation_error_azimuth_range">Muss zwischen %1$d und %2$d liegen</string>
+    <string name="validation_error_inclination_range">Muss zwischen %1$d und %2$d liegen</string>
 
     <!-- Input mode for leg editing -->
     <string-array name="leg_edit_input_mode_options">

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -541,6 +541,7 @@
     <string name="validation_error_must_be_whole_number">Muss eine ganze Zahl sein</string>
     <string name="validation_error_mins_secs_range">Muss zwischen 0 und 59 liegen</string>
     <string name="validation_error_secs_range">Muss zwischen 0 und weniger als 60 liegen</string>
+    <string name="validation_error_must_be_zero_for_90">Muss 0 sein für ±90°</string>
 
     <!-- Input mode for leg editing -->
     <string-array name="leg_edit_input_mode_options">

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -534,7 +534,7 @@
     <string name="validation_error_must_be_number">Muss eine Zahl sein</string>
     <string name="validation_error_distance_minimum">Muss >= %1$d sein</string>
     <string name="validation_error_azimuth_range">Muss zwischen %1$d und %2$d liegen</string>
-    <string name="validation_error_inclination_range">Muss zwischen %1$d und %2$d liegen</string>
+    <string name="validation_error_inclination_range">Muss zwischen -90 und 90 oder zwischen 270 und 360 liegen</string>
 
     <!-- Input mode for leg editing -->
     <string-array name="leg_edit_input_mode_options">

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -540,6 +540,7 @@
     <string name="validation_error_inclination_range">Muss zwischen -90 und 90 oder zwischen 270 und 360 liegen</string>
     <string name="validation_error_must_be_whole_number">Muss eine ganze Zahl sein</string>
     <string name="validation_error_mins_secs_range">Muss zwischen 0 und 59 liegen</string>
+    <string name="validation_error_secs_range">Muss zwischen 0 und weniger als 60 liegen</string>
 
     <!-- Input mode for leg editing -->
     <string-array name="leg_edit_input_mode_options">

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -534,7 +534,7 @@
     <string name="validation_error_must_be_number">Debe ser un número</string>
     <string name="validation_error_distance_minimum">Debe ser >= %1$d</string>
     <string name="validation_error_azimuth_range">Debe ser %1$d-%2$d</string>
-    <string name="validation_error_inclination_range">Debe ser de %1$d a %2$d</string>
+    <string name="validation_error_inclination_range">Debe ser de -90 a 90 o de 270 a 360</string>
 
     <!-- Input mode for leg editing -->
     <string-array name="leg_edit_input_mode_options">

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -540,6 +540,7 @@
     <string name="validation_error_inclination_range">Debe ser de -90 a 90 o de 270 a 360</string>
     <string name="validation_error_must_be_whole_number">Debe ser un número entero</string>
     <string name="validation_error_mins_secs_range">Debe ser de 0 a 59</string>
+    <string name="validation_error_secs_range">Debe ser de 0 a menos de 60</string>
 
     <!-- Input mode for leg editing -->
     <string-array name="leg_edit_input_mode_options">

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -463,6 +463,9 @@
     </string-array>
     <string name="settings_key_deg_mins_secs_title">Azimut en grados/minutos/segundos</string>
     <string name="settings_key_deg_mins_secs_summary">Ingresar valores de azimut en grados/minutos/segundos (en lugar del predeterminado decimal)</string>
+    <string name="manual_edit_inclination_deg_mins_secs">Inclinación (&#176; \' \")</string>
+    <string name="settings_key_inc_deg_mins_secs_title">Inclinación en grados/minutos/segundos</string>
+    <string name="settings_key_inc_deg_mins_secs_summary">Ingresar valores de inclinación en grados/minutos/segundos (en lugar del predeterminado decimal)</string>
     <string name="settings_export_title">Exportación</string>
     <string name="settings_export_summary">Formatos de exportación y opciones de carpeta</string>
     <string name="settings_export_svg_background_title">Fondo SVG</string>
@@ -535,6 +538,8 @@
     <string name="validation_error_distance_minimum">Debe ser >= %1$d</string>
     <string name="validation_error_azimuth_range">Debe ser %1$d-%2$d</string>
     <string name="validation_error_inclination_range">Debe ser de -90 a 90 o de 270 a 360</string>
+    <string name="validation_error_must_be_whole_number">Debe ser un número entero</string>
+    <string name="validation_error_mins_secs_range">Debe ser de 0 a 59</string>
 
     <!-- Input mode for leg editing -->
     <string-array name="leg_edit_input_mode_options">

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -532,9 +532,9 @@
     <string name="validation_error_same_as_from_station">No puede ser la misma que la estación de origen</string>
     <string name="validation_error_station_name_not_unique">El nombre de estación debe ser único</string>
     <string name="validation_error_must_be_number">Debe ser un número</string>
-    <string name="validation_error_distance_minimum">Debe ser >= %1$f</string>
-    <string name="validation_error_azimuth_range">Debe ser %1$f-%2$f</string>
-    <string name="validation_error_inclination_range">Debe ser de %1$f a %2$f</string>
+    <string name="validation_error_distance_minimum">Debe ser >= %1$d</string>
+    <string name="validation_error_azimuth_range">Debe ser %1$d-%2$d</string>
+    <string name="validation_error_inclination_range">Debe ser de %1$d a %2$d</string>
 
     <!-- Input mode for leg editing -->
     <string-array name="leg_edit_input_mode_options">

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -541,6 +541,7 @@
     <string name="validation_error_must_be_whole_number">Debe ser un número entero</string>
     <string name="validation_error_mins_secs_range">Debe ser de 0 a 59</string>
     <string name="validation_error_secs_range">Debe ser de 0 a menos de 60</string>
+    <string name="validation_error_must_be_zero_for_90">Debe ser 0 para ±90°</string>
 
     <!-- Input mode for leg editing -->
     <string-array name="leg_edit_input_mode_options">

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -541,6 +541,7 @@
     <string name="validation_error_must_be_whole_number">Deve essere un numero intero</string>
     <string name="validation_error_mins_secs_range">Deve essere da 0 a 59</string>
     <string name="validation_error_secs_range">Deve essere da 0 a meno di 60</string>
+    <string name="validation_error_must_be_zero_for_90">Deve essere 0 per ±90°</string>
 
     <!-- Input mode for leg editing -->
     <string-array name="leg_edit_input_mode_options">

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -534,7 +534,7 @@
     <string name="validation_error_must_be_number">Deve essere un numero</string>
     <string name="validation_error_distance_minimum">Deve essere >= %1$d</string>
     <string name="validation_error_azimuth_range">Deve essere %1$d-%2$d</string>
-    <string name="validation_error_inclination_range">Deve essere da %1$d a %2$d</string>
+    <string name="validation_error_inclination_range">Deve essere da -90 a 90 o da 270 a 360</string>
 
     <!-- Input mode for leg editing -->
     <string-array name="leg_edit_input_mode_options">

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -463,6 +463,9 @@
     </string-array>
     <string name="settings_key_deg_mins_secs_title">Azimut in gradi/minuti/secondi</string>
     <string name="settings_key_deg_mins_secs_summary">Inserisci valori di azimut in gradi/minuti/secondi (anziché il predefinito decimale)</string>
+    <string name="manual_edit_inclination_deg_mins_secs">Inclinazione (&#176; \' \")</string>
+    <string name="settings_key_inc_deg_mins_secs_title">Inclinazione in gradi/minuti/secondi</string>
+    <string name="settings_key_inc_deg_mins_secs_summary">Inserisci valori di inclinazione in gradi/minuti/secondi (anziché il predefinito decimale)</string>
     <string name="settings_export_title">Esportazione</string>
     <string name="settings_export_summary">Formati di esportazione e opzioni cartella</string>
     <string name="settings_export_svg_background_title">Sfondo SVG</string>
@@ -535,6 +538,8 @@
     <string name="validation_error_distance_minimum">Deve essere >= %1$d</string>
     <string name="validation_error_azimuth_range">Deve essere %1$d-%2$d</string>
     <string name="validation_error_inclination_range">Deve essere da -90 a 90 o da 270 a 360</string>
+    <string name="validation_error_must_be_whole_number">Deve essere un numero intero</string>
+    <string name="validation_error_mins_secs_range">Deve essere da 0 a 59</string>
 
     <!-- Input mode for leg editing -->
     <string-array name="leg_edit_input_mode_options">

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -532,9 +532,9 @@
     <string name="validation_error_same_as_from_station">Non può essere uguale alla stazione di partenza</string>
     <string name="validation_error_station_name_not_unique">Il nome della stazione deve essere univoco</string>
     <string name="validation_error_must_be_number">Deve essere un numero</string>
-    <string name="validation_error_distance_minimum">Deve essere >= %1$f</string>
-    <string name="validation_error_azimuth_range">Deve essere %1$f-%2$f</string>
-    <string name="validation_error_inclination_range">Deve essere da %1$f a %2$f</string>
+    <string name="validation_error_distance_minimum">Deve essere >= %1$d</string>
+    <string name="validation_error_azimuth_range">Deve essere %1$d-%2$d</string>
+    <string name="validation_error_inclination_range">Deve essere da %1$d a %2$d</string>
 
     <!-- Input mode for leg editing -->
     <string-array name="leg_edit_input_mode_options">

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -540,6 +540,7 @@
     <string name="validation_error_inclination_range">Deve essere da -90 a 90 o da 270 a 360</string>
     <string name="validation_error_must_be_whole_number">Deve essere un numero intero</string>
     <string name="validation_error_mins_secs_range">Deve essere da 0 a 59</string>
+    <string name="validation_error_secs_range">Deve essere da 0 a meno di 60</string>
 
     <!-- Input mode for leg editing -->
     <string-array name="leg_edit_input_mode_options">

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -463,6 +463,9 @@
     </string-array>
     <string name="settings_key_deg_mins_secs_title">Azymut jako stopnie/minuty/sekundy</string>
     <string name="settings_key_deg_mins_secs_summary">Wprowadź wartości azymutu w stopniach/minutach/sekundach (w przeciwieństwie do domyślnego dziesiętnego)</string>
+    <string name="manual_edit_inclination_deg_mins_secs">Nachylenie (&#176; \' \")</string>
+    <string name="settings_key_inc_deg_mins_secs_title">Nachylenie jako stopnie/minuty/sekundy</string>
+    <string name="settings_key_inc_deg_mins_secs_summary">Wprowadź wartości nachylenia w stopniach/minutach/sekundach (w przeciwieństwie do domyślnego dziesiętnego)</string>
     <string name="settings_export_title">Eksport</string>
     <string name="settings_export_summary">Formaty eksportu i opcje folderu</string>
     <string name="settings_export_svg_background_title">Tło SVG</string>
@@ -535,6 +538,8 @@
     <string name="validation_error_distance_minimum">Musi być >= %1$d</string>
     <string name="validation_error_azimuth_range">Musi być %1$d-%2$d</string>
     <string name="validation_error_inclination_range">Musi być od -90 do 90 lub od 270 do 360</string>
+    <string name="validation_error_must_be_whole_number">Musi być liczbą całkowitą</string>
+    <string name="validation_error_mins_secs_range">Musi być od 0 do 59</string>
 
     <!-- Input mode for leg editing -->
     <string-array name="leg_edit_input_mode_options">

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -532,9 +532,9 @@
     <string name="validation_error_same_as_from_station">Nie może być takie samo jak stanowisko początkowe</string>
     <string name="validation_error_station_name_not_unique">Nazwa stanowiska musi być unikalna</string>
     <string name="validation_error_must_be_number">Musi być liczbą</string>
-    <string name="validation_error_distance_minimum">Musi być >= %1$f</string>
-    <string name="validation_error_azimuth_range">Musi być %1$f-%2$f</string>
-    <string name="validation_error_inclination_range">Musi być od %1$f do %2$f</string>
+    <string name="validation_error_distance_minimum">Musi być >= %1$d</string>
+    <string name="validation_error_azimuth_range">Musi być %1$d-%2$d</string>
+    <string name="validation_error_inclination_range">Musi być od %1$d do %2$d</string>
 
     <!-- Input mode for leg editing -->
     <string-array name="leg_edit_input_mode_options">

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -541,6 +541,7 @@
     <string name="validation_error_must_be_whole_number">Musi być liczbą całkowitą</string>
     <string name="validation_error_mins_secs_range">Musi być od 0 do 59</string>
     <string name="validation_error_secs_range">Musi być od 0 do mniej niż 60</string>
+    <string name="validation_error_must_be_zero_for_90">Musi być 0 dla ±90°</string>
 
     <!-- Input mode for leg editing -->
     <string-array name="leg_edit_input_mode_options">

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -534,7 +534,7 @@
     <string name="validation_error_must_be_number">Musi być liczbą</string>
     <string name="validation_error_distance_minimum">Musi być >= %1$d</string>
     <string name="validation_error_azimuth_range">Musi być %1$d-%2$d</string>
-    <string name="validation_error_inclination_range">Musi być od %1$d do %2$d</string>
+    <string name="validation_error_inclination_range">Musi być od -90 do 90 lub od 270 do 360</string>
 
     <!-- Input mode for leg editing -->
     <string-array name="leg_edit_input_mode_options">

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -540,6 +540,7 @@
     <string name="validation_error_inclination_range">Musi być od -90 do 90 lub od 270 do 360</string>
     <string name="validation_error_must_be_whole_number">Musi być liczbą całkowitą</string>
     <string name="validation_error_mins_secs_range">Musi być od 0 do 59</string>
+    <string name="validation_error_secs_range">Musi być od 0 do mniej niż 60</string>
 
     <!-- Input mode for leg editing -->
     <string-array name="leg_edit_input_mode_options">

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -541,6 +541,7 @@
     <string name="validation_error_must_be_whole_number">Deve ser um número inteiro</string>
     <string name="validation_error_mins_secs_range">Deve ser de 0 a 59</string>
     <string name="validation_error_secs_range">Deve ser de 0 a menos de 60</string>
+    <string name="validation_error_must_be_zero_for_90">Deve ser 0 para ±90°</string>
 
     <!-- Input mode for leg editing -->
     <string-array name="leg_edit_input_mode_options">

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -463,6 +463,9 @@
     </string-array>
     <string name="settings_key_deg_mins_secs_title">Azimute em graus/minutos/segundos</string>
     <string name="settings_key_deg_mins_secs_summary">Introduzir valores de azimute em graus/minutos/segundos (em vez da predefinição decimal)</string>
+    <string name="manual_edit_inclination_deg_mins_secs">Inclinação (&#176; \' \")</string>
+    <string name="settings_key_inc_deg_mins_secs_title">Inclinação em graus/minutos/segundos</string>
+    <string name="settings_key_inc_deg_mins_secs_summary">Introduzir valores de inclinação em graus/minutos/segundos (em vez da predefinição decimal)</string>
     <string name="settings_export_title">Exportação</string>
     <string name="settings_export_summary">Formatos de exportação e opções de pasta</string>
     <string name="settings_export_svg_background_title">Fundo SVG</string>
@@ -535,6 +538,8 @@
     <string name="validation_error_distance_minimum">Deve ser >= %1$d</string>
     <string name="validation_error_azimuth_range">Deve ser %1$d-%2$d</string>
     <string name="validation_error_inclination_range">Deve ser de -90 a 90 ou de 270 a 360</string>
+    <string name="validation_error_must_be_whole_number">Deve ser um número inteiro</string>
+    <string name="validation_error_mins_secs_range">Deve ser de 0 a 59</string>
 
     <!-- Input mode for leg editing -->
     <string-array name="leg_edit_input_mode_options">

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -532,9 +532,9 @@
     <string name="validation_error_same_as_from_station">Não pode ser a mesma que a estação de origem</string>
     <string name="validation_error_station_name_not_unique">O nome da estação deve ser único</string>
     <string name="validation_error_must_be_number">Deve ser um número</string>
-    <string name="validation_error_distance_minimum">Deve ser >= %1$f</string>
-    <string name="validation_error_azimuth_range">Deve ser %1$f-%2$f</string>
-    <string name="validation_error_inclination_range">Deve ser de %1$f a %2$f</string>
+    <string name="validation_error_distance_minimum">Deve ser >= %1$d</string>
+    <string name="validation_error_azimuth_range">Deve ser %1$d-%2$d</string>
+    <string name="validation_error_inclination_range">Deve ser de %1$d a %2$d</string>
 
     <!-- Input mode for leg editing -->
     <string-array name="leg_edit_input_mode_options">

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -540,6 +540,7 @@
     <string name="validation_error_inclination_range">Deve ser de -90 a 90 ou de 270 a 360</string>
     <string name="validation_error_must_be_whole_number">Deve ser um número inteiro</string>
     <string name="validation_error_mins_secs_range">Deve ser de 0 a 59</string>
+    <string name="validation_error_secs_range">Deve ser de 0 a menos de 60</string>
 
     <!-- Input mode for leg editing -->
     <string-array name="leg_edit_input_mode_options">

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -534,7 +534,7 @@
     <string name="validation_error_must_be_number">Deve ser um número</string>
     <string name="validation_error_distance_minimum">Deve ser >= %1$d</string>
     <string name="validation_error_azimuth_range">Deve ser %1$d-%2$d</string>
-    <string name="validation_error_inclination_range">Deve ser de %1$d a %2$d</string>
+    <string name="validation_error_inclination_range">Deve ser de -90 a 90 ou de 270 a 360</string>
 
     <!-- Input mode for leg editing -->
     <string-array name="leg_edit_input_mode_options">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -498,6 +498,9 @@
     </string-array>
     <string name="settings_key_deg_mins_secs_title">Azimuth as degrees/minutes/seconds</string>
     <string name="settings_key_deg_mins_secs_summary">Enter azimuth values in deg/mins/secs (as opposed to the default of decimal)</string>
+    <string name="manual_edit_inclination_deg_mins_secs">Inclination (&#176; \' \")</string>
+    <string name="settings_key_inc_deg_mins_secs_title">Inclination as degrees/minutes/seconds</string>
+    <string name="settings_key_inc_deg_mins_secs_summary">Enter inclination values in deg/mins/secs (as opposed to the default of decimal)</string>
     <string name="settings_export_title">Export</string>
     <string name="settings_export_svg_background_title">SVG background</string>
     <string name="settings_export_svg_background_summary">Optionally export with an opaque background</string>
@@ -568,6 +571,8 @@
     <string name="validation_error_distance_minimum">Must be >= %1$d</string>
     <string name="validation_error_azimuth_range">Must be %1$d-%2$d</string>
     <string name="validation_error_inclination_range">Must be -90 to 90 or 270 to 360</string>
+    <string name="validation_error_must_be_whole_number">Must be a whole number</string>
+    <string name="validation_error_mins_secs_range">Must be 0 to 59</string>
 
     <!-- Input mode for leg editing -->
     <string-array name="leg_edit_input_mode_options">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -567,7 +567,7 @@
     <string name="validation_error_must_be_number">Must be a number</string>
     <string name="validation_error_distance_minimum">Must be >= %1$d</string>
     <string name="validation_error_azimuth_range">Must be %1$d-%2$d</string>
-    <string name="validation_error_inclination_range">Must be %1$d to %2$d</string>
+    <string name="validation_error_inclination_range">Must be -90 to 90 or 270 to 360</string>
 
     <!-- Input mode for leg editing -->
     <string-array name="leg_edit_input_mode_options">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -574,6 +574,7 @@
     <string name="validation_error_must_be_whole_number">Must be a whole number</string>
     <string name="validation_error_mins_secs_range">Must be 0 to 59</string>
     <string name="validation_error_secs_range">Must be 0 to less than 60</string>
+    <string name="validation_error_must_be_zero_for_90">Must be 0 for ±90°</string>
 
     <!-- Input mode for leg editing -->
     <string-array name="leg_edit_input_mode_options">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -565,9 +565,9 @@
     <string name="validation_error_same_as_from_station">Cannot be the same as from station</string>
     <string name="validation_error_station_name_not_unique">Station name must be unique</string>
     <string name="validation_error_must_be_number">Must be a number</string>
-    <string name="validation_error_distance_minimum">Must be >= %1$f</string>
-    <string name="validation_error_azimuth_range">Must be %1$f-%2$f</string>
-    <string name="validation_error_inclination_range">Must be %1$f to %2$f</string>
+    <string name="validation_error_distance_minimum">Must be >= %1$d</string>
+    <string name="validation_error_azimuth_range">Must be %1$d-%2$d</string>
+    <string name="validation_error_inclination_range">Must be %1$d to %2$d</string>
 
     <!-- Input mode for leg editing -->
     <string-array name="leg_edit_input_mode_options">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -573,6 +573,7 @@
     <string name="validation_error_inclination_range">Must be -90 to 90 or 270 to 360</string>
     <string name="validation_error_must_be_whole_number">Must be a whole number</string>
     <string name="validation_error_mins_secs_range">Must be 0 to 59</string>
+    <string name="validation_error_secs_range">Must be 0 to less than 60</string>
 
     <!-- Input mode for leg editing -->
     <string-array name="leg_edit_input_mode_options">

--- a/app/src/main/res/xml/preferences_manual_data_entry.xml
+++ b/app/src/main/res/xml/preferences_manual_data_entry.xml
@@ -13,4 +13,10 @@
         android:summary="@string/settings_key_deg_mins_secs_summary"
         android:defaultValue="false"/>
 
+    <CheckBoxPreference
+        android:key="pref_inc_deg_mins_secs"
+        android:title="@string/settings_key_inc_deg_mins_secs_title"
+        android:summary="@string/settings_key_inc_deg_mins_secs_summary"
+        android:defaultValue="false"/>
+
 </PreferenceScreen>

--- a/app/src/test/java/org/hwyl/sexytopo/control/table/EditLegFormTest.java
+++ b/app/src/test/java/org/hwyl/sexytopo/control/table/EditLegFormTest.java
@@ -11,6 +11,8 @@ import org.junit.Test;
  */
 public class EditLegFormTest {
 
+    private static final float DELTA = 0.001f;
+
     @Test
     public void testNewLegCreationDoesNotRequireDestination() {
         // Simulate creating a new leg with measurements but no destination yet
@@ -49,5 +51,69 @@ public class EditLegFormTest {
             // Expected - destination should not be null for full legs
             Assert.assertTrue(e.getMessage().contains("Destination"));
         }
+    }
+
+    // ---- decomposeToDms tests ----
+
+    @Test
+    public void testDmsDecompositionPositive() {
+        // 45.5° = 45° 30' 0"
+        float[] dms = Leg.decomposeToDms(45.5f);
+        Assert.assertEquals(45, (int) dms[0]);
+        Assert.assertEquals(30, (int) dms[1]);
+        Assert.assertEquals(0.0f, dms[2], DELTA);
+    }
+
+    @Test
+    public void testDmsDecompositionNegative() {
+        // -30.75° = -30° 45' 0"  (sign on degrees only, minutes/seconds non-negative)
+        float[] dms = Leg.decomposeToDms(-30.75f);
+        Assert.assertEquals(-30, (int) dms[0]);
+        Assert.assertEquals(45, (int) dms[1]);
+        Assert.assertEquals(0.0f, dms[2], DELTA);
+    }
+
+    @Test
+    public void testDmsDecompositionZero() {
+        float[] dms = Leg.decomposeToDms(0.0f);
+        Assert.assertEquals(0, (int) dms[0]);
+        Assert.assertEquals(0, (int) dms[1]);
+        Assert.assertEquals(0.0f, dms[2], DELTA);
+    }
+
+    @Test
+    public void testDmsDecompositionRoundTripPositive() {
+        float original = 47.3f;
+        float[] dms = Leg.decomposeToDms(original);
+        float sign = dms[0] < 0 ? -1.0f : 1.0f;
+        float recomposed = dms[0] + sign * (dms[1] / 60.0f + dms[2] / 3600.0f);
+        Assert.assertEquals(original, recomposed, DELTA);
+    }
+
+    @Test
+    public void testDmsDecompositionRoundTripNegative() {
+        float original = -23.6f;
+        float[] dms = Leg.decomposeToDms(original);
+        float sign = dms[0] < 0 ? -1.0f : 1.0f;
+        float recomposed = dms[0] + sign * (dms[1] / 60.0f + dms[2] / 3600.0f);
+        Assert.assertEquals(original, recomposed, DELTA);
+    }
+
+    @Test
+    public void testDmsDecompositionAtPlusNinety() {
+        // +90° = 90° 0' 0"
+        float[] dms = Leg.decomposeToDms(90.0f);
+        Assert.assertEquals(90, (int) dms[0]);
+        Assert.assertEquals(0, (int) dms[1]);
+        Assert.assertEquals(0.0f, dms[2], DELTA);
+    }
+
+    @Test
+    public void testDmsDecompositionAtMinusNinety() {
+        // -90° = -90° 0' 0"
+        float[] dms = Leg.decomposeToDms(-90.0f);
+        Assert.assertEquals(-90, (int) dms[0]);
+        Assert.assertEquals(0, (int) dms[1]);
+        Assert.assertEquals(0.0f, dms[2], DELTA);
     }
 }

--- a/app/src/test/java/org/hwyl/sexytopo/control/table/EditLegFormTest.java
+++ b/app/src/test/java/org/hwyl/sexytopo/control/table/EditLegFormTest.java
@@ -149,4 +149,47 @@ public class EditLegFormTest {
         float recomposed = dms[0] + sign * (dms[1] / 60.0f + dms[2] / 3600.0f);
         Assert.assertEquals(original, recomposed, DELTA);
     }
+
+    // ---- legal range boundary tests ----
+
+    @Test
+    public void testInclinationAtPlusNinetyIsLegal() {
+        Assert.assertTrue(Leg.isInclinationLegal(90.0f));
+    }
+
+    @Test
+    public void testInclinationAtMinusNinetyIsLegal() {
+        Assert.assertTrue(Leg.isInclinationLegal(-90.0f));
+    }
+
+    @Test
+    public void testInclinationAboveNinetyIsIllegal() {
+        Assert.assertFalse(Leg.isInclinationLegal(90.001f));
+    }
+
+    @Test
+    public void testAzimuthAt360IsIllegal() {
+        Assert.assertFalse(Leg.isAzimuthLegal(360.0f));
+    }
+
+    @Test
+    public void testAzimuthAt359Point9IsLegal() {
+        Assert.assertTrue(Leg.isAzimuthLegal(359.9f));
+    }
+
+    @Test
+    public void testDmsRecompositionOfNinetyIsExact() {
+        float[] dms = Leg.decomposeToDms(90.0f);
+        Assert.assertEquals(90, (int) dms[0]);
+        Assert.assertEquals(0, (int) dms[1]);
+        Assert.assertEquals(0.0f, dms[2], DELTA);
+    }
+
+    @Test
+    public void testDmsRecompositionOfMinusNinetyIsExact() {
+        float[] dms = Leg.decomposeToDms(-90.0f);
+        Assert.assertEquals(-90, (int) dms[0]);
+        Assert.assertEquals(0, (int) dms[1]);
+        Assert.assertEquals(0.0f, dms[2], DELTA);
+    }
 }

--- a/app/src/test/java/org/hwyl/sexytopo/control/table/EditLegFormTest.java
+++ b/app/src/test/java/org/hwyl/sexytopo/control/table/EditLegFormTest.java
@@ -116,4 +116,37 @@ public class EditLegFormTest {
         Assert.assertEquals(0, (int) dms[1]);
         Assert.assertEquals(0.0f, dms[2], DELTA);
     }
+
+    // ---- decimal seconds tests ----
+
+    @Test
+    public void testDmsDecompositionProducesDecimalSeconds() {
+        // 45° 30' 30.5" = 45 + 30/60 + 30.5/3600 = 45.508472...°
+        float input = 45.0f + 30.0f / 60.0f + 30.5f / 3600.0f;
+        float[] dms = Leg.decomposeToDms(input);
+        Assert.assertEquals(45, (int) dms[0]);
+        Assert.assertEquals(30, (int) dms[1]);
+        // seconds should be non-integer (≈ 30.5)
+        Assert.assertTrue("Expected fractional seconds", dms[2] > 30.0f && dms[2] < 31.0f);
+    }
+
+    @Test
+    public void testDmsRoundTripWithDecimalSeconds() {
+        // Build a value whose seconds component is fractional
+        float original = 45.0f + 30.0f / 60.0f + 30.5f / 3600.0f;
+        float[] dms = Leg.decomposeToDms(original);
+        float sign = dms[0] < 0 ? -1.0f : 1.0f;
+        float recomposed = dms[0] + sign * (dms[1] / 60.0f + dms[2] / 3600.0f);
+        Assert.assertEquals(original, recomposed, DELTA);
+    }
+
+    @Test
+    public void testNegativeDmsRoundTripWithDecimalSeconds() {
+        // Negative inclination with fractional seconds: -12° 15' 45.75"
+        float original = -(12.0f + 15.0f / 60.0f + 45.75f / 3600.0f);
+        float[] dms = Leg.decomposeToDms(original);
+        float sign = dms[0] < 0 ? -1.0f : 1.0f;
+        float recomposed = dms[0] + sign * (dms[1] / 60.0f + dms[2] / 3600.0f);
+        Assert.assertEquals(original, recomposed, DELTA);
+    }
 }


### PR DESCRIPTION
Fixed the hang when entering manual readings that are not valid
closes #311
Claude was wrong, but lead to making the validation more robust, I hope.
58b9c98 only fixes that.
0e55a2c adds in 270-360 range that is needed for theodolite readings closes #60 
This has revealed a bug in the DMS, input, it is impossible to save due to the validation, I'll look at that later., possibly add the ability to do it for inclination as well.

closes https://github.com/richsmith/sexytopo/issues/76
closes #170