### PR TITLE
Comments on legs and splays

### DIFF
--- a/app/src/main/java/org/hwyl/sexytopo/control/activity/SurveyEditorActivity.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/activity/SurveyEditorActivity.java
@@ -52,6 +52,10 @@ public abstract class SurveyEditorActivity extends SexyTopoActivity {
         openCommentDialog(station);
     }
 
+    public void onCommentLeg(Leg leg) {
+        openLegCommentDialog(leg);
+    }
+
     public void onJumpToTable(Station station) {
         jumpToStation(station, TableActivity.class);
     }
@@ -248,6 +252,39 @@ public abstract class SurveyEditorActivity extends SexyTopoActivity {
                         (dialog, which) -> {
                             CharSequence inputText = input.getText();
                             station.setComment(inputText != null ? inputText.toString() : "");
+                            invalidateView();
+                        })
+                .setNegativeButton(R.string.cancel, null);
+
+        Dialog dialog = builder.create();
+        DialogUtils.showKeyboardOnDisplay(dialog);
+        dialog.show();
+        input.requestFocus();
+    }
+
+    /** Open the comment dialog for the given leg or splay. */
+    protected void openLegCommentDialog(Leg leg) {
+        boolean isSplay = !leg.hasDestination();
+        int hintRes = isSplay ? R.string.menu_comment_splay : R.string.menu_comment_leg;
+        int titleRes = isSplay ? R.string.menu_comment_splay : R.string.menu_comment_leg;
+
+        TextInputLayout inputLayout = DialogUtils.createStandardTextInputLayout(this, hintRes);
+
+        TextInputEditText input = DialogUtils.getEditText(inputLayout);
+        input.setLines(8);
+        input.setGravity(Gravity.START | Gravity.TOP);
+        input.setText(leg.getComment());
+        input.setFocusableInTouchMode(true);
+
+        MaterialAlertDialogBuilder builder = new MaterialAlertDialogBuilder(this);
+        builder.setView(inputLayout)
+                .setTitle(titleRes)
+                .setPositiveButton(
+                        R.string.save,
+                        (dialog, which) -> {
+                            CharSequence inputText = input.getText();
+                            leg.setComment(inputText != null ? inputText.toString() : "");
+                            getSurveyManager().broadcastSurveyUpdated();
                             invalidateView();
                         })
                 .setNegativeButton(R.string.cancel, null);

--- a/app/src/main/java/org/hwyl/sexytopo/control/activity/TableActivity.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/activity/TableActivity.java
@@ -162,7 +162,9 @@ public class TableActivity extends SurveyEditorActivity
 
         if (headerTable.getChildCount() > 0) {
             android.widget.TableRow headerRow = (android.widget.TableRow) headerTable.getChildAt(0);
-            for (int i = 0; i < headerRow.getChildCount(); i++) {
+            for (int i = 0;
+                    i < headerRow.getChildCount() - 1;
+                    i++) { // exclude fixed-width comment column
                 View cell = headerRow.getChildAt(i);
                 widths.add(cell.getWidth());
             }

--- a/app/src/main/java/org/hwyl/sexytopo/control/graph/ContextMenuManager.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/graph/ContextMenuManager.java
@@ -185,6 +185,12 @@ public class ContextMenuManager {
                     downgradeItem.setVisible(!isSplay);
                     downgradeItem.setEnabled(canDowngrade);
                 }
+
+                MenuItem commentLegItem = menu.findItem(R.id.action_comment_leg);
+                if (commentLegItem != null) {
+                    commentLegItem.setTitle(
+                            isSplay ? R.string.menu_comment_splay : R.string.menu_comment_leg);
+                }
                 if (legMenuItem != null) {
                     legMenuItem.setTitle(R.string.menu_incoming_leg);
                     if (!isSplay) {
@@ -269,6 +275,10 @@ public class ContextMenuManager {
         }
         if (itemId == R.id.action_delete_leg && currentLeg != null) {
             activity.onDeleteLeg(currentLeg);
+            return true;
+        }
+        if (itemId == R.id.action_comment_leg && currentLeg != null) {
+            activity.onCommentLeg(currentLeg);
             return true;
         }
 

--- a/app/src/main/java/org/hwyl/sexytopo/control/io/basic/SurveyJsonTranslater.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/io/basic/SurveyJsonTranslater.java
@@ -259,6 +259,7 @@ public class SurveyJsonTranslater {
         json.put(INCLINATION_TAG, leg.getInclination());
         json.put(DESTINATION_TAG, leg.getDestination().getName());
         json.put(WAS_SHOT_BACKWARDS_TAG, leg.wasShotBackwards());
+        json.put(COMMENT_TAG, leg.getComment());
         if (index != null) {
             json.put(INDEX_TAG, index);
         }
@@ -379,6 +380,7 @@ public class SurveyJsonTranslater {
                             wasShotBackwards);
         }
 
+        leg.setComment(json.optString(COMMENT_TAG, ""));
         return leg;
     }
 

--- a/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/survex/SurvexImporter.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/survex/SurvexImporter.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import org.hwyl.sexytopo.control.io.IoUtils;
+import org.hwyl.sexytopo.control.io.thirdparty.survextherion.SexyTopoVersion;
 import org.hwyl.sexytopo.control.io.thirdparty.survextherion.SurvexTherionImporter;
 import org.hwyl.sexytopo.control.io.thirdparty.survextherion.SurveyFormat;
 import org.hwyl.sexytopo.control.io.translation.Importer;
@@ -19,6 +20,14 @@ public class SurvexImporter extends Importer {
         Survey survey = new Survey();
         String text = IoUtils.slurpFile(context, file);
 
+        // Determine import mode based on the SexyTopo version that wrote the file.
+        // Files with no version header (third-party) or written by 1.11.3+ use the new
+        // leg-comment path. Only files positively identified as 1.11.2 or earlier use the
+        // legacy station-comment path.
+        SexyTopoVersion version = SexyTopoVersion.extractFromText(text);
+        boolean useLegComments =
+                version == null || version.isAfter(SexyTopoVersion.LEG_COMMENTS_VERSION_CUTOFF);
+
         // Parse passage data first to extract station comments
         Map<String, String> passageComments =
                 SurvexTherionImporter.parsePassageData(text, SurveyFormat.SURVEX);
@@ -26,7 +35,7 @@ public class SurvexImporter extends Importer {
         // Parse centreline data from the normal data block only.
         // This avoids trying to parse passage rows (e.g. "1 - - - - comment") as shots.
         String centrelineText = extractNormalDataBlock(text, SurveyFormat.SURVEX);
-        SurvexTherionImporter.parseCentreline(centrelineText, survey);
+        SurvexTherionImporter.parseCentreline(centrelineText, survey, useLegComments);
 
         // Merge passage comments with station comments
         SurvexTherionImporter.mergePassageComments(survey, passageComments);

--- a/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/survextherion/SexyTopoVersion.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/survextherion/SexyTopoVersion.java
@@ -1,0 +1,109 @@
+package org.hwyl.sexytopo.control.io.thirdparty.survextherion;
+
+import androidx.annotation.NonNull;
+
+/**
+ * Parses and compares SexyTopo version numbers embedded in exported file headers.
+ *
+ * <p>The header format written by the exporter is:
+ *
+ * <pre>
+ *   # Created with SexyTopo 1.11.3 on 2025-03-01   (Therion)
+ *   ; Created with SexyTopo 1.11.3 on 2025-03-01   (Survex)
+ * </pre>
+ *
+ * <p>Files with no SexyTopo header (third-party files) return {@code null} from {@link
+ * #extractFromText(String)}.
+ */
+public class SexyTopoVersion {
+
+    /**
+     * The first version that writes leg/splay comments inline on data lines rather than as station
+     * comments in a separate data passage block. Files written by versions strictly after this
+     * cutoff (i.e. 1.11.3+) use the new leg-comment import path. Files at or before this version,
+     * use the legacy station-comment path.
+     */
+    public static final SexyTopoVersion LEG_COMMENTS_VERSION_CUTOFF =
+            new SexyTopoVersion(1, 11, 2);
+
+    private static final String HEADER_MARKER = "Created with SexyTopo ";
+
+    private final int major;
+    private final int minor;
+    private final int patch;
+
+    public SexyTopoVersion(int major, int minor, int patch) {
+        this.major = major;
+        this.minor = minor;
+        this.patch = patch;
+    }
+
+    /**
+     * Scan the first lines of a file for a SexyTopo version header and parse the version.
+     *
+     * @param text full file text
+     * @return parsed version, or {@code null} if no SexyTopo header is found or it cannot be parsed
+     */
+    public static SexyTopoVersion extractFromText(String text) {
+        for (String line : text.split("\n")) {
+            String trimmed = line.trim();
+            // Strip leading comment character (# or ;) then look for the marker
+            String stripped =
+                    (trimmed.startsWith("#") || trimmed.startsWith(";"))
+                            ? trimmed.substring(1).trim()
+                            : trimmed;
+
+            int markerIndex = stripped.indexOf(HEADER_MARKER);
+            if (markerIndex < 0) {
+                continue;
+            }
+
+            // Version token is the word immediately after the marker
+            String afterMarker = stripped.substring(markerIndex + HEADER_MARKER.length()).trim();
+            String[] tokens = afterMarker.split("\\s+");
+            if (tokens.length == 0) {
+                return null;
+            }
+
+            return parse(tokens[0]);
+        }
+        return null;
+    }
+
+    /**
+     * Parse a dotted version string such as {@code "1.11.3"}.
+     *
+     * @return parsed version, or {@code null} if the string is not a valid version
+     */
+    static SexyTopoVersion parse(String versionString) {
+        String[] parts = versionString.split("\\.");
+        if (parts.length != 3) {
+            return null;
+        }
+        try {
+            int major = Integer.parseInt(parts[0]);
+            int minor = Integer.parseInt(parts[1]);
+            int patch = Integer.parseInt(parts[2]);
+            return new SexyTopoVersion(major, minor, patch);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    /**
+     * Returns {@code true} if this version is strictly greater than {@code other}.
+     *
+     * <p>Comparison is major → minor → patch.
+     */
+    public boolean isAfter(SexyTopoVersion other) {
+        if (this.major != other.major) return this.major > other.major;
+        if (this.minor != other.minor) return this.minor > other.minor;
+        return this.patch > other.patch;
+    }
+
+    @NonNull
+    @Override
+    public String toString() {
+        return major + "." + minor + "." + patch;
+    }
+}

--- a/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/survextherion/SexyTopoVersion.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/survextherion/SexyTopoVersion.java
@@ -23,8 +23,7 @@ public class SexyTopoVersion {
      * cutoff (i.e. 1.11.3+) use the new leg-comment import path. Files at or before this version,
      * use the legacy station-comment path.
      */
-    public static final SexyTopoVersion LEG_COMMENTS_VERSION_CUTOFF =
-            new SexyTopoVersion(1, 11, 2);
+    public static final SexyTopoVersion LEG_COMMENTS_VERSION_CUTOFF = new SexyTopoVersion(1, 11, 2);
 
     private static final String HEADER_MARKER = "Created with SexyTopo ";
 

--- a/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/survextherion/SurvexTherionImporter.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/survextherion/SurvexTherionImporter.java
@@ -2,6 +2,7 @@ package org.hwyl.sexytopo.control.io.thirdparty.survextherion;
 
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -56,16 +57,36 @@ public class SurvexTherionImporter {
             }
 
             try {
-                // Extract comment - support both ; (Survex) and # (Therion)
-                String comment = extractCommentFromLine(line);
+                String[] allTokens = trimmed.split("\\s+");
 
-                String[] fields = line.trim().split("\\s+");
+                // A valid leg line must have at least 5 tokens:
+                // from to distance azimuth inclination
+                if (allTokens.length < 5) {
+                    continue;
+                }
+
+                String[] legFields = Arrays.copyOfRange(allTokens, 0, 5);
+
+                // Any tokens after the 5 leg fields form the comment tail.
+                // The tail may optionally start with a comment character (# or ;) which is
+                // stripped — both "1 2 3.0 45.0 0.0 # My Chamber" and
+                // "1 2 3.0 45.0 0.0 My Chamber" are valid and produce the same comment.
+                String comment = "";
+                if (allTokens.length > 5) {
+                    String tail =
+                            String.join(" ", Arrays.copyOfRange(allTokens, 5, allTokens.length));
+                    if (tail.startsWith(";") || tail.startsWith("#")) {
+                        tail = tail.substring(1).trim();
+                    }
+                    comment = tail;
+                }
 
                 // Check for commented new lines promoted legs in subsequent lines
                 List<Leg> commentedNewLineLegs =
-                        parseCommentedNewLinePromotedLegs(lines, lineIndex, fields[0], fields[1]);
+                        parseCommentedNewLinePromotedLegs(
+                                lines, lineIndex, legFields[0], legFields[1]);
 
-                addLegToSurvey(survey, nameToStation, fields, comment, commentedNewLineLegs);
+                addLegToSurvey(survey, nameToStation, legFields, comment, commentedNewLineLegs);
 
             } catch (Exception exception) {
                 throw new Exception("Error importing this line: " + line);
@@ -532,21 +553,6 @@ public class SurvexTherionImporter {
         } else {
             return "";
         }
-    }
-
-    private static String extractCommentFromLine(String line) {
-        String comment = "";
-
-        // Try semicolon first (Survex style)
-        if (line.contains(";")) {
-            comment = line.substring(line.indexOf(";") + 1).trim();
-        }
-        // Try hash (Therion style)
-        else if (line.contains("#")) {
-            comment = line.substring(line.indexOf("#") + 1).trim();
-        }
-
-        return comment;
     }
 
     /**

--- a/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/survextherion/SurvexTherionImporter.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/survextherion/SurvexTherionImporter.java
@@ -33,6 +33,29 @@ public class SurvexTherionImporter {
      * @throws Exception if parsing fails
      */
     public static void parseCentreline(String text, Survey survey) throws Exception {
+        parseCentreline(text, survey, false);
+    }
+
+    /**
+     * Parse centreline data, with control over where trailing leg-line comments are applied.
+     *
+     * <p>When {@code useLegComments} is {@code true} (files written by SexyTopo 1.11.3+, or files
+     * with no SexyTopo version header), a trailing comment on a data line is stored on the {@link
+     * Leg} itself. Promoted-leg precursor comments are similarly stored on each precursor {@link
+     * Leg}.
+     *
+     * <p>When {@code useLegComments} is {@code false} (files written by SexyTopo 1.11.2 or
+     * earlier), the legacy behaviour applies: the comment is stored on the newer station of the
+     * leg.
+     *
+     * @param text The centreline data text
+     * @param survey The survey to populate
+     * @param useLegComments {@code true} to attach comments to legs/splays; {@code false} for the
+     *     legacy station-comment path
+     * @throws Exception if parsing fails
+     */
+    public static void parseCentreline(String text, Survey survey, boolean useLegComments)
+            throws Exception {
 
         Map<String, Station> nameToStation = new HashMap<>();
 
@@ -84,9 +107,15 @@ public class SurvexTherionImporter {
                 // Check for commented new lines promoted legs in subsequent lines
                 List<Leg> commentedNewLineLegs =
                         parseCommentedNewLinePromotedLegs(
-                                lines, lineIndex, legFields[0], legFields[1]);
+                                lines, lineIndex, legFields[0], legFields[1], useLegComments);
 
-                addLegToSurvey(survey, nameToStation, legFields, comment, commentedNewLineLegs);
+                addLegToSurvey(
+                        survey,
+                        nameToStation,
+                        legFields,
+                        comment,
+                        commentedNewLineLegs,
+                        useLegComments);
 
             } catch (Exception exception) {
                 throw new Exception("Error importing this line: " + line);
@@ -386,7 +415,8 @@ public class SurvexTherionImporter {
             Map<String, Station> nameToStation,
             String[] fields,
             String comment,
-            List<Leg> commentedNewLineLegs) {
+            List<Leg> commentedNewLineLegs,
+            boolean useLegComments) {
 
         String fromName = fields[0];
         String toName = fields[1];
@@ -424,7 +454,7 @@ public class SurvexTherionImporter {
         String commentInstructions = extractCommentInstructions(comment);
         Leg[] promotedFrom = parseInlinePromotedLegs(commentInstructions);
 
-        // Strip the instruction from the comment so it doesn't end up on the station
+        // Strip the instruction from the comment so it doesn't end up on the leg or station
         if (!commentInstructions.isEmpty()) {
             comment = comment.replace(commentInstructions, "").trim();
         }
@@ -438,20 +468,24 @@ public class SurvexTherionImporter {
         Station legFrom;
 
         if (isBackward) {
-            // This leg was shot backwards (from new station to existing station)
-            // Store with swapped stations and wasShotBackwards = true
             legFrom = to;
 
-            // Create leg with original measurements and wasShotBackwards = true
             if (from == Survey.NULL_STATION) {
                 leg = new Leg(distance, azimuth, inclination, true);
             } else {
                 leg = new Leg(distance, azimuth, inclination, from, promotedFrom, true);
             }
 
-            // Station comment goes on the TO station (the new one in the file)
-            if (!comment.isEmpty() && from != Survey.NULL_STATION) {
-                from.setComment(comment);
+            if (!comment.isEmpty()) {
+                if (useLegComments) {
+                    // New path: comment belongs to the leg/splay itself
+                    leg.setComment(comment);
+                } else {
+                    // Legacy path: comment goes on the newer station (from, in a backward leg)
+                    if (from != Survey.NULL_STATION) {
+                        from.setComment(comment);
+                    }
+                }
             }
         } else {
             // Forward leg
@@ -463,9 +497,16 @@ public class SurvexTherionImporter {
                 leg = new Leg(distance, azimuth, inclination, to, promotedFrom);
             }
 
-            // Station comment goes on the TO station
-            if (!comment.isEmpty() && to != Survey.NULL_STATION) {
-                to.setComment(comment);
+            if (!comment.isEmpty()) {
+                if (useLegComments) {
+                    // New path: comment belongs to the leg/splay itself
+                    leg.setComment(comment);
+                } else {
+                    // Legacy path: comment goes on the to station
+                    if (to != Survey.NULL_STATION) {
+                        to.setComment(comment);
+                    }
+                }
             }
         }
 
@@ -505,9 +546,16 @@ public class SurvexTherionImporter {
      * <p>These are shots on commented lines that come AFTER the main leg line.
      *
      * <p>Example: 1 2 5.541 253.93 4.67 #1 2 5.542 73.95 -4.64 #1 2 5.541 73.93 -4.69
+     *
+     * <p>When {@code useLegComments} is {@code true}, any trailing comment on a precursor line
+     * (tokens after the 5 data fields) is stored on the returned {@link Leg}.
      */
     private static List<Leg> parseCommentedNewLinePromotedLegs(
-            String[] lines, int startIndex, String expectedFrom, String expectedTo) {
+            String[] lines,
+            int startIndex,
+            String expectedFrom,
+            String expectedTo,
+            boolean useLegComments) {
 
         List<Leg> shots = new ArrayList<>();
 
@@ -533,7 +581,21 @@ public class SurvexTherionImporter {
                     float distance = Float.parseFloat(fields[2]);
                     float azimuth = Float.parseFloat(fields[3]);
                     float inclination = Float.parseFloat(fields[4]);
-                    shots.add(new Leg(distance, azimuth, inclination));
+                    Leg precursor = new Leg(distance, azimuth, inclination);
+
+                    // If using leg comments, capture any trailing comment on this precursor line
+                    if (useLegComments && fields.length > 5) {
+                        String tail =
+                                String.join(" ", Arrays.copyOfRange(fields, 5, fields.length));
+                        if (tail.startsWith(";") || tail.startsWith("#")) {
+                            tail = tail.substring(1).trim();
+                        }
+                        if (!tail.isEmpty()) {
+                            precursor.setComment(tail);
+                        }
+                    }
+
+                    shots.add(precursor);
                 } catch (NumberFormatException e) {
                     Log.e("Failed to parse commented new line promoted leg: " + line);
                 }

--- a/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/survextherion/SurvexTherionImporter.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/survextherion/SurvexTherionImporter.java
@@ -519,7 +519,8 @@ public class SurvexTherionImporter {
      * Detect if a leg was shot backwards.
      *
      * <p>A leg is backward if the FROM station is new (not seen before). Detection is based on
-     * POSITION (from/to), not station names/numbers.
+     * POSITION (from/to), not station names/numbers. Loop closures (both stations already known)
+     * are not supported by SexyTopo.
      */
     private static boolean isBackwardLeg(
             String fromName, String toName, Map<String, Station> seenStations) {
@@ -532,7 +533,7 @@ public class SurvexTherionImporter {
         }
 
         if (!fromIsNew && !toIsNew) {
-            // Both exist - this is a loop/connection, assume forward
+            // Both exist - not valid in SexyTopo (no loop closures), assume forward
             return false;
         }
 

--- a/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/survextherion/SurvexTherionUtil.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/survextherion/SurvexTherionUtil.java
@@ -206,6 +206,11 @@ public class SurvexTherionUtil {
         formatField(builder, TableCol.AZIMUTH.format(leg.getAzimuth(), Locale.UK));
         formatField(builder, TableCol.INCLINATION.format(leg.getInclination(), Locale.UK));
 
+        // Append comment on the active data line if present (Cases 1 & 2)
+        if (leg.hasComment()) {
+            builder.append(flattenComment(leg.getComment()));
+        }
+
         // Handle promoted legs - put readings on subsequent lines
         if (leg.wasPromoted()) {
             char commentChar = format.getCommentChar();
@@ -220,8 +225,17 @@ public class SurvexTherionUtil {
                 builder.append(TableCol.AZIMUTH.format(precursor.getAzimuth(), Locale.UK))
                         .append("\t");
                 builder.append(TableCol.INCLINATION.format(precursor.getInclination(), Locale.UK));
+
+                // Append precursor splay comment if present (Case 3)
+                if (precursor.hasComment()) {
+                    builder.append("\t").append(flattenComment(precursor.getComment()));
+                }
             }
         }
+    }
+
+    private static String flattenComment(String comment) {
+        return comment.replaceAll("(\\r|\\n|\\r\\n)+", "\\\\n");
     }
 
     private static void formatField(StringBuilder builder, Object value) {

--- a/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/therion/TherionImporter.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/therion/TherionImporter.java
@@ -10,6 +10,7 @@ import org.apache.commons.io.FilenameUtils;
 import org.hwyl.sexytopo.SexyTopoConstants;
 import org.hwyl.sexytopo.control.Log;
 import org.hwyl.sexytopo.control.io.IoUtils;
+import org.hwyl.sexytopo.control.io.thirdparty.survextherion.SexyTopoVersion;
 import org.hwyl.sexytopo.control.io.thirdparty.survextherion.SurvexTherionImporter;
 import org.hwyl.sexytopo.control.io.thirdparty.survextherion.SurveyFormat;
 import org.hwyl.sexytopo.control.io.thirdparty.xvi.XviImporter;
@@ -58,8 +59,17 @@ public class TherionImporter extends Importer {
     private static Survey parseTh(Context context, DocumentFile file) throws Exception {
         Survey survey = new Survey();
         String contents = IoUtils.slurpFile(context, file);
+
+        // Determine import mode based on the SexyTopo version that wrote the file.
+        // Files with no version header (third-party) or written by 1.11.3+ use the new
+        // leg-comment path. Only files positively identified as 1.11.2 or earlier use the
+        // legacy station-comment path.
+        SexyTopoVersion version = SexyTopoVersion.extractFromText(contents);
+        boolean useLegComments =
+                version == null || version.isAfter(SexyTopoVersion.LEG_COMMENTS_VERSION_CUTOFF);
+
         List<String> lines = Arrays.asList(contents.split("\n"));
-        updateCentreline(lines, survey);
+        updateCentreline(lines, survey, useLegComments);
 
         Trip trip = SurvexTherionImporter.parseMetadata(contents, SurveyFormat.THERION);
         if (trip != null) {
@@ -82,6 +92,11 @@ public class TherionImporter extends Importer {
     }
 
     public static void updateCentreline(List<String> lines, Survey survey) throws Exception {
+        updateCentreline(lines, survey, false);
+    }
+
+    public static void updateCentreline(List<String> lines, Survey survey, boolean useLegComments)
+            throws Exception {
         List<String> block = getContentsOfBeginEndBlock(lines, "centreline");
 
         String blockText = TextTools.join("\n", block);
@@ -116,7 +131,7 @@ public class TherionImporter extends Importer {
         }
 
         String centrelineText = TextTools.join("\n", sanitisedCentrelineData);
-        SurvexTherionImporter.parseCentreline(centrelineText, survey);
+        SurvexTherionImporter.parseCentreline(centrelineText, survey, useLegComments);
         handleElevationDirectionData(sanitisedElevationDirectionData, survey);
 
         SurvexTherionImporter.mergePassageComments(survey, passageComments);

--- a/app/src/main/java/org/hwyl/sexytopo/control/table/TableRowAdapter.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/table/TableRowAdapter.java
@@ -188,6 +188,40 @@ public class TableRowAdapter extends RecyclerView.Adapter<TableRowAdapter.TableR
                         return true;
                     });
         }
+
+        // Bind comment indicator column
+        TextView commentView = holder.itemView.findViewById(R.id.tableRowComment);
+        if (commentView != null) {
+            commentView.setText(entry.getLeg().hasComment() ? "💬" : "");
+
+            // Match row background colour to the data columns
+            if (isActiveStation(map.get(TableCol.FROM)) || isActiveStation(map.get(TableCol.TO))) {
+                int bgColor = ContextCompat.getColor(context, R.color.tableHighlight);
+                commentView.setBackgroundColor(bgColor);
+            } else if (position % 2 == 0) {
+                int bgColor = ContextCompat.getColor(context, R.color.tableBackground);
+                commentView.setBackgroundColor(bgColor);
+            } else {
+                int bgColor = ContextCompat.getColor(context, R.color.tableBackgroundAlt);
+                commentView.setBackgroundColor(bgColor);
+            }
+
+            // Match bold/normal typeface to the data columns
+            if (entry.getLeg().hasDestination()) {
+                commentView.setTypeface(Typeface.DEFAULT_BOLD);
+            } else {
+                commentView.setTypeface(Typeface.DEFAULT);
+            }
+
+            // Long-press on comment cell also triggers the row context menu
+            commentView.setOnLongClickListener(
+                    v -> {
+                        if (onRowClickListener != null) {
+                            onRowClickListener.onRowLongClick(v, entry, TableCol.FROM);
+                        }
+                        return true;
+                    });
+        }
     }
 
     public void setColumnWidths(List<Integer> widths) {

--- a/app/src/main/java/org/hwyl/sexytopo/control/util/SurveyUpdater.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/util/SurveyUpdater.java
@@ -147,8 +147,11 @@ public class SurveyUpdater {
                         Arrays.asList(leg.wasPromoted() ? leg.getPromotedFrom() : new Leg[] {leg}));
         allShots.add(splay);
 
-        return Leg.upgradeSplayToConnectedLeg(
-                averageLegs(allShots), leg.getDestination(), allShots.toArray(new Leg[0]));
+        Leg newLeg =
+                Leg.upgradeSplayToConnectedLeg(
+                        averageLegs(allShots), leg.getDestination(), allShots.toArray(new Leg[0]));
+        newLeg.setComment(leg.getComment());
+        return newLeg;
     }
 
     private static synchronized String getNextStationName(Survey survey) {

--- a/app/src/main/java/org/hwyl/sexytopo/model/survey/Leg.java
+++ b/app/src/main/java/org/hwyl/sexytopo/model/survey/Leg.java
@@ -100,6 +100,7 @@ public class Leg extends SurveyComponent {
                         destination,
                         promotedFrom,
                         splay.wasShotBackwards);
+        leg.setComment(splay.getComment());
         return leg;
     }
 

--- a/app/src/main/java/org/hwyl/sexytopo/model/survey/Leg.java
+++ b/app/src/main/java/org/hwyl/sexytopo/model/survey/Leg.java
@@ -19,6 +19,7 @@ public class Leg extends SurveyComponent {
     private final Station destination;
     private final Leg[] promotedFrom;
     private final boolean wasShotBackwards;
+    private String comment = "";
 
     private static final Leg[] NO_LEGS = new Leg[] {};
 
@@ -199,6 +200,14 @@ public class Leg extends SurveyComponent {
 
     public static boolean isInclinationLegal(float inclination) {
         return MIN_INCLINATION <= inclination && inclination <= MAX_INCLINATION;
+    }
+
+    public String getComment() {
+        return comment;
+    }
+
+    public void setComment(String comment) {
+        this.comment = (comment != null) ? comment : "";
     }
 
     @NonNull

--- a/app/src/main/java/org/hwyl/sexytopo/model/survey/Leg.java
+++ b/app/src/main/java/org/hwyl/sexytopo/model/survey/Leg.java
@@ -206,6 +206,10 @@ public class Leg extends SurveyComponent {
         return comment;
     }
 
+    public boolean hasComment() {
+        return !comment.isEmpty();
+    }
+
     public void setComment(String comment) {
         this.comment = (comment != null) ? comment : "";
     }

--- a/app/src/main/res/layout-land/activity_table.xml
+++ b/app/src/main/res/layout-land/activity_table.xml
@@ -43,6 +43,7 @@
                     <TextView style="@style/HeaderText" android:layout_weight="1" android:text="@string/table_head_distance"/>
                     <TextView style="@style/HeaderText" android:layout_weight="1" android:text="@string/table_head_azimuth"/>
                     <TextView style="@style/HeaderText" android:layout_weight="1" android:text="@string/table_head_elevation"/>
+                    <TextView style="@style/HeaderText" android:layout_width="@dimen/table_comment_col_width" android:layout_weight="0" android:padding="2dp" android:text=""/>
                 </TableRow>
             </TableLayout>
 

--- a/app/src/main/res/layout/activity_table.xml
+++ b/app/src/main/res/layout/activity_table.xml
@@ -45,6 +45,7 @@
                     <TextView style="@style/HeaderText" android:layout_weight="1" android:text="@string/table_head_distance"/>
                     <TextView style="@style/HeaderText" android:layout_weight="1" android:text="@string/table_head_azimuth"/>
                     <TextView style="@style/HeaderText" android:layout_weight="1" android:text="@string/table_head_elevation"/>
+                    <TextView style="@style/HeaderText" android:layout_width="@dimen/table_comment_col_width" android:layout_weight="0" android:padding="2dp" android:text=""/>
                 </TableRow>
             </TableLayout>
 

--- a/app/src/main/res/layout/table_row.xml
+++ b/app/src/main/res/layout/table_row.xml
@@ -5,4 +5,5 @@
 <TextView android:id="@+id/tableRowDistance" style="@style/BodyText" android:layout_weight="1" android:singleLine="true" android:ellipsize="end" />
 <TextView android:id="@+id/tableRowAzimuth" style="@style/BodyText" android:layout_weight="1" android:singleLine="true" android:ellipsize="end" />
 <TextView android:id="@+id/tableRowInclination" style="@style/BodyText" android:layout_weight="1" android:singleLine="true" android:ellipsize="end" />
+<TextView android:id="@+id/tableRowComment" style="@style/BodyText" android:layout_width="@dimen/table_comment_col_width" android:layout_weight="0" android:padding="2dp" android:gravity="center" android:contentDescription="@string/comment_indicator_description" />
 </TableRow>

--- a/app/src/main/res/menu/context_leg.xml
+++ b/app/src/main/res/menu/context_leg.xml
@@ -31,6 +31,10 @@
             android:id="@+id/action_downgrade_leg"
             android:title="@string/menu_downgrade_leg"
             android:visible="false"/>
+
+        <item
+            android:id="@+id/action_comment_leg"
+            android:title="@string/menu_comment_leg"/>
     </group>
 
     <!-- Delete leg separated by divider -->

--- a/app/src/main/res/values-b+fr/strings.xml
+++ b/app/src/main/res/values-b+fr/strings.xml
@@ -606,6 +606,8 @@
     <string name="menu_start_new_survey">Commencer une nouvelle topographie ici</string>
     <string name="menu_unlink_survey">Dissocier la topographie liée</string>
     <string name="menu_comment">Commentaire</string>
+    <string name="menu_comment_leg">Leg comment</string>
+    <string name="menu_comment_splay">Splay comment</string>
     <string name="menu_toggle_left_right">Basculer Gauche/Droite</string>
     <string name="context_this_will_delete">Cela supprimera :</string>
     <string name="context_jump_to_splay_error">Impossible de se rendre à l\'extrémité d\'une radiale</string>

--- a/app/src/main/res/values-b+fr/strings.xml
+++ b/app/src/main/res/values-b+fr/strings.xml
@@ -608,6 +608,7 @@
     <string name="menu_comment">Commentaire</string>
     <string name="menu_comment_leg">Leg comment</string>
     <string name="menu_comment_splay">Splay comment</string>
+    <string name="comment_indicator_description">Has comment</string>
     <string name="menu_toggle_left_right">Basculer Gauche/Droite</string>
     <string name="context_this_will_delete">Cela supprimera :</string>
     <string name="context_jump_to_splay_error">Impossible de se rendre à l\'extrémité d\'une radiale</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -604,6 +604,8 @@
     <string name="menu_start_new_survey">Hier neue Vermessung beginnen</string>
     <string name="menu_unlink_survey">Verknüpfung zu anderer Vermessungsdatei lösen</string>
     <string name="menu_comment">Kommentar</string>
+    <string name="menu_comment_leg">Leg comment</string>
+    <string name="menu_comment_splay">Splay comment</string>
     <string name="menu_toggle_left_right">Links/Rechts umschalten</string>
     <string name="menu_context_title_leg">Messung %1$s &#10132; %2$s</string>
     <string name="menu_context_title_splay">Splay %s &#10132;</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -606,6 +606,7 @@
     <string name="menu_comment">Kommentar</string>
     <string name="menu_comment_leg">Leg comment</string>
     <string name="menu_comment_splay">Splay comment</string>
+    <string name="comment_indicator_description">Has comment</string>
     <string name="menu_toggle_left_right">Links/Rechts umschalten</string>
     <string name="menu_context_title_leg">Messung %1$s &#10132; %2$s</string>
     <string name="menu_context_title_splay">Splay %s &#10132;</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -606,6 +606,7 @@
     <string name="menu_comment">Comentario</string>
     <string name="menu_comment_leg">Leg comment</string>
     <string name="menu_comment_splay">Splay comment</string>
+    <string name="comment_indicator_description">Has comment</string>
     <string name="menu_toggle_left_right">Alternar Izquierda/Derecha</string>
     <string name="menu_context_title_leg">Tramo %1$s &#10132; %2$s</string>
     <string name="menu_context_title_splay">%s a Radial</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -604,6 +604,8 @@
     <string name="menu_start_new_survey">Iniciar Nueva Topografía Aquí</string>
     <string name="menu_unlink_survey">Desenlazar Topografía Enlazada</string>
     <string name="menu_comment">Comentario</string>
+    <string name="menu_comment_leg">Leg comment</string>
+    <string name="menu_comment_splay">Splay comment</string>
     <string name="menu_toggle_left_right">Alternar Izquierda/Derecha</string>
     <string name="menu_context_title_leg">Tramo %1$s &#10132; %2$s</string>
     <string name="menu_context_title_splay">%s a Radial</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -604,6 +604,8 @@
     <string name="menu_start_new_survey">Inizia Nuovo Rilievo Qui</string>
     <string name="menu_unlink_survey">Scollega Rilievo Collegato</string>
     <string name="menu_comment">Commento</string>
+    <string name="menu_comment_leg">Leg comment</string>
+    <string name="menu_comment_splay">Splay comment</string>
     <string name="menu_toggle_left_right">Commuta Sinistra/Destra</string>
     <string name="menu_context_title_leg">Tratto %1$s &#10132; %2$s</string>
     <string name="menu_context_title_splay">Splay %s &#10132;</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -606,6 +606,7 @@
     <string name="menu_comment">Commento</string>
     <string name="menu_comment_leg">Leg comment</string>
     <string name="menu_comment_splay">Splay comment</string>
+    <string name="comment_indicator_description">Has comment</string>
     <string name="menu_toggle_left_right">Commuta Sinistra/Destra</string>
     <string name="menu_context_title_leg">Tratto %1$s &#10132; %2$s</string>
     <string name="menu_context_title_splay">Splay %s &#10132;</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -606,6 +606,7 @@
     <string name="menu_comment">Komentarz</string>
     <string name="menu_comment_leg">Leg comment</string>
     <string name="menu_comment_splay">Splay comment</string>
+    <string name="comment_indicator_description">Has comment</string>
     <string name="menu_toggle_left_right">Przełącz lewo/prawo</string>
     <string name="menu_context_title_leg">Ciąg %1$s &#10132; %2$s</string>
     <string name="menu_context_title_splay">%s do pomiaru szczegółowego</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -604,6 +604,8 @@
     <string name="menu_survey_start_new_dialog_title">Rozpocznij nowy pomiar</string>
     <string name="menu_survey_start_new_dialog_station_name">Nazwa stanowiska początkowego</string>
     <string name="menu_comment">Komentarz</string>
+    <string name="menu_comment_leg">Leg comment</string>
+    <string name="menu_comment_splay">Splay comment</string>
     <string name="menu_toggle_left_right">Przełącz lewo/prawo</string>
     <string name="menu_context_title_leg">Ciąg %1$s &#10132; %2$s</string>
     <string name="menu_context_title_splay">%s do pomiaru szczegółowego</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -604,6 +604,8 @@
     <string name="menu_start_new_survey">Iniciar Nova Topografia Aqui</string>
     <string name="menu_unlink_survey">Desligar Topografia Ligada</string>
     <string name="menu_comment">Comentário</string>
+    <string name="menu_comment_leg">Leg comment</string>
+    <string name="menu_comment_splay">Splay comment</string>
     <string name="menu_toggle_left_right">Alternar Esquerda/Direita</string>
     <string name="menu_context_title_leg">Trecho %1$s &#10132; %2$s</string>
     <string name="menu_context_title_splay">%s para Raio</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -606,6 +606,7 @@
     <string name="menu_comment">Comentário</string>
     <string name="menu_comment_leg">Leg comment</string>
     <string name="menu_comment_splay">Splay comment</string>
+    <string name="comment_indicator_description">Has comment</string>
     <string name="menu_toggle_left_right">Alternar Esquerda/Direita</string>
     <string name="menu_context_title_leg">Trecho %1$s &#10132; %2$s</string>
     <string name="menu_context_title_splay">%s para Raio</string>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -7,4 +7,7 @@
     <!-- FAB spacing -->
     <dimen name="fab_margin">16dp</dimen>
     <dimen name="fab_vertical_spacing">16dp</dimen>
+
+    <!-- Table comment indicator column: fixed width just large enough for one emoji at 14sp with 2dp padding -->
+    <dimen name="table_comment_col_width">28dp</dimen>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -639,6 +639,8 @@
     <string name="menu_survey_start_new_dialog_title">Start new survey</string>
     <string name="menu_survey_start_new_dialog_station_name">Starting station name</string>
     <string name="menu_comment">Comment</string>
+    <string name="menu_comment_leg">Leg comment</string>
+    <string name="menu_comment_splay">Splay comment</string>
     <string name="menu_toggle_left_right">Toggle Left/Right</string>
     <string name="menu_context_title_leg">Leg %1$s &#10132; %2$s</string>
     <string name="menu_context_title_splay">Splay %s &#10132;</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -641,6 +641,7 @@
     <string name="menu_comment">Comment</string>
     <string name="menu_comment_leg">Leg comment</string>
     <string name="menu_comment_splay">Splay comment</string>
+    <string name="comment_indicator_description">Has comment</string>
     <string name="menu_toggle_left_right">Toggle Left/Right</string>
     <string name="menu_context_title_leg">Leg %1$s &#10132; %2$s</string>
     <string name="menu_context_title_splay">Splay %s &#10132;</string>

--- a/app/src/test/java/org/hwyl/sexytopo/control/io/thirdparty/survex/SurvexImporterTest.java
+++ b/app/src/test/java/org/hwyl/sexytopo/control/io/thirdparty/survex/SurvexImporterTest.java
@@ -103,4 +103,66 @@ public class SurvexImporterTest {
         // passage comment first, then leg comment
         Assert.assertEquals("Tight rift :: The Squeeze", survey.getStationByName("2").getComment());
     }
+
+    // --- Version-gated leg comment routing ---
+
+    @Test
+    public void testLegCommentGoesToLegWhenVersionAfterCutoff() throws Exception {
+        // 1.11.3 → useLegComments = true → comment on the leg, not the station
+        Survey survey = new Survey();
+        SurvexTherionImporter.parseCentreline(
+                "1\t2\t5.0\t0.0\t0.0\tMy Chamber", survey, /* useLegComments= */ true);
+        Leg leg = survey.getOrigin().getConnectedOnwardLegs().get(0);
+        Assert.assertEquals("My Chamber", leg.getComment());
+        Assert.assertTrue(
+                survey.getStationByName("2").getComment() == null
+                        || survey.getStationByName("2").getComment().isEmpty());
+    }
+
+    @Test
+    public void testLegCommentGoesToStationWhenVersionAtCutoff() throws Exception {
+        // 1.11.2 → useLegComments = false → legacy station-comment path
+        Survey survey = new Survey();
+        SurvexTherionImporter.parseCentreline(
+                "1\t2\t5.0\t0.0\t0.0\tMy Chamber", survey, /* useLegComments= */ false);
+        Assert.assertEquals("My Chamber", survey.getStationByName("2").getComment());
+        Leg leg = survey.getOrigin().getConnectedOnwardLegs().get(0);
+        Assert.assertTrue(leg.getComment() == null || leg.getComment().isEmpty());
+    }
+
+    @Test
+    public void testLegCommentGoesToLegWhenNoVersionHeader() throws Exception {
+        // No SexyTopo header → useLegComments = true (same as new format)
+        Survey survey = new Survey();
+        SurvexTherionImporter.parseCentreline(
+                "1\t2\t5.0\t0.0\t0.0\tMy Chamber", survey, /* useLegComments= */ true);
+        Leg leg = survey.getOrigin().getConnectedOnwardLegs().get(0);
+        Assert.assertEquals("My Chamber", leg.getComment());
+    }
+
+    @Test
+    public void testPromotedLegPrecursorCommentImportedOnLeg() throws Exception {
+        // In new format, a trailing comment on a promoted-leg precursor line goes on the Leg
+        final String text =
+                "1\t2\t5.541\t253.93\t4.67\n" + "; 1\t2\t5.542\t73.95\t-4.64\tBack sight\n";
+        Survey survey = new Survey();
+        SurvexTherionImporter.parseCentreline(text, survey, /* useLegComments= */ true);
+        Leg mainLeg = survey.getOrigin().getConnectedOnwardLegs().get(0);
+        Assert.assertEquals(1, mainLeg.getPromotedFrom().length);
+        Assert.assertEquals("Back sight", mainLeg.getPromotedFrom()[0].getComment());
+    }
+
+    @Test
+    public void testPromotedLegPrecursorCommentIgnoredInLegacyMode() throws Exception {
+        // In legacy mode, the precursor comment is not captured
+        final String text =
+                "1\t2\t5.541\t253.93\t4.67\n" + "; 1\t2\t5.542\t73.95\t-4.64\tBack sight\n";
+        Survey survey = new Survey();
+        SurvexTherionImporter.parseCentreline(text, survey, /* useLegComments= */ false);
+        Leg mainLeg = survey.getOrigin().getConnectedOnwardLegs().get(0);
+        Assert.assertEquals(1, mainLeg.getPromotedFrom().length);
+        Assert.assertTrue(
+                mainLeg.getPromotedFrom()[0].getComment() == null
+                        || mainLeg.getPromotedFrom()[0].getComment().isEmpty());
+    }
 }

--- a/app/src/test/java/org/hwyl/sexytopo/control/io/thirdparty/survex/SurvexImporterTest.java
+++ b/app/src/test/java/org/hwyl/sexytopo/control/io/thirdparty/survex/SurvexImporterTest.java
@@ -36,4 +36,71 @@ public class SurvexImporterTest {
         Station created = survey.getStationByName("2");
         Assert.assertEquals("testComment", created.getComment());
     }
+
+    // --- Leg comment tests ---
+
+    @Test
+    public void testLegCommentWithSemicolonAppliedToToStation() throws Exception {
+        // Survex style: comment character present
+        Survey survey = new Survey();
+        SurvexTherionImporter.parseCentreline("1\t2\t5.0\t0.0\t0.0\t; My Chamber", survey);
+        Assert.assertEquals("My Chamber", survey.getStationByName("2").getComment());
+    }
+
+    @Test
+    public void testLegCommentWithHashAppliedToToStation() throws Exception {
+        // Therion style: hash comment character
+        Survey survey = new Survey();
+        SurvexTherionImporter.parseCentreline("1\t2\t5.0\t0.0\t0.0\t# My Chamber", survey);
+        Assert.assertEquals("My Chamber", survey.getStationByName("2").getComment());
+    }
+
+    @Test
+    public void testLegCommentWithoutCommentCharAppliedToToStation() throws Exception {
+        // Bare comment with no comment character — the bug case
+        Survey survey = new Survey();
+        SurvexTherionImporter.parseCentreline("1\t2\t5.0\t0.0\t0.0\tMy Chamber", survey);
+        Assert.assertEquals("My Chamber", survey.getStationByName("2").getComment());
+    }
+
+    @Test
+    public void testLegCommentMultiWordBareAppliedToToStation() throws Exception {
+        // Multi-word bare comment
+        Survey survey = new Survey();
+        SurvexTherionImporter.parseCentreline("1\t2\t3.34\t34.0\t-4.0\tBig Sandy Chamber", survey);
+        Assert.assertEquals("Big Sandy Chamber", survey.getStationByName("2").getComment());
+    }
+
+    @Test
+    public void testLegWithNoCommentLeavesStationCommentEmpty() throws Exception {
+        Survey survey = new Survey();
+        SurvexTherionImporter.parseCentreline("1\t2\t5.0\t0.0\t0.0", survey);
+        Station s = survey.getStationByName("2");
+        Assert.assertTrue(s.getComment() == null || s.getComment().isEmpty());
+    }
+
+    @Test
+    public void testLegCommentAppliedToFromStationOnBackwardLeg() throws Exception {
+        // Station 1 is established first; leg "2 1 ..." is backward so comment goes on station 2
+        Survey survey = new Survey();
+        SurvexTherionImporter.parseCentreline(
+                "1\t2\t5.0\t0.0\t0.0\n2\t1\t3.0\t90.0\t0.0\tThe Squeeze", survey);
+        // "2 1" is backward (1 already exists, 2 is new in from position)
+        // comment should go on station 2 (the newer station, in the from position here)
+        Assert.assertEquals("The Squeeze", survey.getStationByName("2").getComment());
+    }
+
+    @Test
+    public void testPassageAndLegCommentsAreConcatenated() throws Exception {
+        // Leg comment sets station comment, then passage comment is merged on top
+        Survey survey = new Survey();
+        SurvexTherionImporter.parseCentreline("1\t2\t5.0\t0.0\t0.0\tThe Squeeze", survey);
+
+        java.util.Map<String, String> passageComments = new java.util.HashMap<>();
+        passageComments.put("2", "Tight rift");
+        SurvexTherionImporter.mergePassageComments(survey, passageComments);
+
+        // passage comment first, then leg comment
+        Assert.assertEquals("Tight rift :: The Squeeze", survey.getStationByName("2").getComment());
+    }
 }

--- a/app/src/test/java/org/hwyl/sexytopo/control/io/thirdparty/survex/SurvexImporterTest.java
+++ b/app/src/test/java/org/hwyl/sexytopo/control/io/thirdparty/survex/SurvexImporterTest.java
@@ -80,17 +80,6 @@ public class SurvexImporterTest {
     }
 
     @Test
-    public void testLegCommentAppliedToFromStationOnBackwardLeg() throws Exception {
-        // Station 1 is established first; leg "2 1 ..." is backward so comment goes on station 2
-        Survey survey = new Survey();
-        SurvexTherionImporter.parseCentreline(
-                "1\t2\t5.0\t0.0\t0.0\n2\t1\t3.0\t90.0\t0.0\tThe Squeeze", survey);
-        // "2 1" is backward (1 already exists, 2 is new in from position)
-        // comment should go on station 2 (the newer station, in the from position here)
-        Assert.assertEquals("The Squeeze", survey.getStationByName("2").getComment());
-    }
-
-    @Test
     public void testPassageAndLegCommentsAreConcatenated() throws Exception {
         // Leg comment sets station comment, then passage comment is merged on top
         Survey survey = new Survey();

--- a/app/src/test/java/org/hwyl/sexytopo/control/io/thirdparty/survextherion/SexyTopoVersionTest.java
+++ b/app/src/test/java/org/hwyl/sexytopo/control/io/thirdparty/survextherion/SexyTopoVersionTest.java
@@ -1,0 +1,150 @@
+package org.hwyl.sexytopo.control.io.thirdparty.survextherion;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SexyTopoVersionTest {
+
+    // --- extractFromText ---
+
+    @Test
+    public void testVersionExtractedFromTherionHeader() {
+        String text = "# Created with SexyTopo 1.11.3 on 2025-03-01\nsurvey test\n";
+        SexyTopoVersion version = SexyTopoVersion.extractFromText(text);
+        Assert.assertNotNull(version);
+        Assert.assertEquals("1.11.3", version.toString());
+    }
+
+    @Test
+    public void testVersionExtractedFromSurvexHeader() {
+        String text = "; Created with SexyTopo 1.11.2 on 2024-06-01\n*begin test\n";
+        SexyTopoVersion version = SexyTopoVersion.extractFromText(text);
+        Assert.assertNotNull(version);
+        Assert.assertEquals("1.11.2", version.toString());
+    }
+
+    @Test
+    public void testVersionNotFoundReturnsNullForThirdPartyFile() {
+        String text = "; Exported by CaveSnail 3.0\n*begin test\n1 2 5.0 0.0 0.0\n";
+        SexyTopoVersion version = SexyTopoVersion.extractFromText(text);
+        Assert.assertNull(version);
+    }
+
+    @Test
+    public void testVersionNotFoundReturnsNullForEmptyFile() {
+        SexyTopoVersion version = SexyTopoVersion.extractFromText("");
+        Assert.assertNull(version);
+    }
+
+    @Test
+    public void testVersionExtractedFromMiddleOfFile() {
+        // Header is not necessarily on the very first line
+        String text = "survey test\n# Created with SexyTopo 2.0.1 on 2026-01-01\ncentreline\n";
+        SexyTopoVersion version = SexyTopoVersion.extractFromText(text);
+        Assert.assertNotNull(version);
+        Assert.assertEquals("2.0.1", version.toString());
+    }
+
+    // --- parse ---
+
+    @Test
+    public void testParseValidVersion() {
+        SexyTopoVersion v = SexyTopoVersion.parse("1.11.3");
+        Assert.assertNotNull(v);
+        Assert.assertEquals("1.11.3", v.toString());
+    }
+
+    @Test
+    public void testParseInvalidVersionReturnsNull() {
+        Assert.assertNull(SexyTopoVersion.parse("1.11"));
+        Assert.assertNull(SexyTopoVersion.parse("not-a-version"));
+        Assert.assertNull(SexyTopoVersion.parse("1.a.3"));
+    }
+
+    // --- isAfter ---
+
+    @Test
+    public void testVersionIsAfterOlderVersion() {
+        SexyTopoVersion newer = new SexyTopoVersion(1, 11, 3);
+        SexyTopoVersion older = new SexyTopoVersion(1, 11, 2);
+        Assert.assertTrue(newer.isAfter(older));
+    }
+
+    @Test
+    public void testVersionIsNotAfterSelf() {
+        SexyTopoVersion v = new SexyTopoVersion(1, 11, 2);
+        Assert.assertFalse(v.isAfter(v));
+    }
+
+    @Test
+    public void testVersionIsNotAfterNewerVersion() {
+        SexyTopoVersion older = new SexyTopoVersion(1, 11, 2);
+        SexyTopoVersion newer = new SexyTopoVersion(1, 11, 3);
+        Assert.assertFalse(older.isAfter(newer));
+    }
+
+    @Test
+    public void testMajorVersionComparison() {
+        SexyTopoVersion v2 = new SexyTopoVersion(2, 0, 0);
+        SexyTopoVersion v1 = new SexyTopoVersion(1, 11, 2);
+        Assert.assertTrue(v2.isAfter(v1));
+        Assert.assertFalse(v1.isAfter(v2));
+    }
+
+    @Test
+    public void testMinorVersionComparison() {
+        SexyTopoVersion v = new SexyTopoVersion(1, 12, 0);
+        SexyTopoVersion cutoff = new SexyTopoVersion(1, 11, 2);
+        Assert.assertTrue(v.isAfter(cutoff));
+    }
+
+    // --- cutoff constant behaviour ---
+
+    @Test
+    public void testCutoffVersion1_11_2IsNotAfterItself() {
+        Assert.assertFalse(
+                SexyTopoVersion.LEG_COMMENTS_VERSION_CUTOFF.isAfter(
+                        SexyTopoVersion.LEG_COMMENTS_VERSION_CUTOFF));
+    }
+
+    @Test
+    public void testVersion1_11_3IsAfterCutoff() {
+        SexyTopoVersion v = new SexyTopoVersion(1, 11, 3);
+        Assert.assertTrue(v.isAfter(SexyTopoVersion.LEG_COMMENTS_VERSION_CUTOFF));
+    }
+
+    // --- useLegComments logic ---
+
+    @Test
+    public void testUseLegCommentsIsTrueWhenVersionIsNull() {
+        // No SexyTopo header → treat as new format
+        SexyTopoVersion version = null;
+        boolean useLegComments =
+                version == null || version.isAfter(SexyTopoVersion.LEG_COMMENTS_VERSION_CUTOFF);
+        Assert.assertTrue(useLegComments);
+    }
+
+    @Test
+    public void testUseLegCommentsIsTrueWhenVersionIsAfterCutoff() {
+        SexyTopoVersion version = new SexyTopoVersion(1, 11, 3);
+        boolean useLegComments =
+                version == null || version.isAfter(SexyTopoVersion.LEG_COMMENTS_VERSION_CUTOFF);
+        Assert.assertTrue(useLegComments);
+    }
+
+    @Test
+    public void testUseLegCommentsIsFalseWhenVersionIsAtCutoff() {
+        SexyTopoVersion version = new SexyTopoVersion(1, 11, 2);
+        boolean useLegComments =
+                version == null || version.isAfter(SexyTopoVersion.LEG_COMMENTS_VERSION_CUTOFF);
+        Assert.assertFalse(useLegComments);
+    }
+
+    @Test
+    public void testUseLegCommentsIsFalseWhenVersionIsBeforeCutoff() {
+        SexyTopoVersion version = new SexyTopoVersion(1, 10, 9);
+        boolean useLegComments =
+                version == null || version.isAfter(SexyTopoVersion.LEG_COMMENTS_VERSION_CUTOFF);
+        Assert.assertFalse(useLegComments);
+    }
+}

--- a/app/src/test/java/org/hwyl/sexytopo/control/io/thirdparty/therion/TherionImporterTest.java
+++ b/app/src/test/java/org/hwyl/sexytopo/control/io/thirdparty/therion/TherionImporterTest.java
@@ -649,4 +649,52 @@ public class TherionImporterTest {
         Direction stationFiveDirection = stationFive.getExtendedElevationDirection();
         Assert.assertEquals(Direction.RIGHT, stationFiveDirection);
     }
+
+    // --- Leg comment tests (Therion format) ---
+
+    @Test
+    public void testTherionLegCommentWithHashAppliedToToStation() throws Exception {
+        // Therion data normal: hash comment character
+        Survey survey = new Survey();
+        SurvexTherionImporter.parseCentreline("1\t2\t5.0\t45.0\t-5.0\t# Grand Gallery", survey);
+        Assert.assertEquals("Grand Gallery", survey.getStationByName("2").getComment());
+    }
+
+    @Test
+    public void testTherionLegCommentWithoutCommentCharAppliedToToStation() throws Exception {
+        // Bare comment with no comment character — the bug case
+        Survey survey = new Survey();
+        SurvexTherionImporter.parseCentreline("1\t2\t3.34\t34.0\t-4.0\tsome comment here", survey);
+        Assert.assertEquals("some comment here", survey.getStationByName("2").getComment());
+    }
+
+    @Test
+    public void testTherionLegCommentWithSemicolonAppliedToToStation() throws Exception {
+        // Survex-style semicolon also valid in shared parser
+        Survey survey = new Survey();
+        SurvexTherionImporter.parseCentreline("1\t2\t5.0\t45.0\t-5.0\t; Boulder Choke", survey);
+        Assert.assertEquals("Boulder Choke", survey.getStationByName("2").getComment());
+    }
+
+    @Test
+    public void testTherionLegWithNoCommentLeavesStationCommentEmpty() throws Exception {
+        Survey survey = new Survey();
+        SurvexTherionImporter.parseCentreline("1\t2\t5.0\t45.0\t-5.0", survey);
+        Station s = survey.getStationByName("2");
+        Assert.assertTrue(s.getComment() == null || s.getComment().isEmpty());
+    }
+
+    @Test
+    public void testTherionPassageAndLegCommentsAreConcatenated() throws Exception {
+        // Leg comment is set first via parseCentreline, then passage comment is merged
+        Survey survey = new Survey();
+        SurvexTherionImporter.parseCentreline("1\t2\t5.0\t45.0\t-5.0\tChamber", survey);
+
+        java.util.Map<String, String> passageComments = new java.util.HashMap<>();
+        passageComments.put("2", "Large Hall");
+        SurvexTherionImporter.mergePassageComments(survey, passageComments);
+
+        // passage comment first, then leg comment
+        Assert.assertEquals("Large Hall :: Chamber", survey.getStationByName("2").getComment());
+    }
 }

--- a/app/src/test/java/org/hwyl/sexytopo/control/io/thirdparty/therion/TherionImporterTest.java
+++ b/app/src/test/java/org/hwyl/sexytopo/control/io/thirdparty/therion/TherionImporterTest.java
@@ -697,4 +697,63 @@ public class TherionImporterTest {
         // passage comment first, then leg comment
         Assert.assertEquals("Large Hall :: Chamber", survey.getStationByName("2").getComment());
     }
+
+    // --- Version-gated leg comment routing (Therion path) ---
+
+    @Test
+    public void testTherionLegCommentGoesToLegWhenVersionAfterCutoff() throws Exception {
+        Survey survey = new Survey();
+        SurvexTherionImporter.parseCentreline(
+                "1\t2\t5.0\t45.0\t-5.0\tGrand Gallery", survey, /* useLegComments= */ true);
+        Leg leg = survey.getOrigin().getConnectedOnwardLegs().get(0);
+        Assert.assertEquals("Grand Gallery", leg.getComment());
+        Assert.assertTrue(
+                survey.getStationByName("2").getComment() == null
+                        || survey.getStationByName("2").getComment().isEmpty());
+    }
+
+    @Test
+    public void testTherionLegCommentGoesToStationWhenVersionAtCutoff() throws Exception {
+        Survey survey = new Survey();
+        SurvexTherionImporter.parseCentreline(
+                "1\t2\t5.0\t45.0\t-5.0\tGrand Gallery", survey, /* useLegComments= */ false);
+        Assert.assertEquals("Grand Gallery", survey.getStationByName("2").getComment());
+        Leg leg = survey.getOrigin().getConnectedOnwardLegs().get(0);
+        Assert.assertTrue(leg.getComment() == null || leg.getComment().isEmpty());
+    }
+
+    @Test
+    public void testTherionLegCommentGoesToLegWhenNoVersionHeader() throws Exception {
+        // No SexyTopo header → useLegComments = true
+        Survey survey = new Survey();
+        SurvexTherionImporter.parseCentreline(
+                "1\t2\t5.0\t45.0\t-5.0\tGrand Gallery", survey, /* useLegComments= */ true);
+        Leg leg = survey.getOrigin().getConnectedOnwardLegs().get(0);
+        Assert.assertEquals("Grand Gallery", leg.getComment());
+    }
+
+    @Test
+    public void testTherionPromotedLegPrecursorCommentImportedOnLeg() throws Exception {
+        // Therion uses # as comment character on precursor lines
+        final String text =
+                "1\t2\t5.541\t253.93\t4.67\n" + "# 1\t2\t5.542\t73.95\t-4.64\tBack sight\n";
+        Survey survey = new Survey();
+        SurvexTherionImporter.parseCentreline(text, survey, /* useLegComments= */ true);
+        Leg mainLeg = survey.getOrigin().getConnectedOnwardLegs().get(0);
+        Assert.assertEquals(1, mainLeg.getPromotedFrom().length);
+        Assert.assertEquals("Back sight", mainLeg.getPromotedFrom()[0].getComment());
+    }
+
+    @Test
+    public void testTherionPromotedLegPrecursorCommentIgnoredInLegacyMode() throws Exception {
+        final String text =
+                "1\t2\t5.541\t253.93\t4.67\n" + "# 1\t2\t5.542\t73.95\t-4.64\tBack sight\n";
+        Survey survey = new Survey();
+        SurvexTherionImporter.parseCentreline(text, survey, /* useLegComments= */ false);
+        Leg mainLeg = survey.getOrigin().getConnectedOnwardLegs().get(0);
+        Assert.assertEquals(1, mainLeg.getPromotedFrom().length);
+        Assert.assertTrue(
+                mainLeg.getPromotedFrom()[0].getComment() == null
+                        || mainLeg.getPromotedFrom()[0].getComment().isEmpty());
+    }
 }


### PR DESCRIPTION
While working on the crossing out of splays, having the ability to comment would be useful. This is also a useful feature when surveying. Two main example when I use the ability to comment on a leg or a splay.

When using a splay to indicate an important feature of the cave, when the drawing is not enough. Thinks like indicate how a  bone is labelled or marked.

Surveying in none ideal conditions, like scaffolding, things like this leg gong past metal. Then I can downgrade it for the loop closure.

I have not indicated the presence of a comment in the sketches as I cannot think of a method that would work without becoming too crowded. I also have not done a good job of the table layout of the new column. I cannot work out the detail of how the table works, sorry @richsmith 

This also fixes an import bug that was discovered, comments on legs and splays had to also have a comment character on them, which many do not.

closes #45