### PR TITLE
Survex ISO dates

### DIFF
--- a/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/survextherion/SurvexTherionImporter.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/survextherion/SurvexTherionImporter.java
@@ -258,7 +258,7 @@ public class SurvexTherionImporter {
             // Strip command prefix for uniform data handling
             String effective = format.stripCommandPrefix(trimmed);
 
-            // Survey date: "date yyyy.MM.dd" (but not "date explored")
+            // Survey date: "date yyyy.MM.dd" or "date yyyy-MM-dd" (but not "date explored")
             if (effective.startsWith("date ") && !effective.startsWith("date explored")) {
                 String dateStr = effective.substring(5).trim();
                 surveyDate = parseDate(dateStr);
@@ -435,14 +435,26 @@ public class SurvexTherionImporter {
         return rest;
     }
 
+    /**
+     * Date formats accepted on import, tried in order. Export always uses {@link
+     * SurvexTherionUtil#TRIP_DATE_PATTERN} (dot-separated); the ISO hyphen-separated pattern is
+     * accepted here purely as a convenience for files written or edited by other tools.
+     */
+    private static final String[] ACCEPTED_DATE_PATTERNS = {
+        SurvexTherionUtil.TRIP_DATE_PATTERN, SurvexTherionUtil.TRIP_DATE_PATTERN_ISO
+    };
+
     private static Date parseDate(String dateStr) {
-        try {
-            SimpleDateFormat sdf = new SimpleDateFormat(SurvexTherionUtil.TRIP_DATE_PATTERN);
-            return sdf.parse(dateStr);
-        } catch (Exception e) {
-            Log.e("Failed to parse date: " + dateStr);
-            return null;
+        for (String pattern : ACCEPTED_DATE_PATTERNS) {
+            try {
+                SimpleDateFormat sdf = new SimpleDateFormat(pattern);
+                return sdf.parse(dateStr);
+            } catch (Exception ignored) {
+                // Try the next accepted pattern.
+            }
         }
+        Log.e("Failed to parse date: " + dateStr);
+        return null;
     }
 
     private static void addLegToSurvey(

--- a/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/survextherion/SurvexTherionUtil.java
+++ b/app/src/main/java/org/hwyl/sexytopo/control/io/thirdparty/survextherion/SurvexTherionUtil.java
@@ -20,6 +20,13 @@ public class SurvexTherionUtil {
 
     public static final String TRIP_DATE_PATTERN = "yyyy.MM.dd";
 
+    /**
+     * Accepted as a fallback when importing trip dates, so files using ISO-style hyphens (e.g.
+     * "2026-01-05") parse as readily as the native dot-separated Survex/Therion format. Export
+     * always uses {@link #TRIP_DATE_PATTERN}.
+     */
+    public static final String TRIP_DATE_PATTERN_ISO = "yyyy-MM-dd";
+
     public static String getCreationComment(char commentChar, String versionInfo) {
         String dateOnly = new SimpleDateFormat("yyyy-MM-dd").format(new Date());
         return commentChar + " Created with " + versionInfo + " on " + dateOnly;

--- a/app/src/test/java/org/hwyl/sexytopo/control/io/thirdparty/survex/SurvexExporterTest.java
+++ b/app/src/test/java/org/hwyl/sexytopo/control/io/thirdparty/survex/SurvexExporterTest.java
@@ -125,6 +125,19 @@ public class SurvexExporterTest {
     }
 
     @Test
+    public void testSurvexMetadataSurveyDateUsesDotSeparator() {
+        Survey survey = BasicTestSurveyCreator.createStraightNorth();
+        Trip trip = new Trip();
+        trip.setSurveyDate(new java.util.Date(0)); // 1970.01.01
+        survey.setTrip(trip);
+
+        String metadata = SurvexTherionUtil.getMetadata(survey, SurveyFormat.SURVEX, "", "");
+
+        Assert.assertTrue(metadata.contains("*date 1970.01.01"));
+        Assert.assertFalse(metadata.contains("1970-01-01"));
+    }
+
+    @Test
     public void testSurvexMetadataExploDateLinkedUsesSurveyDate() {
         Survey survey = BasicTestSurveyCreator.createStraightNorth();
         Trip trip = new Trip();

--- a/app/src/test/java/org/hwyl/sexytopo/control/io/thirdparty/survex/SurvexImporterTest.java
+++ b/app/src/test/java/org/hwyl/sexytopo/control/io/thirdparty/survex/SurvexImporterTest.java
@@ -1,9 +1,11 @@
 package org.hwyl.sexytopo.control.io.thirdparty.survex;
 
 import org.hwyl.sexytopo.control.io.thirdparty.survextherion.SurvexTherionImporter;
+import org.hwyl.sexytopo.control.io.thirdparty.survextherion.SurveyFormat;
 import org.hwyl.sexytopo.model.survey.Leg;
 import org.hwyl.sexytopo.model.survey.Station;
 import org.hwyl.sexytopo.model.survey.Survey;
+import org.hwyl.sexytopo.model.survey.Trip;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -153,5 +155,15 @@ public class SurvexImporterTest {
         Assert.assertTrue(
                 mainLeg.getPromotedFrom()[0].getComment() == null
                         || mainLeg.getPromotedFrom()[0].getComment().isEmpty());
+    }
+
+    // --- Metadata date parsing ---
+
+    @Test
+    public void testMetadataImportAcceptsHyphenSeparatedSurveyDate() throws Exception {
+        String survexText = "*date 2026-01-05\n";
+        Trip trip = SurvexTherionImporter.parseMetadata(survexText, SurveyFormat.SURVEX);
+        Assert.assertNotNull(trip);
+        Assert.assertNotNull(trip.getSurveyDate());
     }
 }

--- a/app/src/test/java/org/hwyl/sexytopo/control/io/thirdparty/therion/ThExporterTest.java
+++ b/app/src/test/java/org/hwyl/sexytopo/control/io/thirdparty/therion/ThExporterTest.java
@@ -181,6 +181,19 @@ public class ThExporterTest {
     }
 
     @Test
+    public void testTherionMetadataSurveyDateUsesDotSeparator() {
+        Survey survey = new Survey();
+        Trip trip = new Trip();
+        trip.setSurveyDate(new java.util.Date(0)); // 1970.01.01
+        survey.setTrip(trip);
+
+        String metadata = SurvexTherionUtil.getMetadata(survey, SurveyFormat.THERION, "", "");
+
+        Assert.assertTrue(metadata.contains("date 1970.01.01"));
+        Assert.assertFalse(metadata.contains("1970-01-01"));
+    }
+
+    @Test
     public void testTherionMetadataExploDateLinkedUsesSurveyDate() {
         Survey survey = new Survey();
         Trip trip = new Trip();

--- a/app/src/test/java/org/hwyl/sexytopo/control/io/thirdparty/therion/TherionImporterTest.java
+++ b/app/src/test/java/org/hwyl/sexytopo/control/io/thirdparty/therion/TherionImporterTest.java
@@ -562,6 +562,14 @@ public class TherionImporterTest {
     }
 
     @Test
+    public void testTherionMetadataImportAcceptsHyphenSeparatedSurveyDate() throws Exception {
+        String therionText = "date 2026-01-05\n";
+        Trip trip = SurvexTherionImporter.parseMetadata(therionText, SurveyFormat.THERION);
+        Assert.assertNotNull(trip);
+        Assert.assertNotNull(trip.getSurveyDate());
+    }
+
+    @Test
     public void testTherionCopyrightAndLicenceImport() throws Exception {
         String therionText = "date 2026.01.05\n" + "copyright 2026 \"Caver Jane\" #\"CC BY 4.0\"\n";
 


### PR DESCRIPTION
Changed survex export to use ISO dates, period separator. Import allows . and - for backward compatibility.

Closes #330