### PR TITLE
Add Copyright and License field to Trip

### DIFF
--- a/app/src/androidTest/java/org/hwyl/sexytopo/control/activity/TripActivityTest.java
+++ b/app/src/androidTest/java/org/hwyl/sexytopo/control/activity/TripActivityTest.java
@@ -1,13 +1,16 @@
 package org.hwyl.sexytopo.control.activity;
 
+import static androidx.test.espresso.Espresso.onData;
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.RootMatchers.isPlatformPopup;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
+import static org.hamcrest.Matchers.is;
 
 import androidx.test.ext.junit.rules.ActivityScenarioRule;
 import androidx.test.filters.LargeTest;
@@ -38,5 +41,22 @@ public class TripActivityTest {
         onView(withText(R.string.action_view)).perform(click());
         onView(withText(R.string.action_trip)).perform(click());
         onView(withId(R.id.rootLayout)).check(matches(isDisplayed()));
+    }
+
+    @Test
+    public void licenseFieldShowsFullSuggestionListEvenWhenPrefilled() {
+        openActionBarOverflowOrOptionsMenu(getInstrumentation().getTargetContext());
+        onView(withText(R.string.action_view)).perform(click());
+        onView(withText(R.string.action_trip)).perform(click());
+
+        // The License field is pre-filled with the default license (GPLv3.0+) when
+        // screen opens. Tapping it should still offer every configured license, not just the
+        // one matching entry - confirming the field doesn't fall back to stock ArrayAdapter
+        // filtering behaviour.
+        onView(withId(R.id.trip_license)).perform(click());
+
+        onData(is("All rights reserved")).inRoot(isPlatformPopup()).check(matches(isDisplayed()));
+        onData(is("CC0")).inRoot(isPlatformPopup()).check(matches(isDisplayed()));
+        onData(is("GPLv3.0+")).inRoot(isPlatformPopup()).check(matches(isDisplayed()));
     }
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -103,6 +103,10 @@
             android:label="@string/action_trip">
         </activity>
         <activity
+            android:name=".control.activity.LicenseChoiceActivity"
+            android:label="@string/license_choice_title">
+        </activity>
+        <activity
             android:name=".control.activity.ThreeDViewActivity"
             android:label="@string/title_activity_3d" >
         </activity>

--- a/app/src/main/java/org/hwyl/sexytopo/control/activity/LicenseChoiceActivity.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/activity/LicenseChoiceActivity.java
@@ -1,0 +1,73 @@
+package org.hwyl.sexytopo.control.activity;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.widget.ArrayAdapter;
+import android.widget.Button;
+import android.widget.Spinner;
+import java.util.ArrayList;
+import java.util.List;
+import org.hwyl.sexytopo.R;
+import org.hwyl.sexytopo.control.util.GeneralPreferences;
+import org.hwyl.sexytopo.model.survey.LicenseOption;
+
+/**
+ * One-time, first-run screen that asks the user to choose a default license, rather than one being
+ * silently applied on their behalf. Shown from TripActivity the first time a new trip would
+ * otherwise be seeded with a default license - see {@link
+ * GeneralPreferences#isLicenseDefaultConfirmed()}. Returns the confirmed default license name via
+ * {@link #RESULT_LICENSE_NAME_EXTRA} in the result Intent.
+ */
+public class LicenseChoiceActivity extends SexyTopoActivity {
+
+    public static final String RESULT_LICENSE_NAME_EXTRA = "licenseName";
+
+    private static final String PRESELECTED_LICENSE_NAME = "GPLv3.0+";
+
+    private Spinner licenseSpinner;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_license_choice);
+        setupMaterialToolbar();
+        applyEdgeToEdgeInsets(R.id.rootLayout, true, true);
+
+        List<String> names = new ArrayList<>();
+        for (LicenseOption option : GeneralPreferences.getLicenseOptions()) {
+            names.add(option.getName());
+        }
+
+        licenseSpinner = findViewById(R.id.license_choice_spinner);
+        ArrayAdapter<String> adapter =
+                new ArrayAdapter<>(this, android.R.layout.simple_spinner_dropdown_item, names);
+        licenseSpinner.setAdapter(adapter);
+
+        int preselectedIndex = names.indexOf(PRESELECTED_LICENSE_NAME);
+        licenseSpinner.setSelection(Math.max(preselectedIndex, 0));
+
+        Button confirmButton = findViewById(R.id.license_choice_confirm_button);
+        confirmButton.setOnClickListener(v -> confirmAndFinish());
+    }
+
+    @Override
+    public void onBackPressed() {
+        // A default license must be chosen before leaving this screen - treat the hardware
+        // back button as accepting whatever is currently selected, rather than letting the
+        // user leave without a choice being recorded.
+        confirmAndFinish();
+    }
+
+    private void confirmAndFinish() {
+        String selected = (String) licenseSpinner.getSelectedItem();
+        if (selected != null) {
+            GeneralPreferences.setDefaultLicenseOption(selected);
+        }
+        GeneralPreferences.setLicenseDefaultConfirmed(true);
+
+        Intent result = new Intent();
+        result.putExtra(RESULT_LICENSE_NAME_EXTRA, GeneralPreferences.getDefaultLicenseName());
+        setResult(RESULT_OK, result);
+        finish();
+    }
+}

--- a/app/src/main/java/org/hwyl/sexytopo/control/activity/SettingsActivity.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/activity/SettingsActivity.java
@@ -2,10 +2,14 @@ package org.hwyl.sexytopo.control.activity;
 
 import android.content.SharedPreferences;
 import android.os.Bundle;
+import android.text.Editable;
 import android.view.LayoutInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.Button;
+import android.widget.CheckBox;
+import android.widget.CompoundButton;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 import androidx.annotation.NonNull;
@@ -20,6 +24,7 @@ import com.google.android.material.textfield.TextInputEditText;
 import com.google.android.material.textfield.TextInputLayout;
 import org.hwyl.sexytopo.R;
 import org.hwyl.sexytopo.control.util.GeneralPreferences;
+import org.hwyl.sexytopo.model.survey.LicenseOption;
 
 public class SettingsActivity extends SexyTopoActivity
         implements PreferenceFragmentCompat.OnPreferenceStartFragmentCallback {
@@ -244,6 +249,126 @@ public class SettingsActivity extends SexyTopoActivity
                                 dialog.dismiss();
                                 refreshList(root);
                             });
+        }
+    }
+
+    public static class CopyrightFragment extends Fragment {
+        @Nullable
+        @Override
+        public View onCreateView(
+                @NonNull LayoutInflater inflater,
+                @Nullable ViewGroup container,
+                @Nullable Bundle savedInstanceState) {
+            return inflater.inflate(R.layout.fragment_settings_copyright, container, false);
+        }
+
+        @Override
+        public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+            super.onViewCreated(view, savedInstanceState);
+            refreshList(view);
+
+            view.findViewById(R.id.add_license_button)
+                    .setOnClickListener(
+                            v -> {
+                                TextInputEditText field = view.findViewById(R.id.new_license_field);
+                                TextInputLayout layout = view.findViewById(R.id.new_license_layout);
+                                String name = getTrimmedText(field);
+                                if (name.isEmpty()) {
+                                    layout.setError(
+                                            getString(R.string.settings_license_name_required));
+                                    return;
+                                }
+                                layout.setError(null);
+                                GeneralPreferences.addLicenseOption(name);
+                                field.setText("");
+                                refreshList(view);
+                            });
+        }
+
+        private void refreshList(View root) {
+            LinearLayout list = root.findViewById(R.id.licenses_list);
+            list.removeAllViews();
+            LayoutInflater inflater = LayoutInflater.from(requireContext());
+            for (LicenseOption option : GeneralPreferences.getLicenseOptions()) {
+                String name = option.getName();
+                View row = inflater.inflate(R.layout.license_option_item, list, false);
+
+                ((TextView) row.findViewById(R.id.license_name_field)).setText(name);
+                row.setOnClickListener(v -> showEditDialog(root, name));
+
+                CheckBox defaultCheckbox = row.findViewById(R.id.license_default_checkbox);
+                defaultCheckbox.setChecked(option.isDefault());
+                CompoundButton.OnCheckedChangeListener defaultListener =
+                        new CompoundButton.OnCheckedChangeListener() {
+                            @Override
+                            public void onCheckedChanged(
+                                    @NonNull CompoundButton buttonView, boolean isChecked) {
+                                if (isChecked) {
+                                    GeneralPreferences.setDefaultLicenseOption(name);
+                                    refreshList(root);
+                                } else {
+                                    // A default must always be selected; re-check this box
+                                    // rather than allowing the list to end up with no default
+                                    // at all. Detach first so this doesn't re-trigger itself.
+                                    defaultCheckbox.setOnCheckedChangeListener(null);
+                                    defaultCheckbox.setChecked(true);
+                                    defaultCheckbox.setOnCheckedChangeListener(this);
+                                }
+                            }
+                        };
+                defaultCheckbox.setOnCheckedChangeListener(defaultListener);
+
+                Button deleteButton = row.findViewById(R.id.delete_license_button);
+                deleteButton.setOnClickListener(
+                        v -> {
+                            GeneralPreferences.removeLicenseOption(name);
+                            refreshList(root);
+                        });
+
+                list.addView(row);
+            }
+        }
+
+        private void showEditDialog(View root, String currentName) {
+            View dialogView =
+                    LayoutInflater.from(requireContext())
+                            .inflate(R.layout.dialog_edit_license_name, null);
+            TextInputLayout layout = dialogView.findViewById(R.id.license_name_input_layout);
+            TextInputEditText field = dialogView.findViewById(R.id.license_name_field);
+            field.setText(currentName);
+            field.selectAll();
+
+            AlertDialog dialog =
+                    new MaterialAlertDialogBuilder(requireContext())
+                            .setTitle(R.string.edit)
+                            .setView(dialogView)
+                            .setPositiveButton(R.string.save, null)
+                            .setNegativeButton(R.string.cancel, null)
+                            .show();
+
+            dialog.getButton(AlertDialog.BUTTON_POSITIVE)
+                    .setOnClickListener(
+                            v -> {
+                                String newName = getTrimmedText(field);
+                                if (newName.isEmpty()) {
+                                    layout.setError(
+                                            getString(R.string.settings_license_name_required));
+                                    return;
+                                }
+                                GeneralPreferences.renameLicenseOption(currentName, newName);
+                                dialog.dismiss();
+                                refreshList(root);
+                            });
+        }
+
+        /**
+         * Returns the field's text, trimmed, or "" if the field has no text at all. {@link
+         * TextInputEditText#getText()} is nullable, even though in practice it won't be null for an
+         * already-inflated field; this keeps the null-check in one place.
+         */
+        private static String getTrimmedText(TextInputEditText field) {
+            Editable text = field.getText();
+            return text == null ? "" : text.toString().trim();
         }
     }
 

--- a/app/src/main/java/org/hwyl/sexytopo/control/activity/TripActivity.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/activity/TripActivity.java
@@ -1,6 +1,7 @@
 package org.hwyl.sexytopo.control.activity;
 
 import android.annotation.SuppressLint;
+import android.content.Context;
 import android.os.Bundle;
 import android.text.Editable;
 import android.text.TextWatcher;
@@ -11,8 +12,10 @@ import android.widget.AutoCompleteTextView;
 import android.widget.Button;
 import android.widget.CheckBox;
 import android.widget.EditText;
+import android.widget.Filter;
 import android.widget.LinearLayout;
 import android.widget.TextView;
+import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
 import androidx.fragment.app.FragmentManager;
 import com.google.android.material.datepicker.MaterialDatePicker;
@@ -29,6 +32,7 @@ import org.hwyl.sexytopo.comms.Instrument;
 import org.hwyl.sexytopo.control.table.TeamMemberForm;
 import org.hwyl.sexytopo.control.util.GeneralPreferences;
 import org.hwyl.sexytopo.control.util.TextTools;
+import org.hwyl.sexytopo.model.survey.LicenseOption;
 import org.hwyl.sexytopo.model.survey.Trip;
 
 public class TripActivity extends SexyTopoActivity {
@@ -83,6 +87,40 @@ public class TripActivity extends SexyTopoActivity {
                     @Override
                     public void onTextChanged(CharSequence s, int start, int before, int count) {}
                 });
+
+        EditText copyrightField = findViewById(R.id.trip_copyright);
+        copyrightField.addTextChangedListener(
+                new TextWatcher() {
+                    @Override
+                    public void afterTextChanged(Editable s) {
+                        syncTrip();
+                        updateButtonStatus();
+                    }
+
+                    @Override
+                    public void beforeTextChanged(
+                            CharSequence s, int start, int count, int after) {}
+
+                    @Override
+                    public void onTextChanged(CharSequence s, int start, int before, int count) {}
+                });
+
+        AutoCompleteTextView licenseField = findViewById(R.id.trip_license);
+        licenseField.addTextChangedListener(
+                new TextWatcher() {
+                    @Override
+                    public void afterTextChanged(Editable s) {
+                        syncTrip();
+                        updateButtonStatus();
+                    }
+
+                    @Override
+                    public void beforeTextChanged(
+                            CharSequence s, int start, int count, int after) {}
+
+                    @Override
+                    public void onTextChanged(CharSequence s, int start, int before, int count) {}
+                });
     }
 
     @Override
@@ -107,6 +145,17 @@ public class TripActivity extends SexyTopoActivity {
             Instrument connected = getInstrument();
             String name = connected.getName();
             instrumentField.setText(name);
+        }
+
+        EditText copyrightField = findViewById(R.id.trip_copyright);
+        copyrightField.setText(trip.getCopyright());
+
+        setupLicenseAutocomplete();
+        AutoCompleteTextView licenseField = findViewById(R.id.trip_license);
+        if (trip.hasLicense()) {
+            licenseField.setText(trip.getLicense());
+        } else {
+            licenseField.setText(GeneralPreferences.getDefaultLicenseName());
         }
 
         TextInputLayout surveyDateLayout = findViewById(R.id.survey_date_layout);
@@ -217,6 +266,10 @@ public class TripActivity extends SexyTopoActivity {
                         (dialog, whichButton) -> {
                             EditText comments = findViewById(R.id.trip_comments);
                             comments.setText("");
+                            EditText copyright = findViewById(R.id.trip_copyright);
+                            copyright.setText("");
+                            AutoCompleteTextView license = findViewById(R.id.trip_license);
+                            license.setText(GeneralPreferences.getDefaultLicenseName());
                             team.clear();
                             Trip trip = getSurvey().getTrip();
                             if (trip != null) {
@@ -229,6 +282,78 @@ public class TripActivity extends SexyTopoActivity {
                         })
                 .setNegativeButton(R.string.cancel, null)
                 .show();
+    }
+
+    private void setupLicenseAutocomplete() {
+        AutoCompleteTextView licenseField = findViewById(R.id.trip_license);
+        List<String> licenseNames = new ArrayList<>();
+        for (LicenseOption option : GeneralPreferences.getLicenseOptions()) {
+            licenseNames.add(option.getName());
+        }
+
+        // The stock ArrayAdapter filters its suggestions against the text that is already in the
+        // field. Since this field is pre-filled with the default license, that would narrow the
+        // dropdown down to only the matching entry. A non-filtering
+        // adapter keeps the full configured list showing regardless of the current text, while
+        // the field itself stays editable, free text works.
+        ArrayAdapter<String> adapter =
+                new NonFilteringArrayAdapter(
+                        this, android.R.layout.simple_dropdown_item_1line, licenseNames);
+        licenseField.setAdapter(adapter);
+        licenseField.setThreshold(0);
+
+        View.OnClickListener showFullDropdown =
+                v -> {
+                    if (!licenseNames.isEmpty()) {
+                        licenseField.showDropDown();
+                    }
+                };
+        // Tapping the field re-opens the list even if it's already focused (e.g. after the
+        // dropdown was previously dismissed), and gaining focus opens it the first time.
+        licenseField.setOnClickListener(showFullDropdown);
+        licenseField.setOnFocusChangeListener(
+                (v, hasFocus) -> {
+                    if (hasFocus && !licenseNames.isEmpty()) {
+                        licenseField.showDropDown();
+                    }
+                });
+    }
+
+    /**
+     * An ArrayAdapter whose suggestion list is not narrowed by the current text of the field it's
+     * attached to. Used for the License field so the full configured list is always offered, even
+     * though the field is pre-filled with a default value.
+     */
+    private static class NonFilteringArrayAdapter extends ArrayAdapter<String> {
+
+        private final List<String> items;
+
+        private final Filter noOpFilter =
+                new Filter() {
+                    @Override
+                    protected FilterResults performFiltering(CharSequence constraint) {
+                        FilterResults results = new FilterResults();
+                        results.values = items;
+                        results.count = items.size();
+                        return results;
+                    }
+
+                    @Override
+                    protected void publishResults(CharSequence constraint, FilterResults results) {
+                        // Deliberately do nothing: the backing data set (and therefore the
+                        // dropdown contents) never changes in response to typed text.
+                    }
+                };
+
+        NonFilteringArrayAdapter(Context context, int resource, List<String> items) {
+            super(context, resource, items);
+            this.items = items;
+        }
+
+        @Override
+        public @NonNull Filter getFilter() {
+            return noOpFilter;
+        }
     }
 
     private void setupNameAutocomplete(View dialogView) {
@@ -340,6 +465,12 @@ public class TripActivity extends SexyTopoActivity {
         EditText instrumentField = findViewById(R.id.instrument_field);
         trip.setInstrument(instrumentField.getText().toString());
 
+        EditText copyrightField = findViewById(R.id.trip_copyright);
+        trip.setCopyright(copyrightField.getText().toString());
+
+        AutoCompleteTextView licenseField = findViewById(R.id.trip_license);
+        trip.setLicense(licenseField.getText().toString());
+
         getSurvey().setTrip(trip);
     }
 
@@ -352,11 +483,18 @@ public class TripActivity extends SexyTopoActivity {
         EditText instrumentField = findViewById(R.id.instrument_field);
         boolean hasInstrument = !instrumentField.getText().toString().trim().isEmpty();
 
+        EditText copyrightField = findViewById(R.id.trip_copyright);
+        boolean hasCopyright = !copyrightField.getText().toString().trim().isEmpty();
+
         Trip currentTrip = getSurvey().getTrip();
         boolean hasUnlinkedExploDate =
                 currentTrip != null && !currentTrip.isExplorationDateLinked();
 
-        boolean hasAnyData = hasTeam || hasComments || hasInstrument || hasUnlinkedExploDate;
+        // License is deliberately not checked here, like surveyDate - it is always
+        // pre-filled with a default value, so including it would make the buttons permanently
+        // enabled even on an otherwise blank trip.
+        boolean hasAnyData =
+                hasTeam || hasComments || hasInstrument || hasCopyright || hasUnlinkedExploDate;
         boolean hasChanges = savedTrip == null || !savedTrip.equals(currentTrip);
 
         findViewById(R.id.set_trip).setEnabled(hasAnyData && hasChanges);

--- a/app/src/main/java/org/hwyl/sexytopo/control/activity/TripActivity.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/activity/TripActivity.java
@@ -47,6 +47,13 @@ public class TripActivity extends SexyTopoActivity {
     private List<Trip.TeamEntry> team = new ArrayList<>();
     private Trip savedTrip;
 
+    // Suppresses syncTrip() calls triggered by TextWatchers firing as a side effect of the
+    // setText(...) calls in onResume()'s field population - without this, populating an
+    // earlier field (e.g. comments) fires its watcher, which calls syncTrip(), which reads
+    // every field's *current* text including ones not yet populated this cycle, clobbering
+    // them with stale values before they ever get set.
+    private boolean isPopulatingFields = false;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -66,6 +73,9 @@ public class TripActivity extends SexyTopoActivity {
 
                     @Override
                     public void onTextChanged(CharSequence s, int start, int before, int count) {
+                        if (isPopulatingFields) {
+                            return;
+                        }
                         updateButtonStatus();
                         syncTrip();
                     }
@@ -76,6 +86,9 @@ public class TripActivity extends SexyTopoActivity {
                 new TextWatcher() {
                     @Override
                     public void afterTextChanged(Editable s) {
+                        if (isPopulatingFields) {
+                            return;
+                        }
                         syncTrip();
                         updateButtonStatus();
                     }
@@ -93,6 +106,9 @@ public class TripActivity extends SexyTopoActivity {
                 new TextWatcher() {
                     @Override
                     public void afterTextChanged(Editable s) {
+                        if (isPopulatingFields) {
+                            return;
+                        }
                         syncTrip();
                         updateButtonStatus();
                     }
@@ -110,6 +126,9 @@ public class TripActivity extends SexyTopoActivity {
                 new TextWatcher() {
                     @Override
                     public void afterTextChanged(Editable s) {
+                        if (isPopulatingFields) {
+                            return;
+                        }
                         syncTrip();
                         updateButtonStatus();
                     }
@@ -130,32 +149,44 @@ public class TripActivity extends SexyTopoActivity {
         if (trip == null) {
             trip = new Trip();
             getSurvey().setTrip(trip);
+
+            // Seed a brand new trip with the configured default license, so what's shown on
+            // screen is also what actually gets persisted/exported, rather than just a display
+            // hint. This only runs once, for a genuinely new trip - it must not re-apply on
+            // every visit to an existing trip, since a blank license there could mean "the user
+            // deliberately wants no license" (or the trip was imported with none), not "never
+            // decided".
+            trip.setLicense(GeneralPreferences.getDefaultLicenseName());
         }
 
         savedTrip = new Trip(trip);
         team = new ArrayList<>(trip.getTeam());
 
-        TextView commentsField = findViewById(R.id.trip_comments);
-        commentsField.setText(trip.getComments());
+        isPopulatingFields = true;
+        try {
+            TextView commentsField = findViewById(R.id.trip_comments);
+            commentsField.setText(trip.getComments());
 
-        EditText instrumentField = findViewById(R.id.instrument_field);
-        if (trip.hasInstrument()) {
-            instrumentField.setText(trip.getInstrument());
-        } else if (hasInstrument()) {
-            Instrument connected = getInstrument();
-            String name = connected.getName();
-            instrumentField.setText(name);
-        }
+            EditText instrumentField = findViewById(R.id.instrument_field);
+            if (trip.hasInstrument()) {
+                instrumentField.setText(trip.getInstrument());
+            } else if (hasInstrument()) {
+                try {
+                    Instrument connected = getInstrument();
+                    String name = connected.getName();
+                    instrumentField.setText(name);
+                } catch (SecurityException ignored) {
+                }
+            }
 
-        EditText copyrightField = findViewById(R.id.trip_copyright);
-        copyrightField.setText(trip.getCopyright());
+            EditText copyrightField = findViewById(R.id.trip_copyright);
+            copyrightField.setText(trip.getCopyright());
 
-        setupLicenseAutocomplete();
-        AutoCompleteTextView licenseField = findViewById(R.id.trip_license);
-        if (trip.hasLicense()) {
+            setupLicenseAutocomplete();
+            AutoCompleteTextView licenseField = findViewById(R.id.trip_license);
             licenseField.setText(trip.getLicense());
-        } else {
-            licenseField.setText(GeneralPreferences.getDefaultLicenseName());
+        } finally {
+            isPopulatingFields = false;
         }
 
         TextInputLayout surveyDateLayout = findViewById(R.id.survey_date_layout);
@@ -490,9 +521,9 @@ public class TripActivity extends SexyTopoActivity {
         boolean hasUnlinkedExploDate =
                 currentTrip != null && !currentTrip.isExplorationDateLinked();
 
-        // License is deliberately not checked here, like surveyDate - it is always
-        // pre-filled with a default value, so including it would make the buttons permanently
-        // enabled even on an otherwise blank trip.
+        // License is deliberately not checked here, like surveyDate - a new trip is seeded
+        // with a default license (see onResume), so including it would make the buttons
+        // permanently enabled even on an otherwise blank new trip.
         boolean hasAnyData =
                 hasTeam || hasComments || hasInstrument || hasCopyright || hasUnlinkedExploDate;
         boolean hasChanges = savedTrip == null || !savedTrip.equals(currentTrip);

--- a/app/src/main/java/org/hwyl/sexytopo/control/activity/TripActivity.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/activity/TripActivity.java
@@ -2,6 +2,7 @@ package org.hwyl.sexytopo.control.activity;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
+import android.content.Intent;
 import android.os.Bundle;
 import android.text.Editable;
 import android.text.TextWatcher;
@@ -15,6 +16,8 @@ import android.widget.EditText;
 import android.widget.Filter;
 import android.widget.LinearLayout;
 import android.widget.TextView;
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
 import androidx.fragment.app.FragmentManager;
@@ -53,6 +56,36 @@ public class TripActivity extends SexyTopoActivity {
     // every field's *current* text including ones not yet populated this cycle, clobbering
     // them with stale values before they ever get set.
     private boolean isPopulatingFields = false;
+
+    // Launches the one-time first-run license choice screen (see GeneralPreferences.
+    // isLicenseDefaultConfirmed) when a brand new trip needs a default license but nobody has
+    // chosen one yet. Once the user confirms a choice there, it's applied to the license field
+    // here rather than in onResume()'s normal population pass, since that pass has already run
+    // by the time this callback fires.
+    private final ActivityResultLauncher<Intent> licenseChoiceLauncher =
+            registerForActivityResult(
+                    new ActivityResultContracts.StartActivityForResult(),
+                    result -> {
+                        Trip trip = getSurvey().getTrip();
+                        if (trip == null) {
+                            return;
+                        }
+
+                        String chosenLicense = GeneralPreferences.getDefaultLicenseName();
+                        trip.setLicense(chosenLicense);
+                        if (savedTrip != null) {
+                            savedTrip.setLicense(chosenLicense);
+                        }
+
+                        AutoCompleteTextView licenseField = findViewById(R.id.trip_license);
+                        isPopulatingFields = true;
+                        try {
+                            licenseField.setText(trip.getLicense());
+                        } finally {
+                            isPopulatingFields = false;
+                        }
+                        updateButtonStatus();
+                    });
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -152,11 +185,27 @@ public class TripActivity extends SexyTopoActivity {
 
             // Seed a brand new trip with the configured default license, so what's shown on
             // screen is also what actually gets persisted/exported, rather than just a display
-            // hint. This only runs once, for a genuinely new trip - it must not re-apply on
+            // hint. This only ever runs once, for a genuinely new trip - it must not re-apply on
             // every visit to an existing trip, since a blank license there could mean "the user
             // deliberately wants no license" (or the trip was imported with none), not "never
             // decided".
-            trip.setLicense(GeneralPreferences.getDefaultLicenseName());
+            if (GeneralPreferences.isLicenseDefaultConfirmed()) {
+                trip.setLicense(GeneralPreferences.getDefaultLicenseName());
+            } else {
+                // First run: nobody has chosen a default license yet - ask, rather than
+                // silently applying one on their behalf. The license field is left as-is for
+                // this pass and gets filled in once the user has made their choice, in
+                // licenseChoiceLauncher's callback above.
+                //
+                // Deferred via post(): launching a new Activity synchronously mid-onResume(),
+                // before this window has finished attaching, is unreliable and can be silently
+                // dropped. Posting it ensures TripActivity has fully become visible first.
+                View root = findViewById(R.id.rootLayout);
+                root.post(
+                        () ->
+                                licenseChoiceLauncher.launch(
+                                        new Intent(this, LicenseChoiceActivity.class)));
+            }
         }
 
         savedTrip = new Trip(trip);

--- a/app/src/main/java/org/hwyl/sexytopo/control/io/basic/SurveyJsonTranslater.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/io/basic/SurveyJsonTranslater.java
@@ -52,6 +52,8 @@ public class SurveyJsonTranslater {
     public static final String TEAM_MEMBER_NAME_TAG = "name";
     public static final String TEAM_MEMBER_ROLE_TAG = "role";
     public static final String INSTRUMENT_TAG = "instrument";
+    public static final String COPYRIGHT_TAG = "copyright";
+    public static final String LICENSE_TAG = "license";
 
     private static boolean errors; // whether any partial errors were encountered
 
@@ -287,6 +289,8 @@ public class SurveyJsonTranslater {
         json.put(EXPLO_DATE_LINKED_TAG, trip.isExplorationDateLinked());
         json.put(COMMENT_TAG, trip.getComments());
         json.put(INSTRUMENT_TAG, trip.getInstrument());
+        json.put(COPYRIGHT_TAG, trip.getCopyright());
+        json.put(LICENSE_TAG, trip.getLicense());
 
         JSONArray teamArray = new JSONArray();
 
@@ -430,6 +434,8 @@ public class SurveyJsonTranslater {
         trip.setTeam(team);
         trip.setComments(comments);
         trip.setInstrument(json.optString(INSTRUMENT_TAG, ""));
+        trip.setCopyright(json.optString(COPYRIGHT_TAG, ""));
+        trip.setLicense(json.optString(LICENSE_TAG, ""));
         return trip;
     }
 }

--- a/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/survex/SurvexExporter.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/survex/SurvexExporter.java
@@ -26,7 +26,11 @@ public class SurvexExporter extends SingleFileExporter {
         builder.append(
                         SurvexTherionUtil.getCreationComment(
                                 SurveyFormat.SURVEX.getCommentChar(), "SexyTopo"))
-                .append("\n\n");
+                .append("\n");
+
+        // Copyright / license (if the trip has either set)
+        builder.append(SurvexTherionUtil.getCopyrightLine(survey, SurveyFormat.SURVEX));
+        builder.append("\n");
 
         // Metadata
         builder.append(SurvexTherionUtil.getMetadata(survey, SurveyFormat.SURVEX, teamLines, ""))

--- a/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/survextherion/SurvexTherionImporter.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/survextherion/SurvexTherionImporter.java
@@ -22,6 +22,15 @@ public class SurvexTherionImporter {
     public static final Pattern COMMENT_INSTRUCTION_REGEX = Pattern.compile("([{].*?[}])");
 
     /**
+     * Matches a copyright/license line as produced by {@code SurvexTherionUtil.getCopyrightLine}:
+     * {@code copyright <year> "<copyright text>" [;#]"<license text>"}, where the trailing
+     * comment-char/license portion is optional. Group 1 is the copyright text, group 2 is the
+     * license text (may be {@code null} if no license was present).
+     */
+    private static final Pattern COPYRIGHT_LINE_REGEX =
+            Pattern.compile("copyright\\s+\\S+\\s+\"([^\"]*)\"(?:\\s*[;#]\"([^\"]*)\")?");
+
+    /**
      * Parse centreline data from Survex/Therion format.
      *
      * <p>Handles: - Forward and backward legs (detects based on station order) - Promoted legs in
@@ -231,6 +240,8 @@ public class SurvexTherionImporter {
         Date surveyDate = null;
         Date explorationDate = null; // explo-date / date explored line
         String instrument = null;
+        String copyright = null;
+        String license = null;
         Map<String, List<Trip.Role>> teamMap = new java.util.LinkedHashMap<>();
         StringBuilder tripComments = new StringBuilder();
         boolean foundAnyMetadata = false;
@@ -265,6 +276,23 @@ public class SurvexTherionImporter {
             // Commented-out instrument line — explicitly clear
             if (trimmed.startsWith(format.getCommentedInstrumentPrefix())) {
                 instrument = null;
+                foundAnyMetadata = true;
+                continue;
+            }
+
+            // Copyright / license: "copyright <year> \"<copyright>\" [;#]\"<license>\""
+            if (effective.startsWith("copyright ")) {
+                Matcher copyrightMatcher = COPYRIGHT_LINE_REGEX.matcher(effective);
+                if (copyrightMatcher.find()) {
+                    String copyrightText = copyrightMatcher.group(1);
+                    if (copyrightText != null && !copyrightText.isEmpty()) {
+                        copyright = copyrightText;
+                    }
+                    String licenseText = copyrightMatcher.group(2);
+                    if (licenseText != null && !licenseText.isEmpty()) {
+                        license = licenseText;
+                    }
+                }
                 foundAnyMetadata = true;
                 continue;
             }
@@ -329,6 +357,13 @@ public class SurvexTherionImporter {
         }
 
         trip.setInstrument(instrument);
+
+        if (copyright != null) {
+            trip.setCopyright(copyright);
+        }
+        if (license != null) {
+            trip.setLicense(license);
+        }
 
         // Build team list
         List<Trip.TeamEntry> teamEntries = new ArrayList<>();

--- a/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/survextherion/SurvexTherionUtil.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/survextherion/SurvexTherionUtil.java
@@ -8,6 +8,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import org.hwyl.sexytopo.control.util.GraphToListTranslator;
+import org.hwyl.sexytopo.control.util.TextTools;
 import org.hwyl.sexytopo.model.graph.Direction;
 import org.hwyl.sexytopo.model.survey.Leg;
 import org.hwyl.sexytopo.model.survey.Station;
@@ -123,7 +124,7 @@ public class SurvexTherionUtil {
         StringBuilder builder = new StringBuilder();
         builder.append(marker)
                 .append("copyright ")
-                .append(formatYear(trip.getSurveyDate()))
+                .append(TextTools.formatYear(trip.getSurveyDate()))
                 .append(" \"")
                 .append(copyrightText)
                 .append("\"");
@@ -138,11 +139,6 @@ public class SurvexTherionUtil {
 
         builder.append("\n");
         return builder.toString();
-    }
-
-    @SuppressLint("SimpleDateFormat")
-    private static String formatYear(Date date) {
-        return new SimpleDateFormat("yyyy").format(date);
     }
 
     public static String getStationCommentsData(Survey survey, SurveyFormat format) {

--- a/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/survextherion/SurvexTherionUtil.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/survextherion/SurvexTherionUtil.java
@@ -100,6 +100,51 @@ public class SurvexTherionUtil {
         return builder.toString();
     }
 
+    /**
+     * Returns the {@code *copyright <year> "<copyright>" ;"<license>"} line (Survex) or the
+     * equivalent {@code copyright <year> "<copyright>" #"<license>"} line (Therion) for the
+     * survey's trip, or "" if there's no trip, or the trip has neither a copyright nor a license
+     * set.
+     *
+     * <p>The copyright text is always quoted, and is rendered as an empty pair of quotes if blank.
+     * The license (also quoted) is only appended, as a trailing comment, if it is set; if there's
+     * no license, the line ends after the copyright text.
+     */
+    public static String getCopyrightLine(Survey survey, SurveyFormat format) {
+        Trip trip = survey.getTrip();
+        if (trip == null || (!trip.hasCopyright() && !trip.hasLicense())) {
+            return "";
+        }
+
+        String marker = format.getCommandChar();
+        char commentChar = format.getCommentChar();
+        String copyrightText = trip.hasCopyright() ? trip.getCopyright() : "";
+
+        StringBuilder builder = new StringBuilder();
+        builder.append(marker)
+                .append("copyright ")
+                .append(formatYear(trip.getSurveyDate()))
+                .append(" \"")
+                .append(copyrightText)
+                .append("\"");
+
+        if (trip.hasLicense()) {
+            builder.append(" ")
+                    .append(commentChar)
+                    .append("\"")
+                    .append(trip.getLicense())
+                    .append("\"");
+        }
+
+        builder.append("\n");
+        return builder.toString();
+    }
+
+    @SuppressLint("SimpleDateFormat")
+    private static String formatYear(Date date) {
+        return new SimpleDateFormat("yyyy").format(date);
+    }
+
     public static String getStationCommentsData(Survey survey, SurveyFormat format) {
 
         StringBuilder builder = new StringBuilder();

--- a/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/svg/SvgExportOptions.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/svg/SvgExportOptions.java
@@ -15,6 +15,7 @@ public class SvgExportOptions {
     private boolean showSplays = true;
     private boolean showGrid = false;
     private boolean showTagline = true;
+    private boolean showCopyright = true;
 
     public SvgExportOptions() {}
 
@@ -30,7 +31,8 @@ public class SvgExportOptions {
             boolean showStations,
             boolean showSplays,
             boolean showGrid,
-            boolean showTagline) {
+            boolean showTagline,
+            boolean showCopyright) {
         this.whiteBackground = whiteBackground;
         this.showLegend = showLegend;
         this.showNorthArrow = showNorthArrow;
@@ -43,6 +45,7 @@ public class SvgExportOptions {
         this.showSplays = showSplays;
         this.showGrid = showGrid;
         this.showTagline = showTagline;
+        this.showCopyright = showCopyright;
     }
 
     public boolean isWhiteBackground() {
@@ -91,5 +94,9 @@ public class SvgExportOptions {
 
     public boolean isShowTagline() {
         return showTagline;
+    }
+
+    public boolean isShowCopyright() {
+        return showCopyright;
     }
 }

--- a/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/svg/SvgExporter.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/svg/SvgExporter.java
@@ -81,7 +81,8 @@ public class SvgExporter extends DoubleSketchFileExporter {
                             GeneralPreferences.isExportSvgStationsEnabled(),
                             GeneralPreferences.isExportSvgSplaysEnabled(),
                             GeneralPreferences.isExportSvgGridEnabled(),
-                            GeneralPreferences.isExportSvgTaglineEnabled());
+                            GeneralPreferences.isExportSvgTaglineEnabled(),
+                            GeneralPreferences.isExportSvgCopyrightEnabled());
         }
         return exportOptions;
     }
@@ -139,6 +140,16 @@ public class SvgExporter extends DoubleSketchFileExporter {
                 "viewBox",
                 TextTools.join(" ", svgTopLeftX, svgTopLeftY, svgWidth, svgHeight));
         xmlSerializer.attribute(null, "xmlns", "http://www.w3.org/2000/svg");
+
+        Trip trip = survey.getTrip();
+        if (trip != null && (trip.hasCopyright() || trip.hasLicense())) {
+            xmlSerializer.startTag(null, "title");
+            xmlSerializer.text(survey.getName());
+            xmlSerializer.endTag(null, "title");
+            xmlSerializer.startTag(null, "desc");
+            xmlSerializer.text(formatCopyrightLine(trip));
+            xmlSerializer.endTag(null, "desc");
+        }
 
         Colour background = options.isWhiteBackground() ? Colour.WHITE : Colour.TRANSPARENT;
         if (background != Colour.TRANSPARENT) {
@@ -348,6 +359,12 @@ public class SvgExporter extends DoubleSketchFileExporter {
             }
         }
         bodyLines.add(formatStatsLine(survey));
+        if (options.isShowCopyright()) {
+            String copyrightLine = formatCopyrightLine(trip);
+            if (!copyrightLine.isEmpty()) {
+                bodyLines.add(copyrightLine);
+            }
+        }
 
         double barLengthMetres = pickScaleBarLength(surveyWidthMetres);
         return new LegendModel(
@@ -534,6 +551,31 @@ public class SvgExporter extends DoubleSketchFileExporter {
             }
         }
         return TextTools.join(", ", names);
+    }
+
+    /**
+     * Formats a trip's copyright and license as a single line, e.g. "© 2026 Caver Jane — CC BY
+     * 4.0". Either part may be omitted if not set; returns an empty string if neither is set.
+     */
+    private static String formatCopyrightLine(Trip trip) {
+        if (trip == null) {
+            return "";
+        }
+        StringBuilder builder = new StringBuilder();
+        if (trip.hasCopyright()) {
+            builder.append("\u00A9 ");
+            if (trip.getSurveyDate() != null) {
+                builder.append(TextTools.formatYear(trip.getSurveyDate())).append(" ");
+            }
+            builder.append(trip.getCopyright());
+        }
+        if (trip.hasLicense()) {
+            if (builder.length() > 0) {
+                builder.append(" — ");
+            }
+            builder.append(trip.getLicense());
+        }
+        return builder.toString();
     }
 
     private static String formatStatsLine(Survey survey) {
@@ -902,6 +944,7 @@ public class SvgExporter extends DoubleSketchFileExporter {
         CheckBox splaysCheckbox = dialogView.findViewById(R.id.svgSplaysCheckbox);
         CheckBox gridCheckbox = dialogView.findViewById(R.id.svgGridCheckbox);
         CheckBox taglineCheckbox = dialogView.findViewById(R.id.svgTaglineCheckbox);
+        CheckBox copyrightCheckbox = dialogView.findViewById(R.id.svgCopyrightCheckbox);
 
         String[] backgroundValues =
                 context.getResources()
@@ -920,6 +963,7 @@ public class SvgExporter extends DoubleSketchFileExporter {
         splaysCheckbox.setChecked(GeneralPreferences.isExportSvgSplaysEnabled());
         gridCheckbox.setChecked(GeneralPreferences.isExportSvgGridEnabled());
         taglineCheckbox.setChecked(GeneralPreferences.isExportSvgTaglineEnabled());
+        copyrightCheckbox.setChecked(GeneralPreferences.isExportSvgCopyrightEnabled());
 
         new MaterialAlertDialogBuilder(context)
                 .setTitle(R.string.svg_export_dialog_title)
@@ -941,6 +985,7 @@ public class SvgExporter extends DoubleSketchFileExporter {
                             boolean splays = splaysCheckbox.isChecked();
                             boolean grid = gridCheckbox.isChecked();
                             boolean tagline = taglineCheckbox.isChecked();
+                            boolean copyright = copyrightCheckbox.isChecked();
                             exportOptions =
                                     new SvgExportOptions(
                                             white,
@@ -954,7 +999,8 @@ public class SvgExporter extends DoubleSketchFileExporter {
                                             stations,
                                             splays,
                                             grid,
-                                            tagline);
+                                            tagline,
+                                            copyright);
                             saveOptions(
                                     selectedBackground,
                                     legend,
@@ -967,7 +1013,8 @@ public class SvgExporter extends DoubleSketchFileExporter {
                                     stations,
                                     splays,
                                     grid,
-                                    tagline);
+                                    tagline,
+                                    copyright);
                             onReady.run();
                         })
                 .setNegativeButton(R.string.cancel, null)
@@ -995,7 +1042,8 @@ public class SvgExporter extends DoubleSketchFileExporter {
             boolean stations,
             boolean splays,
             boolean grid,
-            boolean tagline) {
+            boolean tagline,
+            boolean copyright) {
         SharedPreferences prefs = GeneralPreferences.getRawPreferences();
         if (prefs == null) {
             return;
@@ -1013,6 +1061,7 @@ public class SvgExporter extends DoubleSketchFileExporter {
                 .putBoolean("pref_export_svg_splays", splays)
                 .putBoolean("pref_export_svg_grid", grid)
                 .putBoolean("pref_export_svg_tagline", tagline)
+                .putBoolean("pref_export_svg_copyright", copyright)
                 .apply();
     }
 

--- a/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/therion/Th2Exporter.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/therion/Th2Exporter.java
@@ -8,6 +8,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import org.hwyl.sexytopo.control.io.thirdparty.survextherion.SurvexTherionUtil;
+import org.hwyl.sexytopo.control.io.thirdparty.survextherion.SurveyFormat;
 import org.hwyl.sexytopo.control.util.GeneralPreferences;
 import org.hwyl.sexytopo.control.util.TextTools;
 import org.hwyl.sexytopo.model.common.Shape;
@@ -125,7 +127,7 @@ public class Th2Exporter {
             Station station = xsDetail.getCrossSection().getStation();
             String scrapName = stationNameToXsScrapName.get(station.getName());
             if (scrapName != null) {
-                scraps.add(getCrossSectionScrap(scrapName, xsDetail, scale, xsScale));
+                scraps.add(getCrossSectionScrap(survey, scrapName, xsDetail, scale, xsScale));
             }
         }
 
@@ -171,7 +173,7 @@ public class Th2Exporter {
     }
 
     private static String getCrossSectionScrap(
-            String name, CrossSectionDetail xsDetail, float scale, float xsScale) {
+            Survey survey, String name, CrossSectionDetail xsDetail, float scale, float xsScale) {
         List<String> lines = new ArrayList<>();
 
         // Scale parameter: [px1 py1 px2 py2 rx1 ry1 rx2 ry2 m]
@@ -186,7 +188,14 @@ public class Th2Exporter {
                         TextTools.formatTo2dp(realWorldRef),
                         TextTools.formatTo2dp(realWorldRef));
 
-        lines.add("scrap " + name + " -projection none -scale " + scaleParam);
+        String startLine = "scrap " + name + " -projection none -scale " + scaleParam;
+        String copyrightLine = SurvexTherionUtil.getCopyrightLine(survey, SurveyFormat.THERION);
+        if (!copyrightLine.isEmpty()) {
+            // As in getStartScrapLines(): drop the trailing newline, since it's joined onto
+            // the previous line with a single "\n" rather than the "\n\n" used elsewhere here.
+            startLine = startLine + "\n" + copyrightLine.substring(0, copyrightLine.length() - 1);
+        }
+        lines.add(startLine);
         lines.add("endscrap");
 
         return TextTools.join("\n\n", lines);
@@ -297,7 +306,7 @@ public class Th2Exporter {
             boolean includeSketchContent,
             Map<String, String> stationNameToXsScrapName) {
         List<String> lines = new ArrayList<>();
-        lines.add(getStartScrapCommands(name, projection, frame));
+        lines.add(getStartScrapLines(survey, name, projection, frame));
         lines.addAll(
                 getScrapCommands(
                         survey,
@@ -330,6 +339,24 @@ public class Th2Exporter {
                 true,
                 true,
                 Collections.emptyMap());
+    }
+
+    /**
+     * Returns the "scrap ... -projection ..." line, followed - on the very next physical line, not
+     * separated by a blank line like the rest of this scrap's sections are - by the
+     * copyright/license line, if the trip has either set.
+     */
+    private static String getStartScrapLines(
+            Survey survey, String name, Projection2D projection, Shape frame) {
+        String startLine = getStartScrapCommands(name, projection, frame);
+        String copyrightLine = SurvexTherionUtil.getCopyrightLine(survey, SurveyFormat.THERION);
+        if (copyrightLine.isEmpty()) {
+            return startLine;
+        }
+        // getCopyrightLine() always ends with a single trailing newline; drop it here, since
+        // this is joined onto the previous line with a single "\n", not the "\n\n" used to
+        // separate the other sections of this scrap.
+        return startLine + "\n" + copyrightLine.substring(0, copyrightLine.length() - 1);
     }
 
     private static String getStartScrapCommands(String name, Projection2D projection, Shape frame) {

--- a/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/therion/ThExporter.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/therion/ThExporter.java
@@ -34,6 +34,9 @@ public class ThExporter {
         // Centreline block
         builder.append("centreline\n");
 
+        // Copyright / license (if the trip has either set)
+        builder.append(SurvexTherionUtil.getCopyrightLine(survey, SurveyFormat.THERION));
+
         // Metadata (inside centreline)
         String teamLines = "";
         String exploTeamLines = "";
@@ -76,6 +79,7 @@ public class ThExporter {
 
         String centrelineText =
                 "centreline\n"
+                        + SurvexTherionUtil.getCopyrightLine(survey, SurveyFormat.THERION)
                         + metadataText
                         + "\n"
                         + SurvexTherionUtil.getStationCommentsData(survey, SurveyFormat.THERION)
@@ -149,7 +153,7 @@ public class ThExporter {
 
     static String replaceCentreline(String original, String replacementText) {
         return original.replaceFirst(
-                "(?s)(\\s*?(centreline|centerline)(.*)(endcentreline|endcenterline)\\s*)",
+                "(?s)((centreline|centerline)(.*)(endcentreline|endcenterline)\\s*)",
                 replacementText);
     }
 

--- a/app/src/main/java/org/hwyl/sexytopo/control/util/GeneralPreferences.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/util/GeneralPreferences.java
@@ -5,13 +5,18 @@ import android.content.SharedPreferences;
 import android.net.Uri;
 import androidx.preference.PreferenceManager;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import org.hwyl.sexytopo.control.Log;
 import org.hwyl.sexytopo.model.sketch.Colour;
+import org.hwyl.sexytopo.model.survey.LicenseOption;
 import org.hwyl.sexytopo.model.table.LRUD;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
 
 public class GeneralPreferences {
 
@@ -392,5 +397,193 @@ public class GeneralPreferences {
         Set<String> set = new HashSet<>(prefs.getStringSet(PREF_KNOWN_CAVERS, new HashSet<>()));
         set.remove(name);
         prefs.edit().putStringSet(PREF_KNOWN_CAVERS, set).apply();
+    }
+
+    // ********** License Options ***********
+
+    private static final String PREF_LICENSE_OPTIONS = "pref_license_options";
+    private static final String LICENSE_NAME_TAG = "name";
+    private static final String LICENSE_DEFAULT_TAG = "default";
+    private static final String FALLBACK_DEFAULT_LICENSE_NAME = "GPLv3.0+";
+
+    private static List<LicenseOption> defaultLicenseOptions() {
+        return new ArrayList<>(
+                Arrays.asList(
+                        new LicenseOption(FALLBACK_DEFAULT_LICENSE_NAME, true),
+                        new LicenseOption("CC0", false),
+                        new LicenseOption("CC BY 4.0", false),
+                        new LicenseOption("CC BY SA 4.0", false),
+                        new LicenseOption("CC BY SA NC 4.0", false),
+                        new LicenseOption("All rights reserved", false)));
+    }
+
+    public static List<LicenseOption> getLicenseOptions() {
+        if (prefs == null) return defaultLicenseOptions();
+
+        String json = prefs.getString(PREF_LICENSE_OPTIONS, null);
+        if (json == null) return defaultLicenseOptions();
+
+        try {
+            return licenseOptionsFromJson(json);
+        } catch (JSONException exception) {
+            Log.e("Could not load license options: " + exception);
+            return defaultLicenseOptions();
+        }
+    }
+
+    public static void setLicenseOptions(List<LicenseOption> options) {
+        if (prefs == null) return;
+        try {
+            String json = licenseOptionsToJson(options).toString();
+            prefs.edit().putString(PREF_LICENSE_OPTIONS, json).apply();
+        } catch (JSONException exception) {
+            Log.e("Could not save license options: " + exception);
+        }
+    }
+
+    /** Returns the name of the license option currently flagged as the default. */
+    public static String getDefaultLicenseName() {
+        for (LicenseOption option : getLicenseOptions()) {
+            if (option.isDefault()) {
+                return option.getName();
+            }
+        }
+        return FALLBACK_DEFAULT_LICENSE_NAME;
+    }
+
+    /**
+     * Adds a new license option. If the list is currently empty, the new option becomes the
+     * default; otherwise it is added as a non-default option.
+     */
+    public static void addLicenseOption(String name) {
+        if (name == null || name.trim().isEmpty()) return;
+        setLicenseOptions(withAdded(getLicenseOptions(), name.trim()));
+    }
+
+    /**
+     * Removes the license option with the given name. If it was the default and other options
+     * remain, the first remaining option is promoted to be the new default, so a default is always
+     * present as long as the list is not empty.
+     */
+    public static void removeLicenseOption(String name) {
+        if (name == null) return;
+        setLicenseOptions(withRemoved(getLicenseOptions(), name));
+    }
+
+    /** Renames a license option, preserving its position in the list and its default flag. */
+    public static void renameLicenseOption(String oldName, String newName) {
+        if (oldName == null || newName == null || newName.trim().isEmpty()) return;
+        setLicenseOptions(withRenamed(getLicenseOptions(), oldName, newName.trim()));
+    }
+
+    /**
+     * Flags the license option with the given name as the default, and un-flags every other option.
+     * Does nothing if no option with that name exists.
+     */
+    public static void setDefaultLicenseOption(String name) {
+        if (name == null) return;
+        setLicenseOptions(withDefaultSet(getLicenseOptions(), name));
+    }
+
+    /**
+     * Pure list transformation backing {@link #addLicenseOption(String)}, kept separate so it can
+     * be unit tested without a SharedPreferences-backed Context.
+     */
+    public static List<LicenseOption> withAdded(List<LicenseOption> options, String trimmedName) {
+        List<LicenseOption> result = new ArrayList<>(options);
+        result.add(new LicenseOption(trimmedName, result.isEmpty()));
+        return result;
+    }
+
+    /**
+     * Pure list transformation backing {@link #removeLicenseOption(String)}, kept separate so it
+     * can be unit tested without a SharedPreferences-backed Context.
+     */
+    public static List<LicenseOption> withRemoved(List<LicenseOption> options, String name) {
+        boolean removedWasDefault = false;
+        List<LicenseOption> remaining = new ArrayList<>();
+        for (LicenseOption option : options) {
+            if (option.getName().equals(name)) {
+                removedWasDefault = option.isDefault();
+            } else {
+                remaining.add(option);
+            }
+        }
+
+        if (removedWasDefault && !remaining.isEmpty() && !hasDefault(remaining)) {
+            remaining.set(0, remaining.get(0).withDefault(true));
+        }
+        return remaining;
+    }
+
+    /**
+     * Pure list transformation backing {@link #renameLicenseOption(String, String)}, kept separate
+     * so it can be unit tested without a SharedPreferences-backed Context.
+     */
+    public static List<LicenseOption> withRenamed(
+            List<LicenseOption> options, String oldName, String trimmedNewName) {
+        List<LicenseOption> result = new ArrayList<>(options);
+        for (int i = 0; i < result.size(); i++) {
+            if (result.get(i).getName().equals(oldName)) {
+                result.set(i, result.get(i).withName(trimmedNewName));
+                break;
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Pure list transformation backing {@link #setDefaultLicenseOption(String)}, kept separate so
+     * it can be unit tested without a SharedPreferences-backed Context. Does nothing (returns an
+     * unchanged copy) if no option with the given name exists.
+     */
+    public static List<LicenseOption> withDefaultSet(List<LicenseOption> options, String name) {
+        if (!hasOption(options, name)) {
+            return new ArrayList<>(options);
+        }
+
+        List<LicenseOption> result = new ArrayList<>();
+        for (LicenseOption option : options) {
+            result.add(option.withDefault(option.getName().equals(name)));
+        }
+        return result;
+    }
+
+    private static boolean hasDefault(List<LicenseOption> options) {
+        for (LicenseOption option : options) {
+            if (option.isDefault()) return true;
+        }
+        return false;
+    }
+
+    private static boolean hasOption(List<LicenseOption> options, String name) {
+        for (LicenseOption option : options) {
+            if (option.getName().equals(name)) return true;
+        }
+        return false;
+    }
+
+    public static JSONArray licenseOptionsToJson(List<LicenseOption> options) throws JSONException {
+        JSONArray array = new JSONArray();
+        for (LicenseOption option : options) {
+            JSONObject json = new JSONObject();
+            json.put(LICENSE_NAME_TAG, option.getName());
+            json.put(LICENSE_DEFAULT_TAG, option.isDefault());
+            array.put(json);
+        }
+        return array;
+    }
+
+    public static List<LicenseOption> licenseOptionsFromJson(String jsonString)
+            throws JSONException {
+        JSONArray array = new JSONArray(jsonString);
+        List<LicenseOption> options = new ArrayList<>();
+        for (int i = 0; i < array.length(); i++) {
+            JSONObject json = array.getJSONObject(i);
+            String name = json.getString(LICENSE_NAME_TAG);
+            boolean isDefault = json.optBoolean(LICENSE_DEFAULT_TAG, false);
+            options.add(new LicenseOption(name, isDefault));
+        }
+        return options;
     }
 }

--- a/app/src/main/java/org/hwyl/sexytopo/control/util/GeneralPreferences.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/util/GeneralPreferences.java
@@ -321,6 +321,10 @@ public class GeneralPreferences {
         return getBoolean("pref_export_svg_tagline", true);
     }
 
+    public static boolean isExportSvgCopyrightEnabled() {
+        return getBoolean("pref_export_svg_copyright", true);
+    }
+
     public static SharedPreferences getRawPreferences() {
         return prefs;
     }

--- a/app/src/main/java/org/hwyl/sexytopo/control/util/GeneralPreferences.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/util/GeneralPreferences.java
@@ -455,6 +455,21 @@ public class GeneralPreferences {
         return FALLBACK_DEFAULT_LICENSE_NAME;
     }
 
+    private static final String PREF_LICENSE_DEFAULT_CONFIRMED = "pref_license_default_confirmed";
+
+    /**
+     * Checks whether the user has been through the one-time first-run screen that asks them to
+     * choose a default license, rather than been silently applied on their behalf.
+     */
+    public static boolean isLicenseDefaultConfirmed() {
+        return getBoolean(PREF_LICENSE_DEFAULT_CONFIRMED, false);
+    }
+
+    public static void setLicenseDefaultConfirmed(boolean confirmed) {
+        if (prefs == null) return;
+        prefs.edit().putBoolean(PREF_LICENSE_DEFAULT_CONFIRMED, confirmed).apply();
+    }
+
     /**
      * Adds a new license option. If the list is currently empty, the new option becomes the
      * default; otherwise it is added as a non-default option.

--- a/app/src/main/java/org/hwyl/sexytopo/control/util/TextTools.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/util/TextTools.java
@@ -28,6 +28,9 @@ public class TextTools {
     @SuppressLint("SimpleDateFormat")
     public static final DateFormat ISO_DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd");
 
+    @SuppressLint("SimpleDateFormat")
+    public static final DateFormat YEAR_FORMAT = new SimpleDateFormat("yyyy");
+
     public static String pluralise(int n, String noun) {
         return n + " " + ((n == 1) ? noun : noun + "s");
     }
@@ -151,6 +154,10 @@ public class TextTools {
 
     public static String toIsoDate(Date date) {
         return ISO_DATE_FORMAT.format(date);
+    }
+
+    public static String formatYear(Date date) {
+        return YEAR_FORMAT.format(date);
     }
 
     public static String getFileAttribution(Context context) {

--- a/app/src/main/java/org/hwyl/sexytopo/model/survey/LicenseOption.java
+++ b/app/src/main/java/org/hwyl/sexytopo/model/survey/LicenseOption.java
@@ -1,0 +1,65 @@
+package org.hwyl.sexytopo.model.survey;
+
+import androidx.annotation.NonNull;
+
+/**
+ * One entry in the user-configurable list of license choices offered on the Trip screen. Exactly
+ * one entry in any given list is flagged as the default; this is enforced by the code that manages
+ * the stored list (see GeneralPreferences.)
+ */
+public class LicenseOption {
+
+    private final String name;
+    private final boolean isDefault;
+
+    public LicenseOption(String name, boolean isDefault) {
+        this.name = name;
+        this.isDefault = isDefault;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public boolean isDefault() {
+        return isDefault;
+    }
+
+    /** Returns a copy of this option with the same name but the given default flag. */
+    public LicenseOption withDefault(boolean newIsDefault) {
+        return new LicenseOption(name, newIsDefault);
+    }
+
+    /** Returns a copy of this option with a new name but the same default flag. */
+    public LicenseOption withName(String newName) {
+        return new LicenseOption(newName, isDefault);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+        if (!(other instanceof LicenseOption)) {
+            return false;
+        }
+        LicenseOption that = (LicenseOption) other;
+        if (isDefault != that.isDefault) {
+            return false;
+        }
+        return name == null ? that.name == null : name.equals(that.name);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = 17;
+        result = 31 * result + (name != null ? name.hashCode() : 0);
+        result = 31 * result + (isDefault ? 1 : 0);
+        return result;
+    }
+
+    @Override
+    public @NonNull String toString() {
+        return name;
+    }
+}

--- a/app/src/main/java/org/hwyl/sexytopo/model/survey/Trip.java
+++ b/app/src/main/java/org/hwyl/sexytopo/model/survey/Trip.java
@@ -75,6 +75,8 @@ public class Trip {
     private List<TeamEntry> team = new ArrayList<>();
     private String comments;
     private String instrument;
+    private String copyright;
+    private String license;
 
     public Trip() {
         this.surveyDate = new Date();
@@ -82,6 +84,8 @@ public class Trip {
         this.explorationDateLinked = true;
         this.instrument = "";
         this.comments = "";
+        this.copyright = "";
+        this.license = "";
     }
 
     public Trip(Trip other) {
@@ -94,6 +98,8 @@ public class Trip {
         }
         this.comments = other.comments;
         this.instrument = other.instrument;
+        this.copyright = other.copyright;
+        this.license = other.license;
     }
 
     public List<TeamEntry> getTeam() {
@@ -152,9 +158,33 @@ public class Trip {
         return instrument != null && !instrument.trim().isEmpty();
     }
 
+    public String getCopyright() {
+        return copyright;
+    }
+
+    public void setCopyright(String copyright) {
+        this.copyright = copyright;
+    }
+
+    public boolean hasCopyright() {
+        return copyright != null && !copyright.trim().isEmpty();
+    }
+
+    public String getLicense() {
+        return license;
+    }
+
+    public void setLicense(String license) {
+        this.license = license;
+    }
+
+    public boolean hasLicense() {
+        return license != null && !license.trim().isEmpty();
+    }
+
     /**
-     * Creates a new Trip for a follow-on survey, copying team and instrument but with a fresh date
-     * and empty comments.
+     * Creates a new Trip for a follow-on survey, copying team, instrument, copyright and license
+     * but with a fresh date and empty comments.
      */
     public Trip toNextTrip() {
         Trip next = new Trip(this);
@@ -194,6 +224,14 @@ public class Trip {
             return false;
         }
 
+        if (objectsNotEqual(trip.copyright, copyright)) {
+            return false;
+        }
+
+        if (objectsNotEqual(trip.license, license)) {
+            return false;
+        }
+
         if (trip.team.size() != team.size()) {
             return false;
         }
@@ -217,6 +255,8 @@ public class Trip {
         result = 31 * result + (explorationDateLinked ? 1 : 0);
         result = 31 * result + (comments != null ? comments.hashCode() : 0);
         result = 31 * result + (instrument != null ? instrument.hashCode() : 0);
+        result = 31 * result + (copyright != null ? copyright.hashCode() : 0);
+        result = 31 * result + (license != null ? license.hashCode() : 0);
         result = 31 * result + team.hashCode();
         return result;
     }

--- a/app/src/main/res/layout/activity_license_choice.xml
+++ b/app/src/main/res/layout/activity_license_choice.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/rootLayout"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context="org.hwyl.sexytopo.control.activity.LicenseChoiceActivity">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/panelBackground">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            android:background="@color/panelBackground"
+            app:title="@string/license_choice_title"
+            app:titleTextColor="@color/white" />
+
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:fillViewport="true">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:background="@color/lightBackground"
+            android:padding="16dp">
+
+            <TextView
+                android:id="@+id/license_choice_message"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/license_choice_message"
+                android:textSize="16sp"
+                android:lineSpacingExtra="4dp" />
+
+            <Spinner
+                android:id="@+id/license_choice_spinner"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="24dp" />
+
+            <Button
+                android:id="@+id/license_choice_confirm_button"
+                style="@style/Widget.Material3.Button"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="24dp"
+                android:layout_gravity="end"
+                android:text="@string/license_choice_confirm_button" />
+
+        </LinearLayout>
+
+    </ScrollView>
+
+</LinearLayout>

--- a/app/src/main/res/layout/activity_trip.xml
+++ b/app/src/main/res/layout/activity_trip.xml
@@ -222,6 +222,40 @@
                     <com.google.android.material.textfield.TextInputLayout
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
+                        android:layout_marginBottom="8dp"
+                        android:hint="@string/trip_copyright_label"
+                        style="@style/Widget.Material3.TextInputLayout.OutlinedBox">
+
+                        <com.google.android.material.textfield.TextInputEditText
+                            android:id="@+id/trip_copyright"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:maxLines="1"
+                            android:inputType="text"/>
+
+                    </com.google.android.material.textfield.TextInputLayout>
+
+                    <com.google.android.material.textfield.TextInputLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginBottom="8dp"
+                        android:hint="@string/trip_license_label"
+                        style="@style/Widget.Material3.TextInputLayout.OutlinedBox">
+
+                        <com.google.android.material.textfield.MaterialAutoCompleteTextView
+                            android:id="@+id/trip_license"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            style="@style/Widget.Material3.AutoCompleteTextView.OutlinedBox"
+                            android:maxLines="1"
+                            android:inputType="text"
+                            android:completionThreshold="0"/>
+
+                    </com.google.android.material.textfield.TextInputLayout>
+
+                    <com.google.android.material.textfield.TextInputLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
                         android:hint="@string/trip_comments"
                         style="@style/Widget.Material3.TextInputLayout.OutlinedBox">
 

--- a/app/src/main/res/layout/dialog_edit_license_name.xml
+++ b/app/src/main/res/layout/dialog_edit_license_name.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:paddingStart="24dp"
+    android:paddingEnd="24dp"
+    android:paddingTop="8dp"
+    android:paddingBottom="8dp">
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/license_name_input_layout"
+        style="@style/Widget.Material3.TextInputLayout.OutlinedBox"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="@string/settings_license_new_hint">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/license_name_field"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:inputType="text"/>
+
+    </com.google.android.material.textfield.TextInputLayout>
+
+</LinearLayout>

--- a/app/src/main/res/layout/dialog_svg_export.xml
+++ b/app/src/main/res/layout/dialog_svg_export.xml
@@ -108,6 +108,13 @@
             android:layout_marginTop="8dp"
             android:text="@string/settings_export_svg_tagline_title" />
 
+        <CheckBox
+            android:id="@+id/svgCopyrightCheckbox"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:text="@string/settings_export_svg_copyright_title" />
+
     </LinearLayout>
 
 </ScrollView>

--- a/app/src/main/res/layout/fragment_settings_copyright.xml
+++ b/app/src/main/res/layout/fragment_settings_copyright.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="center_vertical"
+        android:layout_marginBottom="8dp">
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/new_license_layout"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:hint="@string/settings_license_new_hint"
+            style="@style/Widget.Material3.TextInputLayout.OutlinedBox">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/new_license_field"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="text"/>
+
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <Button
+            android:id="@+id/add_license_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:contentDescription="@string/add"
+            app:icon="@drawable/ic_add"
+            style="@style/Widget.Material3.Button.IconButton"/>
+
+    </LinearLayout>
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1">
+
+        <LinearLayout
+            android:id="@+id/licenses_list"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"/>
+
+    </ScrollView>
+
+</LinearLayout>

--- a/app/src/main/res/layout/license_option_item.xml
+++ b/app/src/main/res/layout/license_option_item.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    android:gravity="center_vertical"
+    android:paddingTop="4dp"
+    android:paddingBottom="4dp">
+
+    <TextView
+        android:id="@+id/license_name_field"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:textAppearance="?attr/textAppearanceBodyLarge"/>
+
+    <CheckBox
+        android:id="@+id/license_default_checkbox"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:text="@string/settings_license_default_label"/>
+
+    <Button
+        android:id="@+id/delete_license_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="4dp"
+        android:contentDescription="@string/delete"
+        app:icon="@drawable/ic_delete"
+        style="@style/Widget.Material3.Button.IconButton"/>
+
+</LinearLayout>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -380,6 +380,8 @@
     <string name="trip_clear_date">Clear date</string>
     <string name="trip_same_as_survey_date">Gleich wie Vermessungsdatum</string>
     <string name="trip_comments">Bemerkungen</string>
+    <string name="trip_copyright_label">Copyright</string>
+    <string name="trip_license_label">Lizenz</string>
     <string name="trip_save_trip">Tour speichern</string>
     <string name="trip_role_book">Zeichnung</string>
     <string name="trip_role_instruments">Vermessung</string>
@@ -435,6 +437,11 @@
     <string name="settings_hot_corners_summary">Im Zeichenmodus: an den Ecken der Skizze ziehen, um die Ansicht zu verschieben</string>
         <string name="settings_team_title">Team</string>
     <string name="settings_team_summary">Bekannte Höhlenforscher-Namen verwalten</string>
+    <string name="settings_copyright_title">Copyright</string>
+    <string name="settings_copyright_summary">Lizenzwahl bearbeiten</string>
+    <string name="settings_license_new_hint">Lizenzname</string>
+    <string name="settings_license_name_required">Lizenzname ist erforderlich</string>
+    <string name="settings_license_default_label">Standard</string>
 <string name="settings_instruments_title">Werkzeuge</string>
     <string name="settings_instruments_summary">Instrumententoleranz, Kalibrierung</string>
     <string name="settings_max_distance_delta_title">Maximal zulässige Abweichung bei der Distanz (m)</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -538,6 +538,8 @@
     <string name="settings_export_svg_grid_summary">Hintergrundraster hinter der Vermessung zeichnen</string>
     <string name="settings_export_svg_tagline_title">Slogan anzeigen</string>
     <string name="settings_export_svg_tagline_summary">SexyTopo angemessen würdigen</string>
+    <string name="settings_export_svg_copyright_title">Copyright/Lizenz in der Legende anzeigen</string>
+    <string name="settings_export_svg_copyright_summary">Copyright und Lizenz werden immer in der Datei gespeichert; dies zeigt zusätzlich einen Hinweis in der Legende an</string>
     <string name="settings_export_therion_symbols_title">Therion-Export Symbole</string>
     <string name="settings_export_therion_symbols_summary">Symbole beim Exportieren im Therion-Format einschließen</string>
     <string name="settings_export_therion_text_title">Therion-Export Text</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -442,6 +442,9 @@
     <string name="settings_license_new_hint">Lizenzname</string>
     <string name="settings_license_name_required">Lizenzname ist erforderlich</string>
     <string name="settings_license_default_label">Standard</string>
+    <string name="license_choice_title">Standardlizenz wählen</string>
+    <string name="license_choice_message">Bitte wählen Sie eine Lizenz für die zukünftige Nutzung der Vermessung. Diese wird zur Standardlizenz und kann in der Tour überschrieben werden. GPLv3.0+ wird für Vermessungsdaten empfohlen und ist dieselbe Lizenz, unter der SexyTopo veröffentlicht wird</string>
+    <string name="license_choice_confirm_button">Bestätigen</string>
 <string name="settings_instruments_title">Werkzeuge</string>
     <string name="settings_instruments_summary">Instrumententoleranz, Kalibrierung</string>
     <string name="settings_max_distance_delta_title">Maximal zulässige Abweichung bei der Distanz (m)</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -442,6 +442,9 @@
     <string name="settings_license_new_hint">Nombre de la licencia</string>
     <string name="settings_license_name_required">El nombre de la licencia es obligatorio</string>
     <string name="settings_license_default_label">Predeterminada</string>
+    <string name="license_choice_title">Elegir una licencia predeterminada</string>
+    <string name="license_choice_message">Por favor, elige una licencia para el uso futuro de la topografía. Esta se convertirá en la predeterminada y se puede sobrescribir en Salida. Se recomienda GPLv3.0+ para datos topográficos y es la misma licencia bajo la que se publica SexyTopo</string>
+    <string name="license_choice_confirm_button">Confirmar</string>
 <string name="settings_instruments_title">Instrumentos</string>
     <string name="settings_instruments_summary">Tolerancias de instrumentos, calibración</string>
     <string name="settings_max_distance_delta_title">Delta de distancia máxima (m)</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -380,6 +380,8 @@
     <string name="trip_clear_date">Clear date</string>
     <string name="trip_same_as_survey_date">Igual que la fecha de topografía</string>
     <string name="trip_comments">Comentarios</string>
+    <string name="trip_copyright_label">Copyright</string>
+    <string name="trip_license_label">Licencia</string>
     <string name="trip_save_trip">Guardar Salida</string>
     <string name="trip_role_book">Topógrafo (dibujo)</string>
     <string name="trip_role_instruments">Instrumentos</string>
@@ -435,6 +437,11 @@
     <string name="settings_hot_corners_summary">Arrastra desde las esquinas del croquis para mover la vista en modos de dibujo</string>
         <string name="settings_team_title">Equipo</string>
     <string name="settings_team_summary">Gestionar nombres de espeleólogos conocidos</string>
+    <string name="settings_copyright_title">Copyright</string>
+    <string name="settings_copyright_summary">Editar la elección de licencia</string>
+    <string name="settings_license_new_hint">Nombre de la licencia</string>
+    <string name="settings_license_name_required">El nombre de la licencia es obligatorio</string>
+    <string name="settings_license_default_label">Predeterminada</string>
 <string name="settings_instruments_title">Instrumentos</string>
     <string name="settings_instruments_summary">Tolerancias de instrumentos, calibración</string>
     <string name="settings_max_distance_delta_title">Delta de distancia máxima (m)</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -538,6 +538,8 @@
     <string name="settings_export_svg_grid_summary">Dibujar una cuadrícula de fondo tras la topografía</string>
     <string name="settings_export_svg_tagline_title">Mostrar eslogan</string>
     <string name="settings_export_svg_tagline_summary">Dar el crédito adecuado a SexyTopo</string>
+    <string name="settings_export_svg_copyright_title">Mostrar copyright/licencia en la leyenda</string>
+    <string name="settings_export_svg_copyright_summary">El copyright y la licencia siempre se guardan en el archivo; esto también muestra una línea de crédito en la leyenda</string>
     <string name="settings_export_therion_symbols_title">Símbolos de exportación Therion</string>
     <string name="settings_export_therion_symbols_summary">Incluir símbolos al exportar a formato Therion</string>
     <string name="settings_export_therion_text_title">Texto de exportación Therion</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -442,6 +442,9 @@
     <string name="settings_license_new_hint">Nom de la licence</string>
     <string name="settings_license_name_required">Le nom de la licence est requis</string>
     <string name="settings_license_default_label">Par défaut</string>
+    <string name="license_choice_title">Choisir une licence par défaut</string>
+    <string name="license_choice_message">Veuillez choisir une licence pour l\'utilisation future du levé. Celle-ci deviendra la licence par défaut et pourra être remplacée dans Sortie. GPLv3.0+ est recommandée pour les données topographiques et c\'est la même licence sous laquelle SexyTopo est publié</string>
+    <string name="license_choice_confirm_button">Confirmer</string>
 <string name="settings_instruments_title">Outils</string>
     <string name="settings_instruments_summary">Tolérances des instruments, calibration</string>
     <string name="settings_max_distance_delta_title">Delta de distance max (m)</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -538,6 +538,8 @@
     <string name="settings_export_svg_grid_summary">Dessiner une grille de fond derrière le levé</string>
     <string name="settings_export_svg_tagline_title">Afficher la signature</string>
     <string name="settings_export_svg_tagline_summary">Créditer correctement SexyTopo</string>
+    <string name="settings_export_svg_copyright_title">Afficher le copyright/la licence dans la légende</string>
+    <string name="settings_export_svg_copyright_summary">Le copyright et la licence sont toujours enregistrés dans le fichier ; ceci affiche aussi une mention dans la légende</string>
     <string name="settings_export_therion_symbols_title">Exportation Therion des symboles</string>
     <string name="settings_export_therion_symbols_summary">Inclure les symboles lors de l\'exportation au format Therion</string>
     <string name="settings_export_therion_text_title">Exportation Therion du texte</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -380,6 +380,8 @@
     <string name="trip_clear_date">Clear date</string>
     <string name="trip_same_as_survey_date">Identique à la date de topographie</string>
     <string name="trip_comments">Commentaires</string>
+    <string name="trip_copyright_label">Copyright</string>
+    <string name="trip_license_label">Licence</string>
     <string name="trip_save_trip">Sauvegarder la sortie</string>
     <string name="trip_role_book">Livre (dessin)</string>
     <string name="trip_role_instruments">Outils</string>
@@ -435,6 +437,11 @@
     <string name="settings_hot_corners_summary">Faites glisser à partir des coins de l\'esquisse pour déplacer la vue en mode dessin</string>
         <string name="settings_team_title">Équipe</string>
     <string name="settings_team_summary">Gérer les noms de spéléologues connus</string>
+    <string name="settings_copyright_title">Copyright</string>
+    <string name="settings_copyright_summary">Modifier le choix de licence</string>
+    <string name="settings_license_new_hint">Nom de la licence</string>
+    <string name="settings_license_name_required">Le nom de la licence est requis</string>
+    <string name="settings_license_default_label">Par défaut</string>
 <string name="settings_instruments_title">Outils</string>
     <string name="settings_instruments_summary">Tolérances des instruments, calibration</string>
     <string name="settings_max_distance_delta_title">Delta de distance max (m)</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -538,6 +538,8 @@
     <string name="settings_export_svg_grid_summary">Disegna una griglia di sfondo dietro il rilievo</string>
     <string name="settings_export_svg_tagline_title">Mostra slogan</string>
     <string name="settings_export_svg_tagline_summary">Dai il giusto credito a SexyTopo</string>
+    <string name="settings_export_svg_copyright_title">Mostra copyright/licenza nella legenda</string>
+    <string name="settings_export_svg_copyright_summary">Il copyright e la licenza sono sempre salvati nel file; questo mostra anche una riga di credito nella legenda</string>
     <string name="settings_export_therion_symbols_title">Simboli esportazione Therion</string>
     <string name="settings_export_therion_symbols_summary">Includi simboli durante l\'esportazione in formato Therion</string>
     <string name="settings_export_therion_text_title">Testo esportazione Therion</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -442,6 +442,9 @@
     <string name="settings_license_new_hint">Nome della licenza</string>
     <string name="settings_license_name_required">Il nome della licenza è obbligatorio</string>
     <string name="settings_license_default_label">Predefinita</string>
+    <string name="license_choice_title">Scegli una licenza predefinita</string>
+    <string name="license_choice_message">Scegli una licenza per l\'uso futuro del rilievo. Questa diventerà quella predefinita e può essere sovrascritta in Uscita. GPLv3.0+ è consigliata per i dati di rilievo ed è la stessa licenza con cui SexyTopo è pubblicato</string>
+    <string name="license_choice_confirm_button">Conferma</string>
 <string name="settings_instruments_title">Strumenti</string>
     <string name="settings_instruments_summary">Tolleranze degli strumenti, calibrazione</string>
     <string name="settings_max_distance_delta_title">Delta distanza massima (m)</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -380,6 +380,8 @@
     <string name="trip_clear_date">Clear date</string>
     <string name="trip_same_as_survey_date">Uguale alla data del rilievo</string>
     <string name="trip_comments">Commenti</string>
+    <string name="trip_copyright_label">Copyright</string>
+    <string name="trip_license_label">Licenza</string>
     <string name="trip_save_trip">Salva Uscita</string>
     <string name="trip_role_book">Rilievo (disegno)</string>
     <string name="trip_role_instruments">Strumenti</string>
@@ -435,6 +437,11 @@
     <string name="settings_hot_corners_summary">Trascina dagli angoli dello schizzo per spostare la vista nelle modalità di disegno</string>
         <string name="settings_team_title">Squadra</string>
     <string name="settings_team_summary">Gestisci i nomi dei cavernicoli conosciuti</string>
+    <string name="settings_copyright_title">Copyright</string>
+    <string name="settings_copyright_summary">Modifica la scelta della licenza</string>
+    <string name="settings_license_new_hint">Nome della licenza</string>
+    <string name="settings_license_name_required">Il nome della licenza è obbligatorio</string>
+    <string name="settings_license_default_label">Predefinita</string>
 <string name="settings_instruments_title">Strumenti</string>
     <string name="settings_instruments_summary">Tolleranze degli strumenti, calibrazione</string>
     <string name="settings_max_distance_delta_title">Delta distanza massima (m)</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -538,6 +538,8 @@
     <string name="settings_export_svg_grid_summary">Rysuj siatkę w tle pomiaru</string>
     <string name="settings_export_svg_tagline_title">Pokaż podpis</string>
     <string name="settings_export_svg_tagline_summary">Odpowiednio podziękuj SexyTopo</string>
+    <string name="settings_export_svg_copyright_title">Pokaż copyright/licencję w legendzie</string>
+    <string name="settings_export_svg_copyright_summary">Copyright i licencja są zawsze zapisywane w pliku; to dodatkowo pokazuje informację w legendzie</string>
     <string name="settings_export_therion_symbols_title">Symbole eksportu Therion</string>
     <string name="settings_export_therion_symbols_summary">Uwzględnij symbole podczas eksportu do formatu Therion</string>
     <string name="settings_export_therion_text_title">Tekst eksportu Therion</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -442,6 +442,9 @@
     <string name="settings_license_new_hint">Nazwa licencji</string>
     <string name="settings_license_name_required">Nazwa licencji jest wymagana</string>
     <string name="settings_license_default_label">Domyślna</string>
+    <string name="license_choice_title">Wybierz domyślną licencję</string>
+    <string name="license_choice_message">Wybierz licencję do przyszłego wykorzystania pomiaru. Stanie się ona domyślna i można ją nadpisać w Wyjeździe. GPLv3.0+ jest zalecana dla danych pomiarowych i jest tą samą licencją, na której opublikowano SexyTopo</string>
+    <string name="license_choice_confirm_button">Potwierdź</string>
 <string name="settings_instruments_title">Instrumenty</string>
     <string name="settings_instruments_summary">Tolerancje instrumentów, kalibracja</string>
     <string name="settings_max_distance_delta_title">Maks. delta odległości (m)</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -380,6 +380,8 @@
     <string name="trip_clear_date">Clear date</string>
     <string name="trip_same_as_survey_date">Taka sama jak data pomiaru</string>
     <string name="trip_comments">Komentarze</string>
+    <string name="trip_copyright_label">Copyright</string>
+    <string name="trip_license_label">Licencja</string>
     <string name="trip_save_trip">Zapisz wyjazd</string>
     <string name="trip_role_book">Dokumentacja (rysowanie)</string>
     <string name="trip_role_instruments">Instrumenty</string>
@@ -435,6 +437,11 @@
     <string name="settings_hot_corners_summary">Przeciągaj z rogów szkicu, aby przesunąć widok w trybach rysowania</string>
         <string name="settings_team_title">Zespół</string>
     <string name="settings_team_summary">Zarządzaj nazwami znanych grotołazów</string>
+    <string name="settings_copyright_title">Copyright</string>
+    <string name="settings_copyright_summary">Edytuj wybór licencji</string>
+    <string name="settings_license_new_hint">Nazwa licencji</string>
+    <string name="settings_license_name_required">Nazwa licencji jest wymagana</string>
+    <string name="settings_license_default_label">Domyślna</string>
 <string name="settings_instruments_title">Instrumenty</string>
     <string name="settings_instruments_summary">Tolerancje instrumentów, kalibracja</string>
     <string name="settings_max_distance_delta_title">Maks. delta odległości (m)</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -380,6 +380,8 @@
     <string name="trip_clear_date">Clear date</string>
     <string name="trip_same_as_survey_date">Igual à data da topografia</string>
     <string name="trip_comments">Comentários</string>
+    <string name="trip_copyright_label">Copyright</string>
+    <string name="trip_license_label">Licença</string>
     <string name="trip_save_trip">Guardar Saída</string>
     <string name="trip_role_book">Topógrafo (desenho)</string>
     <string name="trip_role_instruments">Instrumentos</string>
@@ -435,6 +437,11 @@
     <string name="settings_hot_corners_summary">Arrastar dos cantos do esboço para mover a vista nos modos de desenho</string>
         <string name="settings_team_title">Equipa</string>
     <string name="settings_team_summary">Gerir nomes de espeleólogos conhecidos</string>
+    <string name="settings_copyright_title">Copyright</string>
+    <string name="settings_copyright_summary">Editar a escolha da licença</string>
+    <string name="settings_license_new_hint">Nome da licença</string>
+    <string name="settings_license_name_required">O nome da licença é obrigatório</string>
+    <string name="settings_license_default_label">Predefinida</string>
 <string name="settings_instruments_title">Instrumentos</string>
     <string name="settings_instruments_summary">Tolerâncias dos instrumentos, calibração</string>
     <string name="settings_max_distance_delta_title">Delta de distância máxima (m)</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -442,6 +442,9 @@
     <string name="settings_license_new_hint">Nome da licença</string>
     <string name="settings_license_name_required">O nome da licença é obrigatório</string>
     <string name="settings_license_default_label">Predefinida</string>
+    <string name="license_choice_title">Escolher uma licença predefinida</string>
+    <string name="license_choice_message">Por favor, escolha uma licença para a utilização futura do levantamento. Esta tornar-se-á a predefinida e pode ser substituída em Saída. A GPLv3.0+ é recomendada para dados de levantamento e é a mesma licença sob a qual o SexyTopo é publicado</string>
+    <string name="license_choice_confirm_button">Confirmar</string>
 <string name="settings_instruments_title">Instrumentos</string>
     <string name="settings_instruments_summary">Tolerâncias dos instrumentos, calibração</string>
     <string name="settings_max_distance_delta_title">Delta de distância máxima (m)</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -538,6 +538,8 @@
     <string name="settings_export_svg_grid_summary">Desenhar uma grelha de fundo atrás do levantamento</string>
     <string name="settings_export_svg_tagline_title">Mostrar slogan</string>
     <string name="settings_export_svg_tagline_summary">Dar o devido crédito ao SexyTopo</string>
+    <string name="settings_export_svg_copyright_title">Mostrar copyright/licença na legenda</string>
+    <string name="settings_export_svg_copyright_summary">O copyright e a licença são sempre guardados no arquivo; isto também mostra uma linha de crédito na legenda</string>
     <string name="settings_export_therion_symbols_title">Símbolos de exportação Therion</string>
     <string name="settings_export_therion_symbols_summary">Incluir símbolos ao exportar para formato Therion</string>
     <string name="settings_export_therion_text_title">Texto de exportação Therion</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -486,6 +486,9 @@
     <string name="settings_license_new_hint">License name</string>
     <string name="settings_license_name_required">License name is required</string>
     <string name="settings_license_default_label">Default</string>
+    <string name="license_choice_title">Choose a Default License</string>
+    <string name="license_choice_message">Please pick a license for the future use of the survey. This will become the default and can be written over in Trip. GPLv3.0+ is encouraged for survey data and is the same license that Sexytopo is published under</string>
+    <string name="license_choice_confirm_button">Confirm</string>
     <string name="settings_instruments_title">Instruments</string>
     <string name="settings_leg_amalgamation_algorithm_title">Leg agreement method</string>
     <string name="settings_leg_amalgamation_algorithm_summary">How repeated readings are judged close enough to form a leg</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -412,6 +412,8 @@
     <string name="trip_dialog_name_required">Name is required</string>
     <string name="trip_dialog_confirm_clear_trip">Clear Trip Data?</string>
     <string name="trip_comments">Comments</string>
+    <string name="trip_copyright_label">Copyright</string>
+    <string name="trip_license_label">License</string>
     <string name="trip_save_trip">Save Trip</string>
     <string name="trip_role_book">Book (drawing)</string>
     <string name="trip_role_instruments">Instruments</string>
@@ -479,6 +481,11 @@
     <string name="settings_hot_corners_summary">Drag from the corners of the sketch to move the view in drawing modes</string>
     <string name="settings_team_title">Team</string>
     <string name="settings_team_summary">Manage known caver names</string>
+    <string name="settings_copyright_title">Copyright</string>
+    <string name="settings_copyright_summary">Edit the license choice</string>
+    <string name="settings_license_new_hint">License name</string>
+    <string name="settings_license_name_required">License name is required</string>
+    <string name="settings_license_default_label">Default</string>
     <string name="settings_instruments_title">Instruments</string>
     <string name="settings_leg_amalgamation_algorithm_title">Leg agreement method</string>
     <string name="settings_leg_amalgamation_algorithm_summary">How repeated readings are judged close enough to form a leg</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -588,6 +588,8 @@
     <string name="settings_export_svg_grid_summary">Draw a background grid behind the survey</string>
     <string name="settings_export_svg_tagline_title">Show tagline</string>
     <string name="settings_export_svg_tagline_summary">Provide proper credit to SexyTopo</string>
+    <string name="settings_export_svg_copyright_title">Show copyright/license in legend</string>
+    <string name="settings_export_svg_copyright_summary">Copyright and license are always saved in the file; this also displays a credit line in the legend</string>
     <string name="settings_export_therion_title">Therion</string>
     <string name="settings_export_therion_section_summary">Therion export options</string>
     <string name="settings_export_therion_plan_suffix_title">Plan file suffix</string>

--- a/app/src/main/res/xml/preferences_export_svg.xml
+++ b/app/src/main/res/xml/preferences_export_svg.xml
@@ -75,6 +75,12 @@
         android:summary="@string/settings_export_svg_tagline_summary"
         android:defaultValue="true" />
 
+    <CheckBoxPreference
+        android:key="pref_export_svg_copyright"
+        android:title="@string/settings_export_svg_copyright_title"
+        android:summary="@string/settings_export_svg_copyright_summary"
+        android:defaultValue="true" />
+
     <EditTextPreference
         android:key="pref_export_svg_stroke_width"
         android:title="@string/settings_export_svg_stroke_width_title"

--- a/app/src/main/res/xml/preferences_main.xml
+++ b/app/src/main/res/xml/preferences_main.xml
@@ -33,6 +33,12 @@
         app:fragment="org.hwyl.sexytopo.control.activity.SettingsActivity$TeamFragment" />
 
     <Preference
+        android:key="pref_section_copyright"
+        android:title="@string/settings_copyright_title"
+        android:summary="@string/settings_copyright_summary"
+        app:fragment="org.hwyl.sexytopo.control.activity.SettingsActivity$CopyrightFragment" />
+
+    <Preference
         android:key="pref_section_instruments"
         android:title="@string/settings_instruments_title"
         android:summary="@string/settings_instruments_summary"

--- a/app/src/test/java/org/hwyl/sexytopo/control/activity/LicenseChoiceActivityTest.java
+++ b/app/src/test/java/org/hwyl/sexytopo/control/activity/LicenseChoiceActivityTest.java
@@ -1,0 +1,79 @@
+package org.hwyl.sexytopo.control.activity;
+
+import android.widget.Button;
+import android.widget.Spinner;
+import org.hwyl.sexytopo.R;
+import org.hwyl.sexytopo.control.util.GeneralPreferences;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.android.controller.ActivityController;
+
+@RunWith(RobolectricTestRunner.class)
+public class LicenseChoiceActivityTest {
+
+    @Before
+    public void setUp() {
+        GeneralPreferences.initialise(RuntimeEnvironment.getApplication());
+    }
+
+    private static LicenseChoiceActivity buildActivity() {
+        ActivityController<LicenseChoiceActivity> controller =
+                Robolectric.buildActivity(LicenseChoiceActivity.class).setup();
+        return controller.get();
+    }
+
+    @Test
+    public void testSpinnerIsPopulatedFromLicenseOptions() {
+        LicenseChoiceActivity activity = buildActivity();
+        Spinner spinner = activity.findViewById(R.id.license_choice_spinner);
+
+        Assert.assertEquals(GeneralPreferences.getLicenseOptions().size(), spinner.getCount());
+    }
+
+    @Test
+    public void testSpinnerIsPreselectedToGplv3() {
+        LicenseChoiceActivity activity = buildActivity();
+        Spinner spinner = activity.findViewById(R.id.license_choice_spinner);
+
+        Assert.assertEquals("GPLv3.0+", spinner.getSelectedItem());
+    }
+
+    @Test
+    public void testConfirmPersistsSelectedChoiceAndSetsConfirmedFlag() {
+        LicenseChoiceActivity activity = buildActivity();
+        Spinner spinner = activity.findViewById(R.id.license_choice_spinner);
+
+        int ccZeroIndex = -1;
+        for (int i = 0; i < spinner.getCount(); i++) {
+            if ("CC0".equals(spinner.getItemAtPosition(i))) {
+                ccZeroIndex = i;
+                break;
+            }
+        }
+        Assert.assertTrue("CC0 should be one of the seed license options", ccZeroIndex >= 0);
+        spinner.setSelection(ccZeroIndex);
+
+        Button confirmButton = activity.findViewById(R.id.license_choice_confirm_button);
+        confirmButton.performClick();
+
+        Assert.assertTrue(GeneralPreferences.isLicenseDefaultConfirmed());
+        Assert.assertEquals("CC0", GeneralPreferences.getDefaultLicenseName());
+        Assert.assertTrue(activity.isFinishing());
+    }
+
+    @Test
+    public void testBackPressAlsoConfirmsWhateverIsCurrentlySelected() {
+        LicenseChoiceActivity activity = buildActivity();
+
+        activity.onBackPressed();
+
+        Assert.assertTrue(GeneralPreferences.isLicenseDefaultConfirmed());
+        Assert.assertEquals("GPLv3.0+", GeneralPreferences.getDefaultLicenseName());
+        Assert.assertTrue(activity.isFinishing());
+    }
+}

--- a/app/src/test/java/org/hwyl/sexytopo/control/io/basic/SurveyJsonTranslaterTest.java
+++ b/app/src/test/java/org/hwyl/sexytopo/control/io/basic/SurveyJsonTranslaterTest.java
@@ -76,4 +76,36 @@ public class SurveyJsonTranslaterTest {
         Assert.assertEquals("DistoX BLE", loaded.getInstrument());
         Assert.assertTrue(loaded.hasInstrument());
     }
+
+    @Test
+    public void testTripCopyrightAndLicenseRoundTrip() throws Exception {
+        Trip trip = new Trip();
+        trip.setCopyright("Jane Caver");
+        trip.setLicense("CC BY 4.0");
+
+        JSONObject json = SurveyJsonTranslater.toJson(trip);
+        Trip loaded = SurveyJsonTranslater.toTrip(json);
+
+        Assert.assertEquals("Jane Caver", loaded.getCopyright());
+        Assert.assertEquals("CC BY 4.0", loaded.getLicense());
+        Assert.assertTrue(loaded.hasCopyright());
+        Assert.assertTrue(loaded.hasLicense());
+    }
+
+    @Test
+    public void testOldTripJsonWithoutCopyrightOrLicenseDefaultsToEmptyStrings() throws Exception {
+        Trip trip = new Trip();
+        trip.setInstrument("DistoX BLE");
+
+        JSONObject json = SurveyJsonTranslater.toJson(trip);
+        json.remove(SurveyJsonTranslater.COPYRIGHT_TAG);
+        json.remove(SurveyJsonTranslater.LICENSE_TAG);
+
+        Trip loaded = SurveyJsonTranslater.toTrip(json);
+
+        Assert.assertEquals("", loaded.getCopyright());
+        Assert.assertEquals("", loaded.getLicense());
+        Assert.assertFalse(loaded.hasCopyright());
+        Assert.assertFalse(loaded.hasLicense());
+    }
 }

--- a/app/src/test/java/org/hwyl/sexytopo/control/io/thirdparty/survex/SurvexExporterTest.java
+++ b/app/src/test/java/org/hwyl/sexytopo/control/io/thirdparty/survex/SurvexExporterTest.java
@@ -164,6 +164,74 @@ public class SurvexExporterTest {
         Assert.assertTrue(metadata.contains(";*date explored "));
     }
 
+    @Test
+    public void testCreationCommentThenCopyrightOrder() {
+        // Regression test: the created-with comment must be the first line inside the
+        // survey block, with the copyright/license line immediately after it.
+        SurvexExporter survexExporter = new SurvexExporter();
+        Survey survey = BasicTestSurveyCreator.createStraightNorth();
+        Trip trip = new Trip();
+        trip.setCopyright("Caver Jane");
+        trip.setLicense("CC BY 4.0");
+        survey.setTrip(trip);
+
+        String content = survexExporter.getContent(survey);
+        String[] lines = content.split("\n");
+
+        Assert.assertTrue(lines[0].startsWith("*begin "));
+        Assert.assertTrue(lines[1].startsWith("; Created with SexyTopo"));
+
+        String expectedCopyrightLine =
+                SurvexTherionUtil.getCopyrightLine(survey, SurveyFormat.SURVEX).trim();
+        Assert.assertEquals(expectedCopyrightLine, lines[2]);
+    }
+
+    @Test
+    public void testCreationCommentImmediatelyAfterBeginWhenNoCopyright() {
+        // The creation comment's position must not depend on whether a copyright/license
+        // is set.
+        SurvexExporter survexExporter = new SurvexExporter();
+        Survey survey = BasicTestSurveyCreator.createStraightNorth();
+        Trip trip = new Trip();
+        survey.setTrip(trip);
+
+        String content = survexExporter.getContent(survey);
+        String[] lines = content.split("\n");
+
+        Assert.assertTrue(lines[0].startsWith("*begin "));
+        Assert.assertTrue(lines[1].startsWith("; Created with SexyTopo"));
+    }
+
+    @Test
+    public void testBlankLineSeparatesHeaderFromMetadata() {
+        SurvexExporter survexExporter = new SurvexExporter();
+        Survey survey = BasicTestSurveyCreator.createStraightNorth();
+        Trip trip = new Trip();
+        trip.setCopyright("Caver Jane");
+        trip.setLicense("CC BY 4.0");
+        survey.setTrip(trip);
+
+        String content = survexExporter.getContent(survey);
+        String[] lines = content.split("\n");
+
+        // lines[0] = *begin, lines[1] = creation comment, lines[2] = copyright,
+        // lines[3] must be blank, separating the header from the metadata block.
+        Assert.assertEquals("", lines[3]);
+        Assert.assertTrue(lines[4].startsWith("*date "));
+    }
+
+    @Test
+    public void testNoCopyrightLineWhenTripHasNeitherCopyrightNorLicense() {
+        SurvexExporter survexExporter = new SurvexExporter();
+        Survey survey = BasicTestSurveyCreator.createStraightNorth();
+        Trip trip = new Trip();
+        survey.setTrip(trip);
+
+        String content = survexExporter.getContent(survey);
+
+        Assert.assertFalse(content.contains("*copyright"));
+    }
+
     private static Trip.TeamEntry entry(String name, Trip.Role... roles) {
         return new Trip.TeamEntry(name, Arrays.asList(roles));
     }

--- a/app/src/test/java/org/hwyl/sexytopo/control/io/thirdparty/survextherion/SurvexTherionUtilTest.java
+++ b/app/src/test/java/org/hwyl/sexytopo/control/io/thirdparty/survextherion/SurvexTherionUtilTest.java
@@ -1,0 +1,88 @@
+package org.hwyl.sexytopo.control.io.thirdparty.survextherion;
+
+import java.util.Calendar;
+import java.util.Date;
+import org.hwyl.sexytopo.model.survey.Survey;
+import org.hwyl.sexytopo.model.survey.Trip;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SurvexTherionUtilTest {
+
+    @Test
+    public void testSurvexLineWithBothCopyrightAndLicense() {
+        Survey survey = surveyWithTrip("Caver Jane", "CC BY 4.0", 2026);
+
+        String line = SurvexTherionUtil.getCopyrightLine(survey, SurveyFormat.SURVEX);
+
+        Assert.assertEquals("*copyright 2026 \"Caver Jane\" ;\"CC BY 4.0\"\n", line);
+    }
+
+    @Test
+    public void testTherionLineWithBothCopyrightAndLicense() {
+        Survey survey = surveyWithTrip("Caver Jane", "CC BY 4.0", 2026);
+
+        String line = SurvexTherionUtil.getCopyrightLine(survey, SurveyFormat.THERION);
+
+        Assert.assertEquals("copyright 2026 \"Caver Jane\" #\"CC BY 4.0\"\n", line);
+    }
+
+    @Test
+    public void testCopyrightOnlyOmitsTrailingComment() {
+        Survey survey = surveyWithTrip("Caver Jane", "", 2026);
+
+        String line = SurvexTherionUtil.getCopyrightLine(survey, SurveyFormat.THERION);
+
+        Assert.assertEquals("copyright 2026 \"Caver Jane\"\n", line);
+    }
+
+    @Test
+    public void testLicenseOnlyFillsCopyrightWithEmptyQuotes() {
+        Survey survey = surveyWithTrip("", "CC BY 4.0", 2026);
+
+        String line = SurvexTherionUtil.getCopyrightLine(survey, SurveyFormat.THERION);
+
+        Assert.assertEquals("copyright 2026 \"\" #\"CC BY 4.0\"\n", line);
+    }
+
+    @Test
+    public void testNeitherCopyrightNorLicenseSetReturnsEmptyString() {
+        Survey survey = surveyWithTrip("", "", 2026);
+
+        Assert.assertEquals("", SurvexTherionUtil.getCopyrightLine(survey, SurveyFormat.SURVEX));
+        Assert.assertEquals("", SurvexTherionUtil.getCopyrightLine(survey, SurveyFormat.THERION));
+    }
+
+    @Test
+    public void testNullTripReturnsEmptyString() {
+        Survey survey = new Survey();
+
+        Assert.assertEquals("", SurvexTherionUtil.getCopyrightLine(survey, SurveyFormat.SURVEX));
+        Assert.assertEquals("", SurvexTherionUtil.getCopyrightLine(survey, SurveyFormat.THERION));
+    }
+
+    @Test
+    public void testYearIsTakenFromTripSurveyDate() {
+        Survey survey = surveyWithTrip("Caver Jane", "", 1998);
+
+        String line = SurvexTherionUtil.getCopyrightLine(survey, SurveyFormat.THERION);
+
+        Assert.assertEquals("copyright 1998 \"Caver Jane\"\n", line);
+    }
+
+    private static Survey surveyWithTrip(String copyright, String license, int year) {
+        Survey survey = new Survey();
+        Trip trip = new Trip();
+        trip.setSurveyDate(dateForYear(year));
+        trip.setCopyright(copyright);
+        trip.setLicense(license);
+        survey.setTrip(trip);
+        return survey;
+    }
+
+    private static Date dateForYear(int year) {
+        Calendar calendar = Calendar.getInstance();
+        calendar.set(Calendar.YEAR, year);
+        return calendar.getTime();
+    }
+}

--- a/app/src/test/java/org/hwyl/sexytopo/control/io/thirdparty/svg/SvgExporterTest.java
+++ b/app/src/test/java/org/hwyl/sexytopo/control/io/thirdparty/svg/SvgExporterTest.java
@@ -1,0 +1,129 @@
+package org.hwyl.sexytopo.control.io.thirdparty.svg;
+
+import android.content.SharedPreferences;
+import java.text.SimpleDateFormat;
+import org.hwyl.sexytopo.control.util.GeneralPreferences;
+import org.hwyl.sexytopo.model.graph.Projection2D;
+import org.hwyl.sexytopo.model.survey.Survey;
+import org.hwyl.sexytopo.model.survey.Trip;
+import org.hwyl.sexytopo.testutils.ExampleSurveyCreator;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+
+@RunWith(RobolectricTestRunner.class)
+public class SvgExporterTest {
+
+    @Before
+    public void setUp() {
+        GeneralPreferences.initialise(RuntimeEnvironment.getApplication());
+    }
+
+    private static Survey surveyWithTrip(Trip trip) {
+        Survey survey = ExampleSurveyCreator.create(5, 2);
+        survey.setTrip(trip);
+        return survey;
+    }
+
+    @Test
+    public void testCopyrightAndLicenseAppearInLegendAndDesc() throws Exception {
+        Trip trip = new Trip();
+        trip.setCopyright("Caver Jane");
+        trip.setLicense("CC BY 4.0");
+        Survey survey = surveyWithTrip(trip);
+
+        String content = new SvgExporter().getContent(survey, Projection2D.PLAN);
+
+        Assert.assertTrue(content.contains("Caver Jane"));
+        Assert.assertTrue(content.contains("CC BY 4.0"));
+        Assert.assertTrue(content.contains("<desc>"));
+        Assert.assertTrue(content.contains("<title>"));
+    }
+
+    @Test
+    public void testCopyrightLineOmittedFromLegendButDescStillPresentWhenOptionDisabled()
+            throws Exception {
+        SharedPreferences prefs = GeneralPreferences.getRawPreferences();
+        Assert.assertNotNull(prefs);
+        prefs.edit().putBoolean("pref_export_svg_copyright", false).apply();
+
+        Trip trip = new Trip();
+        trip.setCopyright("Caver Jane");
+        trip.setLicense("CC BY 4.0");
+        Survey survey = surveyWithTrip(trip);
+
+        String content = new SvgExporter().getContent(survey, Projection2D.PLAN);
+
+        // The desc element (non-visual metadata) is independent of the legend toggle, so it
+        // should still be present...
+        Assert.assertTrue(content.contains("<desc>"));
+
+        // ...but the copyright text should now appear only once (inside <desc>), not a second
+        // time as a visible legend line.
+        int occurrences = content.split("Caver Jane", -1).length - 1;
+        Assert.assertEquals(1, occurrences);
+    }
+
+    @Test
+    public void testNoTitleOrDescWhenNeitherCopyrightNorLicenseSet() throws Exception {
+        Survey survey = ExampleSurveyCreator.create(5, 2); // no trip set at all
+
+        String content = new SvgExporter().getContent(survey, Projection2D.PLAN);
+
+        Assert.assertFalse(content.contains("<desc>"));
+        Assert.assertFalse(content.contains("<title>"));
+    }
+
+    @Test
+    public void testCopyrightOnlyOmitsLicenseText() throws Exception {
+        Trip trip = new Trip();
+        trip.setCopyright("Caver Jane");
+        Survey survey = surveyWithTrip(trip);
+
+        String content = new SvgExporter().getContent(survey, Projection2D.PLAN);
+
+        Assert.assertTrue(content.contains("Caver Jane"));
+        Assert.assertTrue(content.contains("\u00A9"));
+        Assert.assertFalse(content.contains("CC BY"));
+    }
+
+    @Test
+    public void testLicenseOnlyOmitsCopyrightSymbol() throws Exception {
+        Trip trip = new Trip();
+        trip.setLicense("CC BY 4.0");
+        Survey survey = surveyWithTrip(trip);
+
+        String content = new SvgExporter().getContent(survey, Projection2D.PLAN);
+
+        Assert.assertTrue(content.contains("CC BY 4.0"));
+        Assert.assertFalse(content.contains("\u00A9"));
+    }
+
+    @Test
+    public void testCopyrightIncludesYearAfterSymbol() throws Exception {
+        Trip trip = new Trip();
+        trip.setSurveyDate(new SimpleDateFormat("yyyy-MM-dd").parse("2024-06-15"));
+        trip.setCopyright("Caver Jane");
+        trip.setLicense("CC BY 4.0");
+        Survey survey = surveyWithTrip(trip);
+
+        String content = new SvgExporter().getContent(survey, Projection2D.PLAN);
+
+        Assert.assertTrue(content.contains("\u00A9 2024 Caver Jane"));
+    }
+
+    @Test
+    public void testCopyrightYearOmittedWhenSurveyDateNull() throws Exception {
+        Trip trip = new Trip();
+        trip.setSurveyDate(null);
+        trip.setCopyright("Caver Jane");
+        Survey survey = surveyWithTrip(trip);
+
+        String content = new SvgExporter().getContent(survey, Projection2D.PLAN);
+
+        Assert.assertTrue(content.contains("\u00A9 Caver Jane"));
+    }
+}

--- a/app/src/test/java/org/hwyl/sexytopo/control/io/thirdparty/therion/Th2ExporterTest.java
+++ b/app/src/test/java/org/hwyl/sexytopo/control/io/thirdparty/therion/Th2ExporterTest.java
@@ -1,11 +1,14 @@
 package org.hwyl.sexytopo.control.io.thirdparty.therion;
 
 import org.hwyl.sexytopo.control.io.basic.ExportFrameFactory;
+import org.hwyl.sexytopo.control.io.thirdparty.survextherion.SurvexTherionUtil;
+import org.hwyl.sexytopo.control.io.thirdparty.survextherion.SurveyFormat;
 import org.hwyl.sexytopo.model.common.Frame;
 import org.hwyl.sexytopo.model.graph.Coord2D;
 import org.hwyl.sexytopo.model.graph.Projection2D;
 import org.hwyl.sexytopo.model.graph.Space;
 import org.hwyl.sexytopo.model.survey.Survey;
+import org.hwyl.sexytopo.model.survey.Trip;
 import org.hwyl.sexytopo.testutils.BasicTestSurveyCreator;
 import org.junit.Assert;
 import org.junit.Test;
@@ -24,5 +27,59 @@ public class Th2ExporterTest {
                 Th2Exporter.getContent(
                         survey, projection, space, "filename.xvi", exportFrame, exportFrame, scale);
         Assert.assertTrue(th2.contains("##XTHERION##"));
+    }
+
+    @Test
+    public void testCopyrightLineAppearsAfterScrapLineInEveryScrap() {
+        // createWithCrossSections() gives us one main "plan" scrap plus two cross-section
+        // scraps, so this exercises both getScrap() and getCrossSectionScrap().
+        Survey survey = BasicTestSurveyCreator.createWithCrossSections();
+        Trip trip = new Trip();
+        trip.setCopyright("Caver Jane");
+        trip.setLicense("CC BY 4.0");
+        survey.setTrip(trip);
+
+        float scale = TherionExporter.getScale();
+        Projection2D projection = Projection2D.PLAN;
+        Frame exportFrame = ExportFrameFactory.getExportFrame(survey, projection);
+        Space<Coord2D> space = projection.project(survey);
+        exportFrame = exportFrame.scale(scale);
+        String th2 =
+                Th2Exporter.getContent(
+                        survey, projection, space, "filename.xvi", exportFrame, exportFrame, scale);
+
+        String expectedCopyrightLine =
+                SurvexTherionUtil.getCopyrightLine(survey, SurveyFormat.THERION).trim();
+
+        String[] lines = th2.split("\n");
+        int scrapLineCount = 0;
+        for (int i = 0; i < lines.length; i++) {
+            if (lines[i].startsWith("scrap ")) {
+                scrapLineCount++;
+                Assert.assertEquals(
+                        "Copyright line should immediately follow: " + lines[i],
+                        expectedCopyrightLine,
+                        lines[i + 1]);
+            }
+        }
+        // One main "plan" scrap + two cross-section scraps
+        Assert.assertEquals(3, scrapLineCount);
+    }
+
+    @Test
+    public void testNoCopyrightLineWhenTripHasNeitherCopyrightNorLicense() {
+        Survey survey = BasicTestSurveyCreator.createWithCrossSections();
+        // No trip set at all, matching a survey that has never used this feature.
+
+        float scale = TherionExporter.getScale();
+        Projection2D projection = Projection2D.PLAN;
+        Frame exportFrame = ExportFrameFactory.getExportFrame(survey, projection);
+        Space<Coord2D> space = projection.project(survey);
+        exportFrame = exportFrame.scale(scale);
+        String th2 =
+                Th2Exporter.getContent(
+                        survey, projection, space, "filename.xvi", exportFrame, exportFrame, scale);
+
+        Assert.assertFalse(th2.contains("copyright"));
     }
 }

--- a/app/src/test/java/org/hwyl/sexytopo/control/io/thirdparty/therion/ThExporterTest.java
+++ b/app/src/test/java/org/hwyl/sexytopo/control/io/thirdparty/therion/ThExporterTest.java
@@ -42,6 +42,24 @@ public class ThExporterTest {
     }
 
     @Test
+    public void testReplaceCentrelineDoesNotMergeWithPrecedingLine() {
+        // Regression test: the blank line separating the preceding content from the
+        // centreline block must be preserved, not swallowed into a single merged line.
+        String updated = ThExporter.replaceCentreline(TEST_CONTENT, "centreline\nreplacement\n");
+        String[] lines = updated.split("\n");
+
+        Assert.assertTrue(indexOfLine(lines, "input dafung-down-westEe.th2") >= 0);
+        Assert.assertTrue(indexOfLine(lines, "centreline") >= 0);
+    }
+
+    @Test
+    public void testReplaceCentrelinePreservesTextBeforeBlock() {
+        String updated = ThExporter.replaceCentreline(TEST_CONTENT, "centreline\nreplacement\n");
+        Assert.assertTrue(updated.contains("input dafung-down-west.th2"));
+        Assert.assertTrue(updated.contains("input dafung-down-westEe.th2"));
+    }
+
+    @Test
     public void testReplaceInputs() {
         String updated = ThExporter.replaceInputsText(TEST_CONTENT, "input replacement");
         Assert.assertTrue(updated.contains("input replacement"));
@@ -181,6 +199,47 @@ public class ThExporterTest {
         String metadata = SurvexTherionUtil.getMetadata(survey, SurveyFormat.THERION, "", "");
 
         Assert.assertTrue(metadata.contains("#explo-date "));
+    }
+
+    @Test
+    public void testCopyrightLineIsImmediatelyAfterCentreline() {
+        Survey survey = new Survey();
+        Trip trip = new Trip();
+        trip.setCopyright("Caver Jane");
+        trip.setLicense("CC BY 4.0");
+        survey.setTrip(trip);
+
+        String updated =
+                ThExporter.updateOriginalContent(survey, TEST_CONTENT, Collections.emptyList());
+        String[] lines = updated.split("\n");
+
+        int centrelineIndex = indexOfLine(lines, "centreline");
+        Assert.assertTrue("centreline line not found", centrelineIndex >= 0);
+
+        String expectedCopyrightLine =
+                SurvexTherionUtil.getCopyrightLine(survey, SurveyFormat.THERION).trim();
+        Assert.assertEquals(expectedCopyrightLine, lines[centrelineIndex + 1]);
+    }
+
+    @Test
+    public void testNoCopyrightLineWhenTripHasNeitherCopyrightNorLicense() {
+        Survey survey = new Survey();
+        Trip trip = new Trip();
+        survey.setTrip(trip);
+
+        String updated =
+                ThExporter.updateOriginalContent(survey, TEST_CONTENT, Collections.emptyList());
+
+        Assert.assertFalse(updated.contains("copyright"));
+    }
+
+    private static int indexOfLine(String[] lines, String target) {
+        for (int i = 0; i < lines.length; i++) {
+            if (lines[i].equals(target)) {
+                return i;
+            }
+        }
+        return -1;
     }
 
     private static Trip.TeamEntry entry(String name, Trip.Role... roles) {

--- a/app/src/test/java/org/hwyl/sexytopo/control/io/thirdparty/therion/TherionImporterTest.java
+++ b/app/src/test/java/org/hwyl/sexytopo/control/io/thirdparty/therion/TherionImporterTest.java
@@ -2,13 +2,16 @@ package org.hwyl.sexytopo.control.io.thirdparty.therion;
 
 import java.util.Arrays;
 import java.util.List;
+import org.hwyl.sexytopo.control.io.thirdparty.survex.SurvexExporter;
 import org.hwyl.sexytopo.control.io.thirdparty.survextherion.SurvexTherionImporter;
+import org.hwyl.sexytopo.control.io.thirdparty.survextherion.SurvexTherionUtil;
 import org.hwyl.sexytopo.control.io.thirdparty.survextherion.SurveyFormat;
 import org.hwyl.sexytopo.model.graph.Direction;
 import org.hwyl.sexytopo.model.survey.Leg;
 import org.hwyl.sexytopo.model.survey.Station;
 import org.hwyl.sexytopo.model.survey.Survey;
 import org.hwyl.sexytopo.model.survey.Trip;
+import org.hwyl.sexytopo.testutils.BasicTestSurveyCreator;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -545,6 +548,93 @@ public class TherionImporterTest {
         Assert.assertNotNull(trip);
         Assert.assertNull(trip.getInstrument());
         Assert.assertFalse(trip.hasInstrument());
+    }
+
+    @Test
+    public void testSurvexCopyrightAndLicenseImport() throws Exception {
+        String survexText =
+                "*date 2026.01.05\n" + "*copyright 2026 \"Caver Jane\" ;\"CC BY 4.0\"\n";
+
+        Trip trip = SurvexTherionImporter.parseMetadata(survexText, SurveyFormat.SURVEX);
+        Assert.assertNotNull(trip);
+        Assert.assertEquals("Caver Jane", trip.getCopyright());
+        Assert.assertEquals("CC BY 4.0", trip.getLicense());
+    }
+
+    @Test
+    public void testTherionCopyrightAndLicenseImport() throws Exception {
+        String therionText = "date 2026.01.05\n" + "copyright 2026 \"Caver Jane\" #\"CC BY 4.0\"\n";
+
+        Trip trip = SurvexTherionImporter.parseMetadata(therionText, SurveyFormat.THERION);
+        Assert.assertNotNull(trip);
+        Assert.assertEquals("Caver Jane", trip.getCopyright());
+        Assert.assertEquals("CC BY 4.0", trip.getLicense());
+    }
+
+    @Test
+    public void testCopyrightWithoutLicenseImport() throws Exception {
+        String survexText = "*date 2026.01.05\n" + "*copyright 2026 \"Caver Jane\"\n";
+
+        Trip trip = SurvexTherionImporter.parseMetadata(survexText, SurveyFormat.SURVEX);
+        Assert.assertNotNull(trip);
+        Assert.assertEquals("Caver Jane", trip.getCopyright());
+        Assert.assertFalse(trip.hasLicense());
+    }
+
+    @Test
+    public void testLicenseWithoutCopyrightImport() throws Exception {
+        String survexText = "*date 2026.01.05\n" + "*copyright 2026 \"\" ;\"CC BY 4.0\"\n";
+
+        Trip trip = SurvexTherionImporter.parseMetadata(survexText, SurveyFormat.SURVEX);
+        Assert.assertNotNull(trip);
+        Assert.assertFalse(trip.hasCopyright());
+        Assert.assertEquals("CC BY 4.0", trip.getLicense());
+    }
+
+    @Test
+    public void testNoCopyrightLineLeavesDefaultsImport() throws Exception {
+        String survexText = "*date 2026.01.05\n" + "*instrument insts \"DistoX2\"\n";
+
+        Trip trip = SurvexTherionImporter.parseMetadata(survexText, SurveyFormat.SURVEX);
+        Assert.assertNotNull(trip);
+        Assert.assertFalse(trip.hasCopyright());
+        Assert.assertFalse(trip.hasLicense());
+    }
+
+    @Test
+    public void testCopyrightLicenseRoundTripSurvex() throws Exception {
+        Survey survey = BasicTestSurveyCreator.createStraightNorth();
+        Trip trip = new Trip();
+        trip.setCopyright("Caver Jane");
+        trip.setLicense("CC BY 4.0");
+        survey.setTrip(trip);
+
+        String content = new SurvexExporter().getContent(survey);
+        Trip imported = SurvexTherionImporter.parseMetadata(content, SurveyFormat.SURVEX);
+
+        Assert.assertNotNull(imported);
+        Assert.assertEquals("Caver Jane", imported.getCopyright());
+        Assert.assertEquals("CC BY 4.0", imported.getLicense());
+    }
+
+    @Test
+    public void testCopyrightLicenseRoundTripTherion() throws Exception {
+        Survey survey = BasicTestSurveyCreator.createStraightNorth();
+        Trip trip = new Trip();
+        trip.setCopyright("Caver Jane");
+        trip.setLicense("CC BY 4.0");
+        survey.setTrip(trip);
+
+        String centrelineText =
+                "centreline\n"
+                        + SurvexTherionUtil.getCopyrightLine(survey, SurveyFormat.THERION)
+                        + SurvexTherionUtil.getMetadata(survey, SurveyFormat.THERION, "", "")
+                        + "\nendcentreline\n";
+        Trip imported = SurvexTherionImporter.parseMetadata(centrelineText, SurveyFormat.THERION);
+
+        Assert.assertNotNull(imported);
+        Assert.assertEquals("Caver Jane", imported.getCopyright());
+        Assert.assertEquals("CC BY 4.0", imported.getLicense());
     }
 
     // Splays from later stations can appear before the first real leg in

--- a/app/src/test/java/org/hwyl/sexytopo/control/util/GeneralPreferencesLicenseTest.java
+++ b/app/src/test/java/org/hwyl/sexytopo/control/util/GeneralPreferencesLicenseTest.java
@@ -37,6 +37,11 @@ public class GeneralPreferencesLicenseTest {
     }
 
     @Test
+    public void testIsLicenseDefaultConfirmedFalseByDefault() {
+        Assert.assertFalse(GeneralPreferences.isLicenseDefaultConfirmed());
+    }
+
+    @Test
     public void testLicenseOptionsToJsonAndFromJsonRoundTrip() throws Exception {
         List<LicenseOption> options =
                 Arrays.asList(new LicenseOption("CC0", false), new LicenseOption("GPLv3.0+", true));

--- a/app/src/test/java/org/hwyl/sexytopo/control/util/GeneralPreferencesLicenseTest.java
+++ b/app/src/test/java/org/hwyl/sexytopo/control/util/GeneralPreferencesLicenseTest.java
@@ -1,0 +1,151 @@
+package org.hwyl.sexytopo.control.util;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.hwyl.sexytopo.model.survey.LicenseOption;
+import org.json.JSONArray;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class GeneralPreferencesLicenseTest {
+
+    @Test
+    public void testGetLicenseOptionsReturnsSeedDefaultsWhenNoPrefs() {
+        List<LicenseOption> options = GeneralPreferences.getLicenseOptions();
+
+        Assert.assertEquals(6, options.size());
+        Assert.assertEquals("GPLv3.0+", options.get(0).getName());
+        Assert.assertEquals("CC0", options.get(1).getName());
+        Assert.assertEquals("CC BY 4.0", options.get(2).getName());
+        Assert.assertEquals("CC BY SA 4.0", options.get(3).getName());
+        Assert.assertEquals("CC BY SA NC 4.0", options.get(4).getName());
+        Assert.assertEquals("All rights reserved", options.get(5).getName());
+        Assert.assertTrue(options.get(0).isDefault());
+
+        int defaultCount = 0;
+        for (LicenseOption option : options) {
+            if (option.isDefault()) defaultCount++;
+        }
+        Assert.assertEquals(1, defaultCount);
+    }
+
+    @Test
+    public void testGetDefaultLicenseNameReturnsGplv3WhenUnset() {
+        Assert.assertEquals("GPLv3.0+", GeneralPreferences.getDefaultLicenseName());
+    }
+
+    @Test
+    public void testLicenseOptionsToJsonAndFromJsonRoundTrip() throws Exception {
+        List<LicenseOption> options =
+                Arrays.asList(new LicenseOption("CC0", false), new LicenseOption("GPLv3.0+", true));
+
+        JSONArray json = GeneralPreferences.licenseOptionsToJson(options);
+        List<LicenseOption> loaded = GeneralPreferences.licenseOptionsFromJson(json.toString());
+
+        Assert.assertEquals(options, loaded);
+    }
+
+    @Test
+    public void testLicenseOptionsFromJsonDefaultsMissingDefaultFlagToFalse() throws Exception {
+        String json = "[{\"name\":\"CC0\"}]";
+        List<LicenseOption> loaded = GeneralPreferences.licenseOptionsFromJson(json);
+
+        Assert.assertEquals(1, loaded.size());
+        Assert.assertEquals("CC0", loaded.get(0).getName());
+        Assert.assertFalse(loaded.get(0).isDefault());
+    }
+
+    @Test
+    public void testWithAddedAppendsNonDefaultEntryToNonEmptyList() {
+        List<LicenseOption> options =
+                Collections.singletonList(new LicenseOption("GPLv3.0+", true));
+        List<LicenseOption> result = GeneralPreferences.withAdded(options, "CC0");
+
+        Assert.assertEquals(2, result.size());
+        Assert.assertEquals("CC0", result.get(1).getName());
+        Assert.assertFalse(result.get(1).isDefault());
+        Assert.assertTrue(result.get(0).isDefault());
+    }
+
+    @Test
+    public void testWithAddedToEmptyListBecomesDefault() {
+        List<LicenseOption> result = GeneralPreferences.withAdded(new ArrayList<>(), "CC0");
+
+        Assert.assertEquals(1, result.size());
+        Assert.assertTrue(result.get(0).isDefault());
+    }
+
+    @Test
+    public void testWithRemovedPromotesFirstRemainingWhenDefaultRemoved() {
+        List<LicenseOption> options =
+                Arrays.asList(
+                        new LicenseOption("CC0", false),
+                        new LicenseOption("GPLv3.0+", true),
+                        new LicenseOption("CC BY 4.0", false));
+
+        List<LicenseOption> result = GeneralPreferences.withRemoved(options, "GPLv3.0+");
+
+        Assert.assertEquals(2, result.size());
+        Assert.assertEquals("CC0", result.get(0).getName());
+        Assert.assertTrue(result.get(0).isDefault());
+        Assert.assertFalse(result.get(1).isDefault());
+    }
+
+    @Test
+    public void testWithRemovedLeavesDefaultUnchangedWhenNonDefaultRemoved() {
+        List<LicenseOption> options =
+                Arrays.asList(new LicenseOption("CC0", false), new LicenseOption("GPLv3.0+", true));
+
+        List<LicenseOption> result = GeneralPreferences.withRemoved(options, "CC0");
+
+        Assert.assertEquals(1, result.size());
+        Assert.assertEquals("GPLv3.0+", result.get(0).getName());
+        Assert.assertTrue(result.get(0).isDefault());
+    }
+
+    @Test
+    public void testWithRemovedLastOptionResultsInEmptyList() {
+        List<LicenseOption> options =
+                Collections.singletonList(new LicenseOption("GPLv3.0+", true));
+        List<LicenseOption> result = GeneralPreferences.withRemoved(options, "GPLv3.0+");
+
+        Assert.assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void testWithRenamedPreservesPositionAndDefaultFlag() {
+        List<LicenseOption> options =
+                Arrays.asList(new LicenseOption("CC0", false), new LicenseOption("GPLv3.0+", true));
+
+        List<LicenseOption> result =
+                GeneralPreferences.withRenamed(options, "GPLv3.0+", "GPLv3.0 only");
+
+        Assert.assertEquals(2, result.size());
+        Assert.assertEquals("CC0", result.get(0).getName());
+        Assert.assertEquals("GPLv3.0 only", result.get(1).getName());
+        Assert.assertTrue(result.get(1).isDefault());
+    }
+
+    @Test
+    public void testWithDefaultSetUnsetsPreviousDefault() {
+        List<LicenseOption> options =
+                Arrays.asList(new LicenseOption("CC0", true), new LicenseOption("GPLv3.0+", false));
+
+        List<LicenseOption> result = GeneralPreferences.withDefaultSet(options, "GPLv3.0+");
+
+        Assert.assertFalse(result.get(0).isDefault());
+        Assert.assertTrue(result.get(1).isDefault());
+    }
+
+    @Test
+    public void testWithDefaultSetIsNoOpForUnknownName() {
+        List<LicenseOption> options =
+                Arrays.asList(new LicenseOption("CC0", true), new LicenseOption("GPLv3.0+", false));
+
+        List<LicenseOption> result = GeneralPreferences.withDefaultSet(options, "Unknown License");
+
+        Assert.assertEquals(options, result);
+    }
+}

--- a/app/src/test/java/org/hwyl/sexytopo/control/util/TextToolsTest.java
+++ b/app/src/test/java/org/hwyl/sexytopo/control/util/TextToolsTest.java
@@ -1,5 +1,7 @@
 package org.hwyl.sexytopo.control.util;
 
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -45,5 +47,19 @@ public class TextToolsTest {
     public void testAdvanceLastNumberWithZeroPadding2() {
         String advanced = TextTools.advanceLastNumber("a09f");
         Assert.assertEquals("a10f", advanced);
+    }
+
+    @Test
+    public void testFormatYear() throws Exception {
+        Date date = new SimpleDateFormat("yyyy-MM-dd").parse("2024-06-15");
+        Assert.assertEquals("2024", TextTools.formatYear(date));
+    }
+
+    @Test
+    public void testFormatYearAtYearBoundary() throws Exception {
+        Date newYearsEve = new SimpleDateFormat("yyyy-MM-dd").parse("2023-12-31");
+        Date newYearsDay = new SimpleDateFormat("yyyy-MM-dd").parse("2024-01-01");
+        Assert.assertEquals("2023", TextTools.formatYear(newYearsEve));
+        Assert.assertEquals("2024", TextTools.formatYear(newYearsDay));
     }
 }

--- a/app/src/test/java/org/hwyl/sexytopo/model/survey/LicenseOptionTest.java
+++ b/app/src/test/java/org/hwyl/sexytopo/model/survey/LicenseOptionTest.java
@@ -1,0 +1,55 @@
+package org.hwyl.sexytopo.model.survey;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class LicenseOptionTest {
+
+    @Test
+    public void testEqualsSameNameAndDefault() {
+        LicenseOption a = new LicenseOption("GPLv3.0+", true);
+        LicenseOption b = new LicenseOption("GPLv3.0+", true);
+        Assert.assertEquals(a, b);
+        Assert.assertEquals(a.hashCode(), b.hashCode());
+    }
+
+    @Test
+    public void testNotEqualDifferentName() {
+        LicenseOption a = new LicenseOption("GPLv3.0+", true);
+        LicenseOption b = new LicenseOption("CC0", true);
+        Assert.assertNotEquals(a, b);
+    }
+
+    @Test
+    public void testNotEqualDifferentDefaultFlag() {
+        LicenseOption a = new LicenseOption("GPLv3.0+", true);
+        LicenseOption b = new LicenseOption("GPLv3.0+", false);
+        Assert.assertNotEquals(a, b);
+    }
+
+    @Test
+    public void testWithDefaultReturnsNewInstanceWithSameName() {
+        LicenseOption original = new LicenseOption("CC0", false);
+        LicenseOption updated = original.withDefault(true);
+
+        Assert.assertEquals("CC0", updated.getName());
+        Assert.assertTrue(updated.isDefault());
+        Assert.assertFalse(original.isDefault());
+    }
+
+    @Test
+    public void testWithNameReturnsNewInstanceWithSameDefaultFlag() {
+        LicenseOption original = new LicenseOption("CC0", true);
+        LicenseOption renamed = original.withName("CC0 (renamed)");
+
+        Assert.assertEquals("CC0 (renamed)", renamed.getName());
+        Assert.assertTrue(renamed.isDefault());
+        Assert.assertEquals("CC0", original.getName());
+    }
+
+    @Test
+    public void testToStringReturnsName() {
+        LicenseOption option = new LicenseOption("CC BY 4.0", false);
+        Assert.assertEquals("CC BY 4.0", option.toString());
+    }
+}

--- a/app/src/test/java/org/hwyl/sexytopo/model/survey/TripTest.java
+++ b/app/src/test/java/org/hwyl/sexytopo/model/survey/TripTest.java
@@ -16,6 +16,8 @@ public class TripTest {
                         new Trip.TeamEntry("Rufus", Arrays.asList(Trip.Role.INSTRUMENTS))));
         trip.setComments("Test comment");
         trip.setInstrument("DistoX");
+        trip.setCopyright("Test Caver");
+        trip.setLicense("GPLv3.0+");
         return trip;
     }
 
@@ -49,6 +51,51 @@ public class TripTest {
         a.setSurveyDate(b.getSurveyDate());
         b.setInstrument("SAP5");
         Assert.assertNotEquals(a, b);
+    }
+
+    @Test
+    public void testNotEqualDifferentCopyright() {
+        Trip a = basicTrip();
+        Trip b = basicTrip();
+        a.setSurveyDate(b.getSurveyDate());
+        b.setCopyright("Someone Else");
+        Assert.assertNotEquals(a, b);
+    }
+
+    @Test
+    public void testNotEqualDifferentLicense() {
+        Trip a = basicTrip();
+        Trip b = basicTrip();
+        a.setSurveyDate(b.getSurveyDate());
+        b.setLicense("CC0");
+        Assert.assertNotEquals(a, b);
+    }
+
+    @Test
+    public void testDefaultCopyrightAndLicenseAreEmpty() {
+        Trip trip = new Trip();
+        Assert.assertEquals("", trip.getCopyright());
+        Assert.assertEquals("", trip.getLicense());
+        Assert.assertFalse(trip.hasCopyright());
+        Assert.assertFalse(trip.hasLicense());
+    }
+
+    @Test
+    public void testHasCopyrightAndHasLicenseWhenSet() {
+        Trip trip = new Trip();
+        trip.setCopyright("Jane Caver");
+        trip.setLicense("CC0");
+        Assert.assertTrue(trip.hasCopyright());
+        Assert.assertTrue(trip.hasLicense());
+    }
+
+    @Test
+    public void testHasCopyrightAndHasLicenseFalseForWhitespaceOnly() {
+        Trip trip = new Trip();
+        trip.setCopyright("   ");
+        trip.setLicense("   ");
+        Assert.assertFalse(trip.hasCopyright());
+        Assert.assertFalse(trip.hasLicense());
     }
 
     @Test
@@ -139,6 +186,22 @@ public class TripTest {
         Trip next = original.toNextTrip();
         Assert.assertEquals(original.getTeam(), next.getTeam());
         Assert.assertEquals(original.getInstrument(), next.getInstrument());
+    }
+
+    @Test
+    public void testToNextTripCopiesCopyrightAndLicense() {
+        Trip original = basicTrip();
+        Trip next = original.toNextTrip();
+        Assert.assertEquals(original.getCopyright(), next.getCopyright());
+        Assert.assertEquals(original.getLicense(), next.getLicense());
+    }
+
+    @Test
+    public void testCopyIncludesCopyrightAndLicense() {
+        Trip original = basicTrip();
+        Trip copy = new Trip(original);
+        Assert.assertEquals(original.getCopyright(), copy.getCopyright());
+        Assert.assertEquals(original.getLicense(), copy.getLicense());
     }
 
     @Test

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         gradlePluginPortal()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:9.0.1'
+        classpath 'com.android.tools.build:gradle:9.2.1'
         classpath 'com.diffplug.spotless:spotless-plugin-gradle:6.25.0'
     }
 }
@@ -23,7 +23,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:9.0.1'
+        classpath 'com.android.tools.build:gradle:9.2.1'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip


### PR DESCRIPTION
Copyright and license field added. If the fields are populated they are exported to survex, therion and svg, with a choice of whether it appears on the image output, it is automatically added to the metadata. The compass export is still very basic and I do not have the knowledge or means of testing so that has been left as is.

License field has user editable list initially set to

GPLv3.0+
CC0
CC BY 4.0
CC BY SA 4.0
CC BY SA NC 4.0
All rights reserved

To avoid silently apply licenses on a new install or upgrade to introduce the feature, there is a first run dialog that says

"Please pick a license for the future use of the survey. This will become the default and can be written over in Trip. GPLv3.0+ is encouraged for survey data and is the same license that Sexytopo is published under"

The License field can also contain free text and left blank.